### PR TITLE
feat(meets): add edit meet details endpoint and UI

### DIFF
--- a/src/KRAFT.Results.Contracts/Meets/MeetDetails.cs
+++ b/src/KRAFT.Results.Contracts/Meets/MeetDetails.cs
@@ -8,6 +8,7 @@ public sealed record class MeetDetails(
     DateOnly StartDate,
     DateOnly? EndDate,
     string Type,
+    int MeetTypeId,
     string ResultMode,
     bool CalculatePlaces,
     bool IsInTeamCompetition,

--- a/src/KRAFT.Results.Contracts/Meets/MeetFormInitialValues.cs
+++ b/src/KRAFT.Results.Contracts/Meets/MeetFormInitialValues.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Meets;
+
+public sealed record class MeetFormInitialValues(string Title, DateOnly StartDate, int MeetTypeId);

--- a/src/KRAFT.Results.Contracts/Meets/MeetFormValues.cs
+++ b/src/KRAFT.Results.Contracts/Meets/MeetFormValues.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Meets;
+
+public sealed record class MeetFormValues(string Title, DateOnly StartDate, int MeetTypeId);

--- a/src/KRAFT.Results.Contracts/Meets/UpdateMeetCommand.cs
+++ b/src/KRAFT.Results.Contracts/Meets/UpdateMeetCommand.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Meets;
+
+public sealed record class UpdateMeetCommand(string Title, DateOnly StartDate, int? MeetTypeId);

--- a/src/KRAFT.Results.Web.Client/Features/Meets/CreateMeetPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/CreateMeetPage.razor
@@ -37,13 +37,14 @@
         }
     }
 
-    private async Task HandleSubmit(CreateMeetCommand command)
+    private async Task HandleSubmit(MeetFormValues values)
     {
         _isLoading = true;
         _errorMessage = null;
 
         try
         {
+            CreateMeetCommand command = new(values.Title, values.StartDate, values.MeetTypeId);
             HttpResponseMessage response = await HttpClient.PostAsJsonAsync("/meets", command);
 
             if (response.StatusCode == HttpStatusCode.Conflict)

--- a/src/KRAFT.Results.Web.Client/Features/Meets/EditMeetPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/EditMeetPage.razor
@@ -1,0 +1,105 @@
+@page "/meets/{slug}/edit"
+
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+
+@attribute [Authorize(Roles = "Admin")]
+
+@using System.Net
+@using KRAFT.Results.Contracts.Meets
+
+@inject HttpClient HttpClient
+@inject NavigationManager NavigationManager
+
+<PageTitle>Breyta móti</PageTitle>
+<h3>Breyta móti</h3>
+
+@if (_isInitializing)
+{
+    <p>Hleð...</p>
+}
+else if (_initialValues is not null)
+{
+    <MeetForm MeetTypes="_meetTypes"
+              OnSubmit="HandleSubmit"
+              IsLoading="_isLoading"
+              ErrorMessage="@_errorMessage"
+              SubmitLabel="Vista breytingar"
+              BackUrl="@($"/meets/{Slug}")"
+              InitialValues="_initialValues" />
+}
+
+@code {
+    [Parameter]
+    public string Slug { get; set; } = string.Empty;
+
+    private IReadOnlyList<MeetTypeSummary> _meetTypes = [];
+    private MeetFormInitialValues? _initialValues;
+    private bool _isInitializing = true;
+    private bool _isLoading;
+    private string? _errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            MeetDetails? meet = await HttpClient.GetFromJsonAsync<MeetDetails>($"/meets/{Slug}");
+            _meetTypes = await HttpClient.GetFromJsonAsync<IReadOnlyList<MeetTypeSummary>>("/meets/types") ?? [];
+
+            if (meet is null)
+            {
+                _errorMessage = "Mót fannst ekki.";
+                return;
+            }
+
+            _initialValues = new MeetFormInitialValues(meet.Title, meet.StartDate, meet.MeetTypeId);
+        }
+        catch (HttpRequestException)
+        {
+            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
+        }
+        finally
+        {
+            _isInitializing = false;
+        }
+    }
+
+    private async Task HandleSubmit(MeetFormValues values)
+    {
+        _isLoading = true;
+        _errorMessage = null;
+
+        try
+        {
+            UpdateMeetCommand command = new(values.Title, values.StartDate, values.MeetTypeId);
+            HttpResponseMessage response = await HttpClient.PutAsJsonAsync($"/meets/{Slug}", command);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _errorMessage = "Mót fannst ekki.";
+                return;
+            }
+
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                _errorMessage = "Mót með þessu nafni og dagsetningu er þegar til.";
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
+                return;
+            }
+
+            NavigationManager.NavigateTo($"/meets/{Slug}");
+        }
+        catch (HttpRequestException)
+        {
+            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -5,7 +5,18 @@
 
 @inject HttpClient HttpClient;
 
-<h1>@Meet?.Title</h1>
+<div class="page-header">
+    <h1>@Meet?.Title</h1>
+    <AuthorizeView Roles="Admin">
+        <a href="/meets/@Slug/edit" class="btn-action" aria-label="Breyta móti">
+            <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+                <path d="m15 5 4 4"/>
+            </svg>
+            Breyta
+        </a>
+    </AuthorizeView>
+</div>
 <p>
     @($"{Meet?.StartDate:dd-MM-yyyy}")
     @if (Meet?.EndDate is DateOnly endDate && endDate != Meet?.StartDate)

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -1,3 +1,43 @@
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-block-end: 1rem;
+    border-block-end: 1px solid var(--color-border);
+}
+
+.btn-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 1rem;
+    background: var(--color-primary);
+    color: var(--color-white);
+    border: none;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background-color var(--transition-fast) ease;
+}
+
+.btn-icon {
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+}
+
+.btn-action:hover {
+    background: var(--color-primary-dark);
+}
+
+.btn-action:focus-visible {
+    outline-color: var(--color-text);
+}
+
 .card-grid {
     display: grid;
     gap: 1rem;
@@ -27,4 +67,10 @@
 
 .first-attempt {
     border-inline-start: 1px solid var(--color-border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .btn-action {
+        transition: none;
+    }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetForm.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetForm.razor
@@ -68,12 +68,13 @@
 
 @code {
     private readonly MeetFormModel _model = new();
+    private bool _initialized;
 
     [Parameter, EditorRequired]
     public IReadOnlyList<MeetTypeSummary> MeetTypes { get; set; } = [];
 
     [Parameter, EditorRequired]
-    public EventCallback<CreateMeetCommand> OnSubmit { get; set; }
+    public EventCallback<MeetFormValues> OnSubmit { get; set; }
 
     [Parameter, EditorRequired]
     public bool IsLoading { get; set; }
@@ -87,11 +88,23 @@
     [Parameter, EditorRequired]
     public string BackUrl { get; set; } = string.Empty;
 
+    [Parameter]
+    public MeetFormInitialValues? InitialValues { get; set; }
+
     private bool HasError => !string.IsNullOrEmpty(ErrorMessage);
 
     protected override void OnParametersSet()
     {
-        if (_model.MeetTypeId == 0 && MeetTypes.Count > 0)
+        if (!_initialized && InitialValues is not null)
+        {
+            _model.Title = InitialValues.Title;
+            _model.StartDate = InitialValues.StartDate;
+            _model.MeetTypeId = InitialValues.MeetTypeId;
+            _initialized = true;
+            return;
+        }
+
+        if (!_initialized && _model.MeetTypeId == 0 && MeetTypes.Count > 0)
         {
             MeetTypeSummary? powerlifting = MeetTypes.FirstOrDefault(x => x.Title == "Powerlifting");
 
@@ -99,6 +112,8 @@
             {
                 _model.MeetTypeId = powerlifting.Id;
             }
+
+            _initialized = true;
         }
     }
 
@@ -114,12 +129,12 @@
 
     private async Task HandleValidSubmit()
     {
-        CreateMeetCommand command = new(
+        MeetFormValues values = new(
             _model.Title,
             _model.StartDate!.Value,
             _model.MeetTypeId);
 
-        await OnSubmit.InvokeAsync(command);
+        await OnSubmit.InvokeAsync(values);
     }
 
     private sealed class MeetFormModel

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
@@ -18,6 +18,7 @@ internal sealed class GetMeetDetailsHandler(ResultsDbContext dbContext)
                 DateOnly.FromDateTime(x.StartDate),
                 DateOnly.FromDateTime(x.EndDate),
                 x.MeetType.Title,
+                x.MeetType.MeetTypeId,
                 ((ResultMode)x.ResultModeId).ToString(),
                 x.CalcPlaces,
                 x.IsInTeamCompetition,

--- a/src/KRAFT.Results.WebApi/Features/Meets/Meet.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Meet.cs
@@ -89,4 +89,28 @@ internal sealed class Meet
 
         return meet;
     }
+
+    internal Result Update(User modifier, MeetType type, string title, DateOnly startDate)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return MeetErrors.EmptyTitle;
+        }
+
+        if (startDate.Year < StartDateMinimumYear)
+        {
+            return MeetErrors.InvalidStartDate(startDate);
+        }
+
+        DateTime date = startDate.ToDateTime(TimeOnly.MinValue);
+
+        Title = title;
+        StartDate = date;
+        EndDate = date;
+        MeetType = type;
+        ModifiedOn = DateTime.UtcNow;
+        ModifiedBy = modifier.Username;
+
+        return Result.Success();
+    }
 }

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetEndpoints.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetEndpoints.cs
@@ -3,6 +3,7 @@ using KRAFT.Results.WebApi.Features.Meets.Get;
 using KRAFT.Results.WebApi.Features.Meets.GetDetails;
 using KRAFT.Results.WebApi.Features.Meets.GetMeetTypes;
 using KRAFT.Results.WebApi.Features.Meets.GetParticipations;
+using KRAFT.Results.WebApi.Features.Meets.Update;
 
 namespace KRAFT.Results.WebApi.Features.Meets;
 
@@ -18,6 +19,7 @@ internal static class MeetEndpoints
         group.MapGetMeetsEndpoint();
         group.MapGetMeetDetailsEndpoint();
         group.MapGetMeetParticipationsEndpoint();
+        group.MapUpdateMeetEndpoint();
 
         return group;
     }

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetErrors.cs
@@ -4,6 +4,8 @@ namespace KRAFT.Results.WebApi.Features.Meets;
 
 internal static class MeetErrors
 {
+    internal const string MeetNotFoundCode = "Meets.NotFound";
+
     internal const string MeetExistsCode = "Meets.AlreadyExists";
 
     internal static readonly Error EmptyTitle = new(
@@ -13,6 +15,10 @@ internal static class MeetErrors
     internal static readonly Error MeetTypeNotFound = new(
         "Meets.MeetTypeNotFound",
         "Meet type not found in database");
+
+    internal static readonly Error MeetNotFound = new(
+        MeetNotFoundCode,
+        "Meet not found.");
 
     internal static Error InvalidStartDate(DateOnly startDate) => new(
         "Meets.InvalidStartDate",

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
@@ -3,6 +3,7 @@ using KRAFT.Results.WebApi.Features.Meets.Get;
 using KRAFT.Results.WebApi.Features.Meets.GetDetails;
 using KRAFT.Results.WebApi.Features.Meets.GetMeetTypes;
 using KRAFT.Results.WebApi.Features.Meets.GetParticipations;
+using KRAFT.Results.WebApi.Features.Meets.Update;
 
 namespace KRAFT.Results.WebApi.Features.Meets;
 
@@ -15,6 +16,7 @@ internal static class MeetServices
         services.AddScoped<GetMeetsHandler>();
         services.AddScoped<GetMeetDetailsHandler>();
         services.AddScoped<GetMeetParticipationsHandler>();
+        services.AddScoped<UpdateMeetHandler>();
 
         return services;
     }

--- a/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetEndpoint.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetEndpoint.cs
@@ -1,0 +1,43 @@
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.Abstractions;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace KRAFT.Results.WebApi.Features.Meets.Update;
+
+internal static class UpdateMeetEndpoint
+{
+    internal const string Name = "UpdateMeet";
+
+    internal static RouteGroupBuilder MapUpdateMeetEndpoint(this RouteGroupBuilder endpoints)
+    {
+        endpoints.MapPut("/{slug}", static async (
+            [FromRoute] string slug,
+            [FromBody] UpdateMeetCommand command,
+            [FromServices] UpdateMeetHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            Result result = await handler.Handle(slug, command, cancellationToken);
+
+            return result.Match<IResult>(
+                success: () => TypedResults.Ok(),
+                failure: error => error.Code switch
+                {
+                    MeetErrors.MeetNotFoundCode => TypedResults.NotFound(),
+                    MeetErrors.MeetExistsCode => TypedResults.Conflict(),
+                    _ => TypedResults.BadRequest(error.Description),
+                });
+        })
+        .WithName(Name)
+        .WithSummary("Updates a meet.")
+        .WithDescription("Updates an existing meet's details.")
+        .Produces(StatusCodes.Status200OK)
+        .ProducesProblem(StatusCodes.Status400BadRequest)
+        .ProducesProblem(StatusCodes.Status404NotFound)
+        .ProducesProblem(StatusCodes.Status409Conflict)
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .RequireAuthorization(policy => policy.RequireRole("Admin"));
+
+        return endpoints;
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
@@ -1,0 +1,74 @@
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.Services;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace KRAFT.Results.WebApi.Features.Meets.Update;
+
+internal sealed class UpdateMeetHandler
+{
+    private readonly ILogger<UpdateMeetHandler> _logger;
+    private readonly ResultsDbContext _dbContext;
+    private readonly IHttpContextService _httpContextService;
+
+    public UpdateMeetHandler(ILogger<UpdateMeetHandler> logger, ResultsDbContext dbContext, IHttpContextService httpContextService)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+        _httpContextService = httpContextService;
+    }
+
+    public async Task<Result> Handle(string slug, UpdateMeetCommand command, CancellationToken cancellationToken)
+    {
+        User modifier = await _dbContext.GetUserAsync(_httpContextService, cancellationToken);
+
+        Meet? meet = await _dbContext.Set<Meet>()
+            .Where(x => x.Slug == slug)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (meet is null)
+        {
+            _logger.LogWarning("Meet with slug '{Slug}' was not found", slug);
+            return Result.Failure(MeetErrors.MeetNotFound);
+        }
+
+        if (await IsDuplicateAsync(slug, command.Title, command.StartDate, cancellationToken))
+        {
+            _logger.LogWarning("A meet with the title '{Title}' and start date '{StartDate}' already exists.", command.Title, command.StartDate);
+            return Result.Failure(MeetErrors.MeetExists(command.Title, command.StartDate));
+        }
+
+        int meetTypeId = command.MeetTypeId ?? 1;
+
+        if (await GetMeetTypeAsync(meetTypeId, cancellationToken) is not MeetType type)
+        {
+            _logger.LogWarning("Meet type with Id {Id} was not found in the database", meetTypeId);
+            return Result.Failure(MeetErrors.MeetTypeNotFound);
+        }
+
+        Result result = meet.Update(modifier, type, command.Title, command.StartDate);
+
+        if (result.IsFailure)
+        {
+            return result;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+
+    private Task<bool> IsDuplicateAsync(string currentSlug, string title, DateOnly startDate, CancellationToken cancellationToken) =>
+        _dbContext.Set<Meet>()
+        .Where(x => x.Slug != currentSlug)
+        .Where(x => x.Title == title)
+        .Where(x => x.StartDate == startDate.ToDateTime(TimeOnly.MinValue))
+        .AnyAsync(cancellationToken);
+
+    private Task<MeetType?> GetMeetTypeAsync(int meetTypeId, CancellationToken cancellationToken) =>
+        _dbContext.Set<MeetType>()
+        .Where(x => x.MeetTypeId == meetTypeId)
+        .FirstOrDefaultAsync(cancellationToken);
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/UpdateMeetCommandBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/UpdateMeetCommandBuilder.cs
@@ -1,0 +1,31 @@
+using KRAFT.Results.Contracts.Meets;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Builders;
+
+internal sealed class UpdateMeetCommandBuilder
+{
+    private string _title = Guid.NewGuid().ToString();
+    private DateOnly _startDate = DateOnly.FromDateTime(DateTime.UtcNow);
+    private int? _meetTypeId;
+
+    public UpdateMeetCommandBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    public UpdateMeetCommandBuilder WithStartDate(DateOnly startDate)
+    {
+        _startDate = startDate;
+        return this;
+    }
+
+    public UpdateMeetCommandBuilder WithMeetTypeId(int? meetTypeId)
+    {
+        _meetTypeId = meetTypeId;
+        return this;
+    }
+
+    public UpdateMeetCommand Build() =>
+        new(_title, _startDate, _meetTypeId);
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateMeetTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateMeetTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
+
+public sealed class UpdateMeetTests(IntegrationTestFixture fixture)
+{
+    private const string BasePath = "/meets";
+
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory.CreateClient();
+
+    [Fact]
+    public async Task ReturnsOk_WhenSuccessful()
+    {
+        // Arrange
+        string slug = await CreateMeetAsync();
+        UpdateMeetCommand command = new UpdateMeetCommandBuilder()
+            .WithTitle("Updated Title")
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenMeetDoesNotExist()
+    {
+        // Arrange
+        UpdateMeetCommand command = new UpdateMeetCommandBuilder().Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/non-existent-slug", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReturnsForbidden_WhenUserIsNotAdmin()
+    {
+        // Arrange
+        string slug = await CreateMeetAsync();
+        UpdateMeetCommand command = new UpdateMeetCommandBuilder().Build();
+
+        // Act
+        HttpResponseMessage response = await _nonAdminHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ReturnsUnauthorized_WhenNotAuthenticated()
+    {
+        // Arrange
+        UpdateMeetCommand command = new UpdateMeetCommandBuilder().Build();
+
+        // Act
+        HttpResponseMessage response = await _unauthorizedHttpClient.PutAsJsonAsync($"{BasePath}/some-slug", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequest_WhenTitleIsEmpty()
+    {
+        // Arrange
+        string slug = await CreateMeetAsync();
+        UpdateMeetCommand command = new UpdateMeetCommandBuilder()
+            .WithTitle(string.Empty)
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequest_WhenDateIsBefore1900()
+    {
+        // Arrange
+        string slug = await CreateMeetAsync();
+        UpdateMeetCommand command = new UpdateMeetCommandBuilder()
+            .WithStartDate(new DateOnly(1899, 1, 1))
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequest_WhenMeetTypeDoesNotExist()
+    {
+        // Arrange
+        string slug = await CreateMeetAsync();
+        UpdateMeetCommand command = new UpdateMeetCommandBuilder()
+            .WithMeetTypeId(int.MaxValue)
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    private async Task<string> CreateMeetAsync()
+    {
+        CreateMeetCommand createCommand = new CreateMeetCommandBuilder().Build();
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync(BasePath, createCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        string? location = createResponse.Headers.Location?.ToString();
+        location.ShouldNotBeNull();
+
+        return location.TrimStart('/');
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PUT /meets/{slug}` endpoint with Admin auth to update meet title, start date, and meet type (slug stays immutable)
- Add `Update()` instance method to `Meet` entity and `MeetNotFound` error
- Add `MeetTypeId` to `MeetDetails` contract for form pre-population
- Refactor `MeetForm.razor` to accept `InitialValues` parameter and emit `MeetFormValues` (shared between create and edit)
- Add `EditMeetPage.razor` at `/meets/{slug}/edit` with admin-only access
- Add admin-only edit link (pencil icon) on `MeetDetailsPage`
- Duplicate title+date check excludes self on update

## Test plan
- [x] `ReturnsOk_WhenSuccessful` — create then PUT with modified title
- [x] `ReturnsNotFound_WhenMeetDoesNotExist` — PUT to non-existent slug
- [x] `ReturnsForbidden_WhenUserIsNotAdmin` — non-admin client
- [x] `ReturnsUnauthorized_WhenNotAuthenticated` — no auth
- [x] `ReturnsBadRequest_WhenTitleIsEmpty` — empty title
- [x] `ReturnsBadRequest_WhenDateIsBefore1900` — invalid date
- [x] `ReturnsBadRequest_WhenMeetTypeDoesNotExist` — invalid MeetTypeId
- [x] All 147 existing tests still pass

Closes #167