### PR TITLE
Add restore-db scripts to automate production DB restore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Claude Code
 .claude/
 CLAUDE.md
+docs/superpowers/
 
 # User-specific files
 *.rsuser

--- a/README.md
+++ b/README.md
@@ -1,46 +1,16 @@
 # Populate local database with production backup
 
-1. Export database dump from [Plesk](https://plesk8600.is.cc:8443/smb/database/list) and download it.
-1. Extract zip file. It contains a single file with no extension. Add a `.bak` extension to it.
-1. Copy the `.bak` file to the SQL container (change the first part of the command to use the filename of your file).
+1. Export database dump from [Plesk](https://plesk8600.is.cc:8443/smb/database/list) and download the zip file.
+1. Start the Aspire AppHost if not already running:
 
     ```bash
-    docker cp backup.bak kraft-sql:/var/opt/mssql/data/backup.bak
+    dotnet run --project src/KRAFT.Results.AppHost
     ```
 
-1. Run the following SQL script to get the logical data and log names
+1. Run the restore script:
 
-    ```sql
-    RESTORE FILELISTONLY
-    FROM DISK = '/var/opt/mssql/data/backup.bak';
+    ```bash
+    ./restore-db.sh /path/to/dump.zip
     ```
 
-1. Use `master` database
-
-    ```sql
-    USE master;
-    ```
-
-1. Set `kraft-db` database to only accept a single connection.
-
-    ```sql
-    ALTER DATABASE [kraft-db] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
-    ```
-
-1. Restore the backup (the names after tha `MOVE` command are the logical data and log names).
-
-    ```sql
-    RESTORE DATABASE [kraft-db]
-    FROM DISK = '/var/opt/mssql/data/backup.bak'
-    WITH
-        MOVE 'resultskraftisdev' TO '/var/opt/mssql/data/kraft-db.mdf',
-        MOVE 'resultskraftisdev_log' TO '/var/opt/mssql/data/kraft-db.ldf',
-        REPLACE,
-        STATS = 10;
-    ```
-
-1. Set `kraft-db` to accept multiple connections.
-
-    ```sql
-    ALTER DATABASE [kraft-db] SET MULTI_USER;
-    ```
+    The script will extract the zip, copy the backup into the SQL container, and restore it to the `kraft-db` database.

--- a/restore-db.ps1
+++ b/restore-db.ps1
@@ -1,0 +1,120 @@
+param(
+    [string]$Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ContainerName = 'kraft-sql'
+$DbName = 'kraft-db'
+$Sqlcmd = '/opt/mssql-tools18/bin/sqlcmd'
+$BackupDest = '/var/opt/mssql/data/backup.bak'
+$AppHostProject = 'src/KRAFT.Results.AppHost'
+$LogicalData = 'resultskraftisdev'
+$LogicalLog = 'resultskraftisdev_log'
+
+if (-not $Path) {
+    $downloads = Join-Path $env:USERPROFILE 'Downloads'
+    $file = Get-ChildItem -Path $downloads -Filter 'resultskraftisdev_*.zip' -File |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+
+    if (-not $file) {
+        Write-Error "No resultskraftisdev_*.zip found in $downloads"
+        exit 1
+    }
+
+    $backupFile = $file.FullName
+    Write-Host "Found backup: $backupFile"
+}
+else {
+    $backupFile = $Path
+}
+
+if (-not (Test-Path $backupFile)) {
+    Write-Error "File not found: $backupFile"
+    exit 1
+}
+
+$tempDir = $null
+
+try {
+    if ($backupFile -like '*.zip') {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        Expand-Archive -Path $backupFile -DestinationPath $tempDir -Force
+
+        $extracted = Get-ChildItem -Path $tempDir -File -Recurse -Force | Select-Object -First 1
+        if (-not $extracted) {
+            Write-Error 'No file found inside the zip archive.'
+            exit 1
+        }
+
+        $backupFile = $extracted.FullName
+    }
+
+    $running = docker inspect --format='{{.State.Running}}' $ContainerName 2>$null
+    if ($running -ne 'true') {
+        Write-Error "Container '$ContainerName' is not running. Start it with: dotnet run --project $AppHostProject"
+        exit 1
+    }
+
+    $saPassword = (dotnet user-secrets list --project $AppHostProject 2>$null |
+        Select-String 'Parameters:sql-password' |
+        ForEach-Object { ($_ -split ' = ', 2)[1] })
+    if (-not $saPassword) {
+        Write-Error "Could not find SA password in user-secrets for $AppHostProject."
+        exit 1
+    }
+
+    Write-Host 'Copying backup into container...'
+    docker cp $backupFile "${ContainerName}:${BackupDest}"
+
+    Write-Host 'Restoring database...'
+    docker exec -e "SQLCMDPASSWORD=$saPassword" $ContainerName $Sqlcmd `
+        -S localhost -U sa -C -Q @"
+        ALTER DATABASE [$DbName] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+        RESTORE DATABASE [$DbName]
+        FROM DISK = '$BackupDest'
+        WITH
+            MOVE '$LogicalData' TO '/var/opt/mssql/data/kraft-db.mdf',
+            MOVE '$LogicalLog' TO '/var/opt/mssql/data/kraft-db.ldf',
+            REPLACE,
+            STATS = 10;
+        ALTER DATABASE [$DbName] SET MULTI_USER;
+"@
+
+    Write-Host 'Seeding migration history...'
+    $migrations = Get-ChildItem -Path src/KRAFT.Results.WebApi/Migrations/*.cs |
+        Where-Object { $_.Name -notmatch 'Designer|Snapshot' } |
+        ForEach-Object { $_.BaseName }
+
+    $seedSql = @"
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;
+"@
+
+    foreach ($migration in $migrations) {
+        $seedSql += "`nIF NOT EXISTS (SELECT 1 FROM [__EFMigrationsHistory] WHERE [MigrationId] = '$migration')"
+        $seedSql += "`n    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion]) VALUES ('$migration', '10.0.0');"
+    }
+
+    docker exec -e "SQLCMDPASSWORD=$saPassword" $ContainerName $Sqlcmd `
+        -S localhost -U sa -C -d $DbName -Q $seedSql
+
+    Write-Host 'Applying migrations...'
+    $dbPort = (docker port $ContainerName 1433 | Select-Object -First 1) -replace '.*:', ''
+    $connectionString = "Server=127.0.0.1,$dbPort;Database=$DbName;User Id=sa;Password=$saPassword;TrustServerCertificate=True"
+    dotnet ef database update --project src/KRAFT.Results.WebApi --connection $connectionString
+
+    Write-Host "Database '$DbName' restored and migrations applied successfully."
+}
+finally {
+    if ($tempDir -and (Test-Path $tempDir)) {
+        Remove-Item -Path $tempDir -Recurse -Force
+    }
+}

--- a/restore-db.sh
+++ b/restore-db.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="kraft-sql"
+DB_NAME="kraft-db"
+SQLCMD="/opt/mssql-tools18/bin/sqlcmd"
+BACKUP_DEST="/var/opt/mssql/data/backup.bak"
+APPHOST_PROJECT="src/KRAFT.Results.AppHost"
+LOGICAL_DATA="resultskraftisdev"
+LOGICAL_LOG="resultskraftisdev_log"
+
+if [[ $# -eq 0 ]]; then
+    DOWNLOADS="$USERPROFILE/Downloads"
+    BACKUP_FILE=$(find "$DOWNLOADS" -maxdepth 1 -name 'resultskraftisdev_*.zip' -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -n 1 | cut -d' ' -f2-)
+    if [[ -z "$BACKUP_FILE" ]]; then
+        echo "Error: No resultskraftisdev_*.zip found in $DOWNLOADS" >&2
+        exit 1
+    fi
+    echo "Found backup: $BACKUP_FILE"
+elif [[ $# -eq 1 ]]; then
+    BACKUP_FILE="$1"
+else
+    echo "Usage: $0 [/path/to/dump.zip]" >&2
+    exit 1
+fi
+
+if [[ ! -f "$BACKUP_FILE" ]]; then
+    echo "Error: File not found: $BACKUP_FILE" >&2
+    exit 1
+fi
+
+if [[ "$BACKUP_FILE" == *.zip ]]; then
+    TEMP_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEMP_DIR"' EXIT
+    unzip -j -q "$BACKUP_FILE" -d "$TEMP_DIR"
+    BACKUP_FILE=$(find "$TEMP_DIR" -type f | head -n 1)
+    if [[ -z "$BACKUP_FILE" ]]; then
+        echo "Error: No file found inside the zip archive." >&2
+        exit 1
+    fi
+fi
+
+if [[ "$(docker inspect --format='{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null)" != "true" ]]; then
+    echo "Error: Container '$CONTAINER_NAME' is not running. Start it with: dotnet run --project $APPHOST_PROJECT" >&2
+    exit 1
+fi
+
+SA_PASSWORD=$(dotnet user-secrets list --project "$APPHOST_PROJECT" 2>/dev/null \
+    | grep 'Parameters:sql-password' \
+    | sed 's/^.*= //')
+
+if [[ -z "$SA_PASSWORD" ]]; then
+    echo "Error: Could not find SA password in user-secrets for $APPHOST_PROJECT." >&2
+    exit 1
+fi
+
+echo "Copying backup into container..."
+docker cp "$BACKUP_FILE" "$CONTAINER_NAME:$BACKUP_DEST"
+
+echo "Restoring database..."
+MSYS_NO_PATHCONV=1 docker exec -e SQLCMDPASSWORD="$SA_PASSWORD" "$CONTAINER_NAME" "$SQLCMD" \
+    -S localhost -U sa -C -Q "
+        ALTER DATABASE [$DB_NAME] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+        RESTORE DATABASE [$DB_NAME]
+        FROM DISK = '$BACKUP_DEST'
+        WITH
+            MOVE '$LOGICAL_DATA' TO '/var/opt/mssql/data/kraft-db.mdf',
+            MOVE '$LOGICAL_LOG' TO '/var/opt/mssql/data/kraft-db.ldf',
+            REPLACE,
+            STATS = 10;
+        ALTER DATABASE [$DB_NAME] SET MULTI_USER;
+    "
+
+echo "Seeding migration history..."
+MIGRATIONS=$(ls src/KRAFT.Results.WebApi/Migrations/*.cs \
+    | grep -v Designer | grep -v Snapshot \
+    | sed 's|.*/||; s|\.cs$||')
+
+SEED_SQL="IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;"
+
+while IFS= read -r migration; do
+    SEED_SQL="$SEED_SQL
+IF NOT EXISTS (SELECT 1 FROM [__EFMigrationsHistory] WHERE [MigrationId] = '$migration')
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion]) VALUES ('$migration', '10.0.0');"
+done <<< "$MIGRATIONS"
+
+MSYS_NO_PATHCONV=1 docker exec -e SQLCMDPASSWORD="$SA_PASSWORD" "$CONTAINER_NAME" "$SQLCMD" \
+    -S localhost -U sa -C -d "$DB_NAME" -Q "$SEED_SQL"
+
+echo "Applying migrations..."
+DB_PORT=$(docker port "$CONTAINER_NAME" 1433 | head -n 1 | cut -d: -f2)
+CONNECTION_STRING="Server=127.0.0.1,$DB_PORT;Database=$DB_NAME;User Id=sa;Password=$SA_PASSWORD;TrustServerCertificate=True"
+dotnet ef database update --project src/KRAFT.Results.WebApi --connection "$CONNECTION_STRING"
+
+echo "Database '$DB_NAME' restored and migrations applied successfully."


### PR DESCRIPTION
## Summary
- Add `restore-db.sh` (bash) and `restore-db.ps1` (PowerShell) to automate the manual 7-step production DB restore
- Scripts auto-detect the latest `resultskraftisdev_*.zip` from Downloads when called with no arguments
- Extract zip, copy backup into `kraft-sql` container, restore DB, seed EF migration history, run pending migrations
- Add `.gitattributes` to enforce LF line endings on shell scripts
- Simplify `README.md` to reference the new scripts

## Test plan
- [x] `./restore-db.sh` with no args finds latest backup in Downloads
- [ ] `./restore-db.sh /path/to/dump.zip` works with explicit path
- [ ] Script errors clearly when container is not running
- [x] DB restores and migrations apply successfully