### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: main
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: main


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated dependency updates
- Configured weekly NuGet package updates
- Configured weekly GitHub Actions version updates

## Test plan
- [ ] Verify Dependabot picks up the config and creates PRs on the next scheduled run