### PR TITLE
Add JWT authentication to Blazor web frontend

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.1.3" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />

--- a/src/KRAFT.Results.Web.Client/Features/Auth/AuthServices.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/AuthServices.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KRAFT.Results.Web.Client.Features.Auth;
+
+public static class AuthServices
+{
+    public static IServiceCollection AddAuthServices(this IServiceCollection services)
+    {
+        services.AddAuthorizationCore();
+        services.AddScoped<TokenStorageService>();
+        services.AddScoped<JwtAuthenticationStateProvider>();
+        services.AddScoped<AuthenticationStateProvider>(provider =>
+            provider.GetRequiredService<JwtAuthenticationStateProvider>());
+
+        return services;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Auth/AuthorizationMessageHandler.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/AuthorizationMessageHandler.cs
@@ -1,0 +1,35 @@
+using System.Net.Http.Headers;
+
+namespace KRAFT.Results.Web.Client.Features.Auth;
+
+public sealed class AuthorizationMessageHandler : DelegatingHandler
+{
+    private readonly TokenStorageService _tokenStorage;
+    private readonly Uri _allowedBaseUri;
+
+    public AuthorizationMessageHandler(TokenStorageService tokenStorage, Uri allowedBaseUri)
+    {
+        _tokenStorage = tokenStorage;
+        _allowedBaseUri = allowedBaseUri;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.RequestUri is not null &&
+            request.RequestUri.AbsoluteUri.StartsWith(_allowedBaseUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
+        {
+            string? token = await _tokenStorage.GetTokenAsync();
+
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Auth/JwtAuthenticationStateProvider.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/JwtAuthenticationStateProvider.cs
@@ -1,0 +1,79 @@
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace KRAFT.Results.Web.Client.Features.Auth;
+
+public sealed class JwtAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private static readonly AuthenticationState Anonymous = new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    private readonly TokenStorageService _tokenStorage;
+    private string? _cachedToken;
+    private AuthenticationState? _cachedState;
+
+    public JwtAuthenticationStateProvider(TokenStorageService tokenStorage)
+    {
+        _tokenStorage = tokenStorage;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        string? token = await _tokenStorage.GetTokenAsync();
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Anonymous;
+        }
+
+        if (token == _cachedToken && _cachedState is not null)
+        {
+            return _cachedState;
+        }
+
+        return BuildAuthenticationState(token);
+    }
+
+    public void MarkUserAsAuthenticated(string token)
+    {
+        AuthenticationState authState = BuildAuthenticationState(token);
+        _cachedToken = token;
+        _cachedState = authState;
+        NotifyAuthenticationStateChanged(Task.FromResult(authState));
+    }
+
+    public void MarkUserAsLoggedOut()
+    {
+        _cachedToken = null;
+        _cachedState = null;
+        NotifyAuthenticationStateChanged(Task.FromResult(Anonymous));
+    }
+
+    private AuthenticationState BuildAuthenticationState(string token)
+    {
+        IEnumerable<Claim> claims = JwtClaimParser.ParseClaimsFromJwt(token);
+        Claim? expClaim = claims.OfType<Claim>().FirstOrDefault(c => c.Type == "exp");
+
+        if (expClaim is not null && long.TryParse(expClaim.Value, out long expUnix))
+        {
+            DateTimeOffset expiration = DateTimeOffset.FromUnixTimeSeconds(expUnix);
+
+            if (expiration <= DateTimeOffset.UtcNow)
+            {
+                _cachedToken = null;
+                _cachedState = null;
+                _tokenStorage.RemoveTokenAsync().ConfigureAwait(false);
+                return Anonymous;
+            }
+        }
+
+        ClaimsIdentity identity = new(claims, "jwt");
+        ClaimsPrincipal user = new(identity);
+        AuthenticationState state = new(user);
+
+        _cachedToken = token;
+        _cachedState = state;
+
+        return state;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Auth/JwtClaimParser.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/JwtClaimParser.cs
@@ -1,0 +1,58 @@
+using System.Security.Claims;
+using System.Text.Json;
+
+namespace KRAFT.Results.Web.Client.Features.Auth;
+
+public static class JwtClaimParser
+{
+    public static IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
+    {
+        ArgumentNullException.ThrowIfNull(jwt);
+
+        string[] parts = jwt.Split('.');
+
+        if (parts.Length != 3)
+        {
+            return [];
+        }
+
+        byte[] payload = ParseBase64WithoutPadding(parts[1]);
+        Dictionary<string, JsonElement>? claims = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payload);
+
+        if (claims is null)
+        {
+            return [];
+        }
+
+        List<Claim> result = [];
+
+        foreach (KeyValuePair<string, JsonElement> claim in claims)
+        {
+            if (claim.Value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement element in claim.Value.EnumerateArray())
+                {
+                    result.Add(new Claim(claim.Key, element.GetString() ?? string.Empty));
+                }
+            }
+            else
+            {
+                result.Add(new Claim(claim.Key, claim.Value.GetString() ?? claim.Value.GetRawText()));
+            }
+        }
+
+        return result;
+    }
+
+    private static byte[] ParseBase64WithoutPadding(string base64)
+    {
+        int remainder = base64.Length % 4;
+
+        if (remainder != 0)
+        {
+            base64 += new string('=', 4 - remainder);
+        }
+
+        return Convert.FromBase64String(base64.Replace('-', '+').Replace('_', '/'));
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Auth/Login.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/Login.razor
@@ -1,0 +1,134 @@
+@page "/login"
+
+@rendermode InteractiveWebAssembly
+
+@using System.ComponentModel.DataAnnotations
+@using System.Net
+@using System.Net.Http.Json
+@using KRAFT.Results.Contracts.Users
+
+@inject HttpClient HttpClient
+@inject NavigationManager NavigationManager
+@inject JwtAuthenticationStateProvider AuthStateProvider
+@inject TokenStorageService TokenStorage
+
+<div class="login-wrapper">
+    <div class="login-card">
+        <h1 class="login-title">KRAFT.Results</h1>
+
+        <EditForm Model="_model" OnValidSubmit="HandleLogin" FormName="login">
+            <DataAnnotationsValidator />
+
+            <div class="form-field">
+                <label class="form-label" for="username">Notandanafn</label>
+                <InputText id="username"
+                           class="form-input"
+                           autocomplete="username"
+                           aria-describedby="@(HasError ? "login-error" : null)"
+                           @bind-Value="_model.Username"
+                           disabled="@_isLoading" />
+            </div>
+
+            <div class="form-field">
+                <label class="form-label" for="password">Lykilorð</label>
+                <InputText type="password"
+                           id="password"
+                           class="form-input"
+                           autocomplete="current-password"
+                           aria-describedby="@(HasError ? "login-error" : null)"
+                           @bind-Value="_model.Password"
+                           disabled="@_isLoading" />
+            </div>
+
+            <button type="submit" class="btn-primary" disabled="@_isLoading" aria-busy="@_isLoading">
+                @if (_isLoading)
+                {
+                    <span>Augnablik...</span>
+                }
+                else
+                {
+                    <span>Innskr&#225;</span>
+                }
+            </button>
+
+            @if (!string.IsNullOrEmpty(_errorMessage))
+            {
+                <div id="login-error" class="error-message" role="alert">@_errorMessage</div>
+            }
+        </EditForm>
+    </div>
+</div>
+
+@code {
+    [SupplyParameterFromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+
+    private readonly LoginModel _model = new();
+    private bool _isLoading;
+    private string? _errorMessage;
+
+    private bool HasError => !string.IsNullOrEmpty(_errorMessage);
+
+    protected override async Task OnInitializedAsync()
+    {
+        AuthenticationState authState = await AuthStateProvider.GetAuthenticationStateAsync();
+
+        if (authState.User.Identity?.IsAuthenticated == true)
+        {
+            NavigationManager.NavigateTo(ReturnUrl ?? "/");
+        }
+    }
+
+    private async Task HandleLogin()
+    {
+        _isLoading = true;
+        _errorMessage = null;
+
+        try
+        {
+            LoginCommand command = new(_model.Username, _model.Password);
+            HttpResponseMessage response = await HttpClient.PostAsJsonAsync("/users/login", command);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                _errorMessage = "Rangt notandanafn e\u00f0a lykilor\u00f0.";
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _errorMessage = "Villa kom upp. Reyndu aftur s\u00ed\u00f0ar.";
+                return;
+            }
+
+            AuthenticatedResponse? authResponse = await response.Content.ReadFromJsonAsync<AuthenticatedResponse>();
+
+            if (authResponse is null)
+            {
+                _errorMessage = "Villa kom upp. Reyndu aftur s\u00ed\u00f0ar.";
+                return;
+            }
+
+            await TokenStorage.SetTokenAsync(authResponse.AccessToken);
+            AuthStateProvider.MarkUserAsAuthenticated(authResponse.AccessToken);
+            NavigationManager.NavigateTo(ReturnUrl ?? "/");
+        }
+        catch (HttpRequestException)
+        {
+            _errorMessage = "Villa kom upp. Reyndu aftur s\u00ed\u00f0ar.";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private sealed class LoginModel
+    {
+        [Required]
+        public string Username { get; set; } = string.Empty;
+
+        [Required]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Auth/Login.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/Login.razor.css
@@ -1,0 +1,109 @@
+.login-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background: var(--color-bg);
+    padding: 1rem;
+}
+
+.login-card {
+    max-width: 24rem;
+    width: 100%;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    border-top: 3px solid var(--color-primary);
+    box-shadow: var(--shadow-md);
+    background: var(--color-white);
+    padding: 2rem;
+}
+
+.login-title {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-text);
+    text-align: center;
+    margin-block-end: 2rem;
+}
+
+.form-field {
+    margin-block-end: 1.25rem;
+}
+
+.form-label {
+    display: block;
+    font-family: var(--font-body);
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    margin-block-end: 0.25rem;
+}
+
+.form-input {
+    width: 100%;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-body);
+    font-size: 1rem;
+    color: var(--color-text);
+    background: var(--color-white);
+    transition: border-color var(--transition-fast) ease;
+}
+
+.form-input:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.btn-primary {
+    width: 100%;
+    padding: 0.75rem 1.5rem;
+    background: var(--color-primary);
+    color: var(--color-white);
+    border: none;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-heading);
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: background-color var(--transition-fast) ease;
+}
+
+.btn-primary:hover {
+    background: var(--color-primary-dark);
+}
+
+.btn-primary:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.error-message {
+    margin-block-start: 1rem;
+    padding: 0.75rem;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: var(--radius-sm);
+    color: var(--color-danger);
+    font-size: 0.875rem;
+    text-align: center;
+}
+
+@media (max-width: 640px) {
+    .login-card {
+        margin-inline: 1rem;
+        padding: 1.5rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .form-input,
+    .btn-primary {
+        transition: none;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Auth/Logout.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/Logout.razor
@@ -1,0 +1,21 @@
+@page "/logout"
+
+@rendermode InteractiveWebAssembly
+
+@inject NavigationManager NavigationManager
+@inject JwtAuthenticationStateProvider AuthStateProvider
+@inject TokenStorageService TokenStorage
+
+<div class="logout-wrapper" role="status" aria-live="polite">
+    <h1 class="visually-hidden">Utskra</h1>
+    <span class="logout-message">Skr&#225;ir &#254;ig &#250;t...</span>
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        await TokenStorage.RemoveTokenAsync();
+        AuthStateProvider.MarkUserAsLoggedOut();
+        NavigationManager.NavigateTo("/login");
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Auth/TokenStorageService.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Auth/TokenStorageService.cs
@@ -1,0 +1,54 @@
+using Microsoft.JSInterop;
+
+namespace KRAFT.Results.Web.Client.Features.Auth;
+
+public sealed class TokenStorageService
+{
+    private const string TokenKey = "auth_token";
+
+    private readonly IJSRuntime _jsRuntime;
+    private string? _cachedToken;
+
+    public TokenStorageService(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task<string?> GetTokenAsync()
+    {
+        if (_cachedToken is not null)
+        {
+            return _cachedToken;
+        }
+
+        try
+        {
+            _cachedToken = await _jsRuntime.InvokeAsync<string?>("sessionStorage.getItem", TokenKey);
+            return _cachedToken;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    public async Task SetTokenAsync(string token)
+    {
+        _cachedToken = token;
+        await _jsRuntime.InvokeVoidAsync("sessionStorage.setItem", TokenKey, token);
+    }
+
+    public async Task RemoveTokenAsync()
+    {
+        _cachedToken = null;
+
+        try
+        {
+            await _jsRuntime.InvokeVoidAsync("sessionStorage.removeItem", TokenKey);
+        }
+        catch (InvalidOperationException)
+        {
+            // JS interop is unavailable during SSR pre-rendering
+        }
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
@@ -1,5 +1,9 @@
 ﻿@page "/users"
 
+@rendermode InteractiveWebAssembly
+
+@attribute [Authorize]
+
 @using KRAFT.Results.Contracts.Users
 
 @inject HttpClient HttpClient;

--- a/src/KRAFT.Results.Web.Client/KRAFT.Results.Web.Client.csproj
+++ b/src/KRAFT.Results.Web.Client/KRAFT.Results.Web.Client.csproj
@@ -4,9 +4,11 @@
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <NoWarn>$(NoWarn);CA1515</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
   </ItemGroup>
 

--- a/src/KRAFT.Results.Web.Client/Program.cs
+++ b/src/KRAFT.Results.Web.Client/Program.cs
@@ -1,5 +1,25 @@
+using KRAFT.Results.Web.Client.Features.Auth;
+
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 WebAssemblyHostBuilder builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.Services.AddAuthServices();
+
+Uri baseAddress = new(builder.HostEnvironment.BaseAddress);
+
+builder.Services.AddScoped(services =>
+{
+    TokenStorageService tokenStorage = services.GetRequiredService<TokenStorageService>();
+    AuthorizationMessageHandler handler = new(tokenStorage, baseAddress)
+    {
+        InnerHandler = new HttpClientHandler(),
+    };
+
+    return new HttpClient(handler)
+    {
+        BaseAddress = baseAddress,
+    };
+});
 
 await builder.Build().RunAsync();

--- a/src/KRAFT.Results.Web.Client/_Imports.razor
+++ b/src/KRAFT.Results.Web.Client/_Imports.razor
@@ -2,6 +2,8 @@
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization

--- a/src/KRAFT.Results.Web/Components/Layout/NavMenu.razor
+++ b/src/KRAFT.Results.Web/Components/Layout/NavMenu.razor
@@ -1,16 +1,16 @@
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+<input type="checkbox" title="Navigation menu" aria-label="Navigation menu" class="navbar-toggler" />
 
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
-    <nav class="nav">
+    <nav class="nav" aria-label="Main navigation">
         <div class="nav-item">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-nav-menu" aria-hidden="true"></span> Forsíða
+                <span class="bi bi-house-nav-menu" aria-hidden="true"></span> Forsida
             </NavLink>
         </div>
 
         <div class="nav-item">
             <NavLink class="nav-link" href="meets">
-                <span class="bi bi-trophy-nav-menu" aria-hidden="true"></span> Mótaskrá
+                <span class="bi bi-trophy-nav-menu" aria-hidden="true"></span> Motaskra
             </NavLink>
         </div>
 
@@ -22,24 +22,39 @@
 
         <div class="nav-item">
             <NavLink class="nav-link" href="teams">
-                <span class="bi bi-people-nav-menu" aria-hidden="true"></span> Félög
+                <span class="bi bi-people-nav-menu" aria-hidden="true"></span> Felog
             </NavLink>
         </div>
 
-        <div class="nav-item">
-            <NavLink class="nav-link" href="users">
-                <span class="bi bi-gear-nav-menu" aria-hidden="true"></span> Notendur
-            </NavLink>
-        </div>
+        <AuthorizeView>
+            <Authorized>
+                <div class="nav-item">
+                    <NavLink class="nav-link" href="users">
+                        <span class="bi bi-gear-nav-menu" aria-hidden="true"></span> Notendur
+                    </NavLink>
+                </div>
 
-        <div class="nav-item">
-            <NavLink class="nav-link" href="login">
-                <span class="bi bi-login-nav-menu" aria-hidden="true"></span> Innskrá
-            </NavLink>
-        </div>
+                <div class="nav-separator"></div>
+
+                <div class="nav-item">
+                    <NavLink class="nav-link" href="logout">
+                        <span class="bi bi-logout-nav-menu" aria-hidden="true"></span> Utskra
+                    </NavLink>
+                </div>
+            </Authorized>
+            <NotAuthorized>
+                <div class="nav-separator"></div>
+
+                <div class="nav-item">
+                    <NavLink class="nav-link" href="login">
+                        <span class="bi bi-login-nav-menu" aria-hidden="true"></span> Innskra
+                    </NavLink>
+                </div>
+            </NotAuthorized>
+        </AuthorizeView>
     </nav>
 
     <div class="sidebar-footer">
-        Kraftlyftingasamband Íslands
+        Kraftlyftingasamband Islands
     </div>
 </div>

--- a/src/KRAFT.Results.Web/Components/Layout/NavMenu.razor.css
+++ b/src/KRAFT.Results.Web/Components/Layout/NavMenu.razor.css
@@ -50,6 +50,16 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M6 3.5a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-2a.5.5 0 0 0-1 0v2A1.5 1.5 0 0 0 6.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-8A1.5 1.5 0 0 0 5 3.5v2a.5.5 0 0 0 1 0z'/%3E%3Cpath fill-rule='evenodd' d='M11.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H1.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z'/%3E%3C/svg%3E");
 }
 
+.bi-logout-nav-menu {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' viewBox='0 0 16 16'%3E%3Cpath d='M2 2.5A1.5 1.5 0 0 1 3.5 1h5A1.5 1.5 0 0 1 10 2.5V5h-1V2.5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0-.5.5v11a.5.5 0 0 0 .5.5h5a.5.5 0 0 0 .5-.5V11h1v2.5A1.5 1.5 0 0 1 8.5 15h-5A1.5 1.5 0 0 1 2 13.5v-11z'/%3E%3Cpath d='M10.354 8.354a.5.5 0 0 0 0-.708l-2.5-2.5a.5.5 0 1 0-.708.708L9.293 8l-2.147 2.146a.5.5 0 0 0 .708.708l2.5-2.5z'/%3E%3Cpath d='M6 8a.5.5 0 0 1 .5-.5H14a.5.5 0 0 1 0 1H6.5A.5.5 0 0 1 6 8z'/%3E%3C/svg%3E");
+}
+
+.nav-separator {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    margin-block: 0.5rem;
+    margin-inline: 1.25rem;
+}
+
 .nav-item {
     font-size: 0.9rem;
     padding-block-end: 0.25rem;

--- a/src/KRAFT.Results.Web/Components/RedirectToLogin.razor
+++ b/src/KRAFT.Results.Web/Components/RedirectToLogin.razor
@@ -1,0 +1,10 @@
+@inject NavigationManager NavigationManager
+
+@code {
+    protected override void OnInitialized()
+    {
+        string currentUri = NavigationManager.Uri;
+        string encodedReturnUrl = Uri.EscapeDataString(currentUri);
+        NavigationManager.NavigateTo($"/login?returnUrl={encodedReturnUrl}", forceLoad: false);
+    }
+}

--- a/src/KRAFT.Results.Web/Components/Routes.razor
+++ b/src/KRAFT.Results.Web/Components/Routes.razor
@@ -1,6 +1,17 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
+            <NotAuthorized>
+                @if (context.User.Identity?.IsAuthenticated != true)
+                {
+                    <RedirectToLogin />
+                }
+                else
+                {
+                    <p>Access denied. You do not have permission to view this page.</p>
+                }
+            </NotAuthorized>
+        </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>

--- a/src/KRAFT.Results.Web/Components/_Imports.razor
+++ b/src/KRAFT.Results.Web/Components/_Imports.razor
@@ -2,6 +2,8 @@
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization

--- a/src/KRAFT.Results.Web/KRAFT.Results.Web.csproj
+++ b/src/KRAFT.Results.Web/KRAFT.Results.Web.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
   </ItemGroup>
 

--- a/src/KRAFT.Results.Web/Program.cs
+++ b/src/KRAFT.Results.Web/Program.cs
@@ -1,3 +1,4 @@
+using KRAFT.Results.Web.Client.Features.Auth;
 using KRAFT.Results.Web.Components;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -8,15 +9,25 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
 
+builder.Services.AddAuthServices();
+builder.Services.AddCascadingAuthenticationState();
+
+Uri apiBaseAddress = builder.Configuration.GetValue<Uri>("API:BaseAddress")
+    ?? throw new InvalidOperationException("No API base address");
+
+builder.Services.AddTransient(services =>
+{
+    TokenStorageService tokenStorage = services.GetRequiredService<TokenStorageService>();
+    return new AuthorizationMessageHandler(tokenStorage, apiBaseAddress);
+});
+
 builder.Services.AddHttpClient(
     "WebApi",
     client =>
     {
-        Uri baseAddress = builder.Configuration.GetValue<Uri>("API:BaseAddress")
-            ?? throw new InvalidOperationException("No API base address");
-
-        client.BaseAddress = baseAddress;
-    });
+        client.BaseAddress = apiBaseAddress;
+    })
+    .AddHttpMessageHandler<AuthorizationMessageHandler>();
 
 builder.Services.AddScoped(services => services.GetRequiredService<IHttpClientFactory>()
     .CreateClient("WebApi"));

--- a/src/KRAFT.Results.WebApi/Features/Users/Get/GetUsersEndpoint.cs
+++ b/src/KRAFT.Results.WebApi/Features/Users/Get/GetUsersEndpoint.cs
@@ -22,7 +22,9 @@ internal static class GetUsersEndpoint
         .WithSummary("Gets users")
         .WithDescription("Gets a list of all users")
         .Produces<IReadOnlyList<UserSummary>>()
-        .ProducesProblem(StatusCodes.Status500InternalServerError);
+        .ProducesProblem(StatusCodes.Status401Unauthorized)
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .RequireAuthorization();
 
         return endpoints;
     }

--- a/src/KRAFT.Results.WebApi/Program.cs
+++ b/src/KRAFT.Results.WebApi/Program.cs
@@ -65,12 +65,13 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapHealthChecks("/healthz");
-app.MapFeatureEndpoints();
 
 app.UseExceptionHandler();
 app.UseStatusCodePages();
 app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.MapFeatureEndpoints();
 
 await app.RunAsync();

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Users/GetUsersTest.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Users/GetUsersTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Users;
@@ -11,10 +11,12 @@ public sealed class GetUsersTest
 {
     private const string Path = "/users";
 
+    private readonly HttpClient _authorizedHttpClient;
     private readonly HttpClient _unauthorizedHttpClient;
 
     public GetUsersTest(IntegrationTestFixture fixture)
     {
+        _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
         _unauthorizedHttpClient = fixture.Factory.CreateClient();
     }
 
@@ -24,7 +26,7 @@ public sealed class GetUsersTest
         // Arrange
 
         // Act
-        HttpResponseMessage response = await _unauthorizedHttpClient.GetAsync(Path, CancellationToken.None);
+        HttpResponseMessage response = await _authorizedHttpClient.GetAsync(Path, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -36,7 +38,7 @@ public sealed class GetUsersTest
         // Arrange
 
         // Act
-        IReadOnlyList<UserSummary>? response = await _unauthorizedHttpClient.GetFromJsonAsync<IReadOnlyList<UserSummary>>(Path, CancellationToken.None);
+        IReadOnlyList<UserSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<UserSummary>>(Path, CancellationToken.None);
 
         // Assert
         response.ShouldNotBeNull();
@@ -48,9 +50,21 @@ public sealed class GetUsersTest
         // Arrange
 
         // Act
-        IReadOnlyList<UserSummary>? response = await _unauthorizedHttpClient.GetFromJsonAsync<IReadOnlyList<UserSummary>>(Path, CancellationToken.None);
+        IReadOnlyList<UserSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<UserSummary>>(Path, CancellationToken.None);
 
         // Assert
         response!.ShouldContain(x => x.Email == Constants.TestUser.Email);
+    }
+
+    [Fact]
+    public async Task ReturnsUnauthorized_WhenHttpClientIsUnauthorized()
+    {
+        // Arrange
+
+        // Act
+        HttpResponseMessage response = await _unauthorizedHttpClient.GetAsync(Path, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 }


### PR DESCRIPTION
## Summary

- Wires Blazor Web and Web.Client projects to the existing WebApi login endpoint with custom `AuthenticationStateProvider`, `sessionStorage` token persistence, and Bearer token `DelegatingHandler`
- Adds login page with form validation, error handling, and `returnUrl` support
- Adds logout flow, dynamic NavMenu with `AuthorizeView` for conditional links
- Protects `/users` route with `[Authorize]` and adds `.RequireAuthorization()` to `GetUsersEndpoint`
- Fixes middleware ordering: `UseAuthentication`/`UseAuthorization` before `MapFeatureEndpoints`
- Includes in-memory token and auth state caching, client-side token expiry checking, origin-scoped token forwarding
- WCAG 2.1 AA accessibility: `aria-label`, `autocomplete`, `aria-describedby`, `role="status"`

Closes #83, #136, #137, #138, #139

## Test plan

- [ ] Login with valid credentials — verify token stored, redirect to `/`, nav shows "Utskra"
- [ ] Login with invalid credentials — verify inline error, stay on `/login`
- [ ] Navigate to `/users` unauthenticated — verify redirect to `/login?returnUrl=...`
- [ ] After login from redirect, verify navigation to original `returnUrl`
- [ ] Click "Utskra" — verify token cleared, redirect to `/login`, nav shows "Innskra"
- [ ] Refresh page while authenticated — verify session persists (sessionStorage)
- [ ] Open new tab — verify no session (sessionStorage is per-tab)
- [ ] Verify "Notendur" nav link only visible when authenticated
- [ ] `dotnet test` passes all 71 tests including new 401 test for GET /users