### PR TITLE
Fix flaky E2E tests across all test files

### DIFF
--- a/tests/KRAFT.Results.Web.E2ETests/Features/Athletes/AthleteDetailsTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Athletes/AthleteDetailsTests.cs
@@ -1,6 +1,8 @@
+using System.Text.RegularExpressions;
+
 using Microsoft.Playwright;
 
-using Shouldly;
+using static Microsoft.Playwright.Assertions;
 
 namespace KRAFT.Results.Web.E2ETests.Features.Athletes;
 
@@ -21,15 +23,16 @@ public class AthleteDetailsTests(PlaywrightFixture fixture)
         await firstAthleteLink.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
         await firstAthleteLink.ClickAsync();
 
-        ILocator heading = page.Locator("h1");
-        await heading.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
-
-        // Assert
-        string name = await heading.InnerTextAsync();
-        name.ShouldNotBeNullOrWhiteSpace();
+        await page.WaitForURLAsync(new Regex(@"/athletes/[a-z0-9-]+$"), new PageWaitForURLOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
         ILocator athleteMeta = page.Locator(".athlete-meta");
-        string meta = await athleteMeta.InnerTextAsync();
-        meta.ShouldContain("Fæðingarár:");
+        await athleteMeta.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
+
+        // Assert
+        ILocator heading = page.Locator("h1");
+        await Expect(heading).ToBeVisibleAsync();
+        await Expect(heading).Not.ToBeEmptyAsync();
+
+        await Expect(athleteMeta).ToContainTextAsync("Fæðingarár:");
     }
 }

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Athletes/AthletesIndexTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Athletes/AthletesIndexTests.cs
@@ -29,8 +29,7 @@ public class AthletesIndexTests(PlaywrightFixture fixture)
         string headingText = await heading.InnerTextAsync();
         headingText.ShouldBe("Keppendur");
 
-        bool searchVisible = await searchInput.IsVisibleAsync();
-        searchVisible.ShouldBeTrue();
+        await Expect(searchInput).ToBeVisibleAsync();
 
         ILocator athleteRows = page.Locator("table tbody tr");
         await Expect(athleteRows).Not.ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = PageConstants.DefaultTimeoutMs });

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Auth/LoginTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Auth/LoginTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Playwright;
 
 using Shouldly;
 
+using static Microsoft.Playwright.Assertions;
+
 namespace KRAFT.Results.Web.E2ETests.Features.Auth;
 
 public class LoginTests(PlaywrightFixture fixture)
@@ -26,18 +28,15 @@ public class LoginTests(PlaywrightFixture fixture)
 
         ILocator usernameInput = page.Locator("#username");
         await usernameInput.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
-        bool usernameVisible = await usernameInput.IsVisibleAsync();
-        usernameVisible.ShouldBeTrue();
+        await Expect(usernameInput).ToBeVisibleAsync();
 
         ILocator passwordInput = page.Locator("#password");
         await passwordInput.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
-        bool passwordVisible = await passwordInput.IsVisibleAsync();
-        passwordVisible.ShouldBeTrue();
+        await Expect(passwordInput).ToBeVisibleAsync();
 
         ILocator submitButton = page.Locator("button[type='submit']");
         await submitButton.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
-        bool submitVisible = await submitButton.IsVisibleAsync();
-        submitVisible.ShouldBeTrue();
+        await Expect(submitButton).ToBeVisibleAsync();
 
         string submitText = await submitButton.InnerTextAsync();
         submitText.ShouldContain("Innskrá");

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Meets/CreateMeetPageTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Meets/CreateMeetPageTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Playwright;
 
 using Shouldly;
 
+using static Microsoft.Playwright.Assertions;
+
 namespace KRAFT.Results.Web.E2ETests.Features.Meets;
 
 public class CreateMeetPageTests(PlaywrightFixture fixture)
@@ -24,8 +26,7 @@ public class CreateMeetPageTests(PlaywrightFixture fixture)
         await heading.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
         // Assert
-        bool headingVisible = await heading.IsVisibleAsync();
-        headingVisible.ShouldBeTrue();
+        await Expect(heading).ToBeVisibleAsync();
     }
 
     [Fact]
@@ -45,16 +46,13 @@ public class CreateMeetPageTests(PlaywrightFixture fixture)
 
         // Assert
         ILocator nafnLabel = page.GetByText("Nafn", new PageGetByTextOptions { Exact = true });
-        bool nafnVisible = await nafnLabel.IsVisibleAsync();
-        nafnVisible.ShouldBeTrue();
+        await Expect(nafnLabel).ToBeVisibleAsync();
 
         ILocator dagsetningLabel = page.GetByText("Dagsetning", new PageGetByTextOptions { Exact = true });
-        bool dagsetningVisible = await dagsetningLabel.IsVisibleAsync();
-        dagsetningVisible.ShouldBeTrue();
+        await Expect(dagsetningLabel).ToBeVisibleAsync();
 
         ILocator tegundLabel = page.GetByText("Tegund móts", new PageGetByTextOptions { Exact = true });
-        bool tegundVisible = await tegundLabel.IsVisibleAsync();
-        tegundVisible.ShouldBeTrue();
+        await Expect(tegundLabel).ToBeVisibleAsync();
     }
 
     [Fact]

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Rankings/RankingsTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Rankings/RankingsTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Playwright;
 
 using Shouldly;
 
+using static Microsoft.Playwright.Assertions;
+
 namespace KRAFT.Results.Web.E2ETests.Features.Rankings;
 
 public class RankingsTests(PlaywrightFixture fixture)
@@ -26,7 +28,6 @@ public class RankingsTests(PlaywrightFixture fixture)
 
         ILocator filterBar = page.Locator(".filter-bar");
         await filterBar.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
-        bool filterVisible = await filterBar.IsVisibleAsync();
-        filterVisible.ShouldBeTrue();
+        await Expect(filterBar).ToBeVisibleAsync();
     }
 }

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Records/RecordsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Records/RecordsIndexTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Playwright;
 
 using Shouldly;
 
+using static Microsoft.Playwright.Assertions;
+
 namespace KRAFT.Results.Web.E2ETests.Features.Records;
 
 public class RecordsIndexTests(PlaywrightFixture fixture)
@@ -26,8 +28,7 @@ public class RecordsIndexTests(PlaywrightFixture fixture)
 
         ILocator equipmentToggle = page.Locator(".equipment-toggle");
         await equipmentToggle.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
-        bool toggleVisible = await equipmentToggle.IsVisibleAsync();
-        toggleVisible.ShouldBeTrue();
+        await Expect(equipmentToggle).ToBeVisibleAsync();
 
         ILocator maleSection = page.Locator("h2", new PageLocatorOptions { HasText = "Karlar" });
         string maleText = await maleSection.InnerTextAsync();

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Records/RecordsPageTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Records/RecordsPageTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Playwright;
 
 using Shouldly;
 
+using static Microsoft.Playwright.Assertions;
+
 namespace KRAFT.Results.Web.E2ETests.Features.Records;
 
 public class RecordsPageTests(PlaywrightFixture fixture)
@@ -27,8 +29,7 @@ public class RecordsPageTests(PlaywrightFixture fixture)
 
         ILocator breadcrumb = page.Locator("nav.breadcrumb");
         await breadcrumb.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
-        bool breadcrumbVisible = await breadcrumb.IsVisibleAsync();
-        breadcrumbVisible.ShouldBeTrue();
+        await Expect(breadcrumb).ToBeVisibleAsync();
 
         ILocator recordTables = page.Locator(".record-section table");
         await recordTables.First.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Teams/CreateTeamPageTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Teams/CreateTeamPageTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Playwright;
 
 using Shouldly;
 
+using static Microsoft.Playwright.Assertions;
+
 namespace KRAFT.Results.Web.E2ETests.Features.Teams;
 
 public class CreateTeamPageTests(PlaywrightFixture fixture)
@@ -24,8 +26,7 @@ public class CreateTeamPageTests(PlaywrightFixture fixture)
         await heading.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
         // Assert
-        bool headingVisible = await heading.IsVisibleAsync();
-        headingVisible.ShouldBeTrue();
+        await Expect(heading).ToBeVisibleAsync();
     }
 
     [Fact]
@@ -45,20 +46,16 @@ public class CreateTeamPageTests(PlaywrightFixture fixture)
 
         // Assert
         ILocator nafnLabel = page.GetByText("Nafn", new PageGetByTextOptions { Exact = true });
-        bool nafnVisible = await nafnLabel.IsVisibleAsync();
-        nafnVisible.ShouldBeTrue();
+        await Expect(nafnLabel).ToBeVisibleAsync();
 
         ILocator skammstofunLabel = page.GetByText("Skammstöfun", new PageGetByTextOptions { Exact = true });
-        bool skammstofunVisible = await skammstofunLabel.IsVisibleAsync();
-        skammstofunVisible.ShouldBeTrue();
+        await Expect(skammstofunLabel).ToBeVisibleAsync();
 
         ILocator fulltNafnLabel = page.GetByText("Fullt nafn", new PageGetByTextOptions { Exact = true });
-        bool fulltNafnVisible = await fulltNafnLabel.IsVisibleAsync();
-        fulltNafnVisible.ShouldBeTrue();
+        await Expect(fulltNafnLabel).ToBeVisibleAsync();
 
         ILocator landLabel = page.GetByText("Land", new PageGetByTextOptions { Exact = true });
-        bool landVisible = await landLabel.IsVisibleAsync();
-        landVisible.ShouldBeTrue();
+        await Expect(landLabel).ToBeVisibleAsync();
     }
 
     [Fact]
@@ -77,8 +74,7 @@ public class CreateTeamPageTests(PlaywrightFixture fixture)
         await createTeamLink.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
         // Assert
-        bool linkVisible = await createTeamLink.IsVisibleAsync();
-        linkVisible.ShouldBeTrue();
+        await Expect(createTeamLink).ToBeVisibleAsync();
     }
 
     [Fact]

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Users/CreateUserPageTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Users/CreateUserPageTests.cs
@@ -1,6 +1,6 @@
 using Microsoft.Playwright;
 
-using Shouldly;
+using static Microsoft.Playwright.Assertions;
 
 namespace KRAFT.Results.Web.E2ETests.Features.Users;
 
@@ -24,7 +24,6 @@ public class CreateUserPageTests(PlaywrightFixture fixture)
         await heading.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
         // Assert
-        bool headingVisible = await heading.IsVisibleAsync();
-        headingVisible.ShouldBeTrue();
+        await Expect(heading).ToBeVisibleAsync();
     }
 }

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Users/UserIndexTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Users/UserIndexTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Playwright;
 
 using Shouldly;
 
+using static Microsoft.Playwright.Assertions;
+
 namespace KRAFT.Results.Web.E2ETests.Features.Users;
 
 public class UserIndexTests(PlaywrightFixture fixture)
@@ -24,8 +26,7 @@ public class UserIndexTests(PlaywrightFixture fixture)
         await heading.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
         // Assert
-        bool headingVisible = await heading.IsVisibleAsync();
-        headingVisible.ShouldBeTrue();
+        await Expect(heading).ToBeVisibleAsync();
 
         ILocator tableRows = page.Locator("table tbody tr");
         await tableRows.First.WaitForAsync(new LocatorWaitForOptions { Timeout = PageConstants.DefaultTimeoutMs });


### PR DESCRIPTION
## Summary
- Replace all point-in-time `IsVisibleAsync()` + Shouldly assertions with Playwright's auto-retrying `Expect().ToBeVisibleAsync()` across 10 E2E test files (19 instances)
- Fix `AthleteDetailsTests.LoadsAthleteDetails` navigation timeout by waiting for URL change with `WaitForURLAsync` and page-specific `.athlete-meta` element after Blazor enhanced navigation

## Test plan
- [x] All 147 tests pass (110 integration + 11 client + 26 E2E)
- [x] No production code changed

Closes #193