### PR TITLE
Skip CI pipeline for docs-only pull requests

### DIFF
--- a/.github/workflows/dotnet-skip.yml
+++ b/.github/workflows/dotnet-skip.yml
@@ -1,0 +1,20 @@
+name: .NET
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '**.md'
+      - 'LICENSE'
+      - 'docs/**'
+      - '.editorconfig'
+      - '.gitignore'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Skipping CI for docs-only changes"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,6 +5,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'docs/**'
+      - '.editorconfig'
+      - '.gitignore'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `pull_request` trigger — skips full build for docs-only changes (`.md`, `LICENSE`, `docs/**`, `.editorconfig`, `.gitignore`)
- Add lightweight skip workflow (`.github/workflows/dotnet-skip.yml`) with matching workflow name and job id so required status checks pass
- Pushes to main continue running all tests unconditionally

## Test plan
- [ ] Open a PR that only changes a `.md` file — verify the full pipeline is skipped and the skip workflow passes
- [ ] Open a PR that changes a `.cs` file — verify the full pipeline runs
- [ ] Open a PR that changes `.github/workflows/dotnet.yml` — verify the full pipeline runs

Closes #197