### PR TITLE
Add edit team details with shared TeamForm component

### DIFF
--- a/src/KRAFT.Results.Contracts/Teams/TeamDetails.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamDetails.cs
@@ -5,4 +5,5 @@ public sealed record class TeamDetails(
     string Title,
     string ShortTitle,
     string FullTitle,
+    int? CountryId,
     IReadOnlyList<TeamMember> Members);

--- a/src/KRAFT.Results.Contracts/Teams/TeamFormInitialValues.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamFormInitialValues.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Teams;
+
+public sealed record class TeamFormInitialValues(string Title, string TitleShort, string TitleFull, int CountryId);

--- a/src/KRAFT.Results.Contracts/Teams/TeamFormValues.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamFormValues.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Teams;
+
+public sealed record class TeamFormValues(string Title, string TitleShort, string TitleFull, int CountryId);

--- a/src/KRAFT.Results.Contracts/Teams/UpdateTeamCommand.cs
+++ b/src/KRAFT.Results.Contracts/Teams/UpdateTeamCommand.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Teams;
+
+public sealed record class UpdateTeamCommand(string Title, string TitleShort, string TitleFull, int CountryId);

--- a/src/KRAFT.Results.Web.Client/Features/Teams/CreateTeamPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/CreateTeamPage.razor
@@ -4,7 +4,6 @@
 
 @attribute [Authorize(Roles = "Admin")]
 
-@using System.ComponentModel.DataAnnotations
 @using System.Net
 @using KRAFT.Results.Contracts.Countries
 @using KRAFT.Results.Contracts.Teams
@@ -12,93 +11,20 @@
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
 
+<PageTitle>Nýtt félag</PageTitle>
 <h3>Nýtt félag</h3>
 
-<div class="form-card">
-    <EditForm Model="_model" OnValidSubmit="HandleSubmit" FormName="create-team">
-        <DataAnnotationsValidator />
-
-        <div class="form-field">
-            <label class="form-label" for="title">Nafn</label>
-            <InputText id="title"
-                       class="form-input"
-                       aria-required="true"
-                       aria-describedby="@(HasError ? "create-error" : null)"
-                       @bind-Value="_model.Title"
-                       disabled="@_isLoading" />
-            <ValidationMessage For="@(() => _model.Title)" />
-        </div>
-
-        <div class="form-field">
-            <label class="form-label" for="title-short">Skammstöfun</label>
-            <InputText id="title-short"
-                       class="form-input"
-                       maxlength="3"
-                       aria-required="true"
-                       aria-describedby="@(HasError ? "title-short-hint create-error" : "title-short-hint")"
-                       @bind-Value="_model.TitleShort"
-                       disabled="@_isLoading" />
-            <span id="title-short-hint" class="form-hint">Nákvæmlega 3 stafir</span>
-            <ValidationMessage For="@(() => _model.TitleShort)" />
-        </div>
-
-        <div class="form-field">
-            <label class="form-label" for="title-full">Fullt nafn</label>
-            <InputText id="title-full"
-                       class="form-input"
-                       aria-required="true"
-                       aria-describedby="@(HasError ? "create-error" : null)"
-                       @bind-Value="_model.TitleFull"
-                       disabled="@_isLoading" />
-            <ValidationMessage For="@(() => _model.TitleFull)" />
-        </div>
-
-        <div class="form-field">
-            <label class="form-label" for="country">Land</label>
-            <InputSelect id="country"
-                         class="form-input form-select"
-                         aria-required="true"
-                         aria-describedby="@(HasError ? "create-error" : null)"
-                         @bind-Value="_model.CountryId"
-                         disabled="@_isLoading">
-                <option value="">-- Veldu land --</option>
-                @foreach (CountrySummary country in _countries)
-                {
-                    <option value="@country.Id">@country.Name</option>
-                }
-            </InputSelect>
-            <ValidationMessage For="@(() => _model.CountryId)" />
-        </div>
-
-        <div class="form-actions">
-            <button type="submit" class="btn-primary" disabled="@_isLoading" aria-busy="@_isLoading">
-                @if (_isLoading)
-                {
-                    <span>Augnablik...</span>
-                }
-                else
-                {
-                    <span>Stofna félag</span>
-                }
-            </button>
-
-            <a href="/teams" class="btn-cancel">Til baka</a>
-        </div>
-
-        @if (!string.IsNullOrEmpty(_errorMessage))
-        {
-            <div id="create-error" class="error-message" role="alert">@_errorMessage</div>
-        }
-    </EditForm>
-</div>
+<TeamForm Countries="_countries"
+          OnSubmit="HandleSubmit"
+          IsLoading="_isLoading"
+          ErrorMessage="@_errorMessage"
+          SubmitLabel="Stofna félag"
+          BackUrl="/teams" />
 
 @code {
-    private readonly CreateTeamModel _model = new();
     private IReadOnlyCollection<CountrySummary> _countries = [];
     private bool _isLoading;
     private string? _errorMessage;
-
-    private bool HasError => !string.IsNullOrEmpty(_errorMessage);
 
     protected override async Task OnInitializedAsync()
     {
@@ -112,7 +38,7 @@
         }
     }
 
-    private async Task HandleSubmit()
+    private async Task HandleSubmit(TeamFormValues values)
     {
         _isLoading = true;
         _errorMessage = null;
@@ -120,10 +46,10 @@
         try
         {
             CreateTeamCommand command = new(
-                _model.Title,
-                _model.TitleShort,
-                _model.TitleFull,
-                _model.CountryId);
+                values.Title,
+                values.TitleShort,
+                values.TitleFull,
+                values.CountryId);
 
             HttpResponseMessage response = await HttpClient.PostAsJsonAsync("/teams", command);
 
@@ -154,21 +80,5 @@
         {
             _isLoading = false;
         }
-    }
-
-    private sealed class CreateTeamModel
-    {
-        [Required]
-        public string Title { get; set; } = string.Empty;
-
-        [Required]
-        [StringLength(3, MinimumLength = 3)]
-        public string TitleShort { get; set; } = string.Empty;
-
-        [Required]
-        public string TitleFull { get; set; } = string.Empty;
-
-        [Range(1, int.MaxValue)]
-        public int CountryId { get; set; }
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Teams/EditTeamPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/EditTeamPage.razor
@@ -1,0 +1,127 @@
+@page "/teams/{slug}/edit"
+
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+
+@attribute [Authorize(Roles = "Admin")]
+
+@using System.Net
+@using KRAFT.Results.Contracts.Countries
+@using KRAFT.Results.Contracts.Teams
+
+@inject HttpClient HttpClient
+@inject NavigationManager NavigationManager
+
+<PageTitle>Breyta félagi</PageTitle>
+<h3>Breyta félagi</h3>
+
+@if (_isInitializing)
+{
+    <p>Hleð...</p>
+}
+else if (_initialValues is not null)
+{
+    <TeamForm Countries="_countries"
+              OnSubmit="HandleSubmit"
+              IsLoading="_isLoading"
+              ErrorMessage="@_errorMessage"
+              SubmitLabel="Vista breytingar"
+              BackUrl="@($"/teams/{Slug}")"
+              InitialValues="_initialValues" />
+}
+else if (_errorMessage is not null)
+{
+    <div role="alert" class="error-message">
+        <p>@_errorMessage</p>
+        <a href="/teams">Til baka í félagalista</a>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public string Slug { get; set; } = string.Empty;
+
+    private IReadOnlyCollection<CountrySummary> _countries = [];
+    private TeamFormInitialValues? _initialValues;
+    private bool _isInitializing = true;
+    private bool _isLoading;
+    private string? _errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            TeamDetails? team = await HttpClient.GetFromJsonAsync<TeamDetails>($"/teams/{Slug}");
+            _countries = await HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries") ?? [];
+
+            if (team is null)
+            {
+                _errorMessage = "Félag fannst ekki.";
+                return;
+            }
+
+            _initialValues = new TeamFormInitialValues(
+                team.Title,
+                team.ShortTitle,
+                team.FullTitle,
+                team.CountryId ?? 0);
+        }
+        catch (HttpRequestException)
+        {
+            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
+        }
+        finally
+        {
+            _isInitializing = false;
+        }
+    }
+
+    private async Task HandleSubmit(TeamFormValues values)
+    {
+        _isLoading = true;
+        _errorMessage = null;
+
+        try
+        {
+            UpdateTeamCommand command = new(
+                values.Title,
+                values.TitleShort,
+                values.TitleFull,
+                values.CountryId);
+
+            HttpResponseMessage response = await HttpClient.PutAsJsonAsync($"/teams/{Slug}", command);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _errorMessage = "Félag fannst ekki.";
+                return;
+            }
+
+            if (response.StatusCode == HttpStatusCode.BadRequest)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+
+                _errorMessage = body.Contains("already exists")
+                    ? "Félag með þessa skammstöfun er þegar til."
+                    : "Villa kom upp. Reyndu aftur síðar.";
+
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
+                return;
+            }
+
+            NavigationManager.NavigateTo($"/teams/{Slug}");
+        }
+        catch (HttpRequestException)
+        {
+            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
@@ -6,26 +6,54 @@
 
 @inject HttpClient HttpClient;
 
-<h3>@Team?.FullTitle (@Team?.ShortTitle)</h3>
+@if (_isLoading)
+{
+    <p>Hleð gögnum...</p>
+}
+else if (_errorMessage is not null)
+{
+    <div role="alert" class="error-message">
+        <p>@_errorMessage</p>
+        <a href="/teams">Til baka í félagslista</a>
+    </div>
+}
+else
+{
+    <div class="page-header">
+        <h3>@Team?.FullTitle (@Team?.ShortTitle)</h3>
+        <AuthorizeView Roles="Admin">
+            <a href="/teams/@Slug/edit" class="btn-action" aria-label="Breyta félagi">
+                <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+                    <path d="m15 5 4 4"/>
+                </svg>
+                Breyta
+            </a>
+        </AuthorizeView>
+    </div>
 
-<br/>
+    <br/>
 
-<h4>Meðlimir</h4>
+    <h4>Meðlimir</h4>
 
-<table>
-    @foreach (var member in Team?.Members ?? [])
-    {
-        <tr>
-            <td>
-                <NavLink class="nav-link" href="@($"/athletes/{member.Slug}")">
-                    @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
-                </NavLink>
-            </td>
-        </tr>
-    }
-</table>
+    <table>
+        @foreach (var member in Team?.Members ?? [])
+        {
+            <tr>
+                <td>
+                    <NavLink class="nav-link" href="@($"/athletes/{member.Slug}")">
+                        @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
+                    </NavLink>
+                </td>
+            </tr>
+        }
+    </table>
+}
 
 @code {
+    private bool _isLoading = true;
+    private string? _errorMessage;
+
     [Parameter]
     public string Slug { get; set; } = string.Empty;
 
@@ -33,6 +61,22 @@
 
     protected override async Task OnInitializedAsync()
     {
-        Team = await HttpClient.GetFromJsonAsync<TeamDetails>($"/teams/{Slug}");
+        try
+        {
+            Team = await HttpClient.GetFromJsonAsync<TeamDetails>($"/teams/{Slug}");
+
+            if (Team is null)
+            {
+                _errorMessage = "Félag fannst ekki.";
+            }
+        }
+        catch (HttpRequestException)
+        {
+            _errorMessage = "Villa kom upp við að sækja félag. Reyndu aftur síðar.";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
@@ -1,0 +1,45 @@
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-block-end: 1rem;
+    border-block-end: 1px solid var(--color-border);
+}
+
+.btn-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 1rem;
+    background: var(--color-primary);
+    color: var(--color-white);
+    border: none;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background-color var(--transition-fast) ease;
+}
+
+.btn-icon {
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+}
+
+.btn-action:hover {
+    background: var(--color-primary-dark);
+}
+
+.btn-action:focus-visible {
+    outline-color: var(--color-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .btn-action {
+        transition: none;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamForm.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamForm.razor
@@ -1,0 +1,164 @@
+@using System.ComponentModel.DataAnnotations
+@using KRAFT.Results.Contracts.Countries
+@using KRAFT.Results.Contracts.Teams
+
+<div class="form-card">
+    <EditForm Model="_model" OnValidSubmit="HandleValidSubmit" FormName="team-form">
+        <DataAnnotationsValidator />
+
+        <div class="form-field">
+            <label class="form-label" for="title">Nafn</label>
+            <InputText id="title"
+                       class="form-input"
+                       aria-required="true"
+                       aria-describedby="@GetAriaDescribedBy("title-error")"
+                       @bind-Value="_model.Title"
+                       disabled="@IsLoading" />
+            <div id="title-error">
+                <ValidationMessage For="@(() => _model.Title)" />
+            </div>
+        </div>
+
+        <div class="form-field">
+            <label class="form-label" for="title-short">Skammstöfun</label>
+            <InputText id="title-short"
+                       class="form-input"
+                       maxlength="3"
+                       aria-required="true"
+                       aria-describedby="@GetAriaDescribedBy("title-short-error", "title-short-hint")"
+                       @bind-Value="_model.TitleShort"
+                       disabled="@IsLoading" />
+            <span id="title-short-hint" class="form-hint">Nákvæmlega 3 stafir</span>
+            <div id="title-short-error">
+                <ValidationMessage For="@(() => _model.TitleShort)" />
+            </div>
+        </div>
+
+        <div class="form-field">
+            <label class="form-label" for="title-full">Fullt nafn</label>
+            <InputText id="title-full"
+                       class="form-input"
+                       aria-required="true"
+                       aria-describedby="@GetAriaDescribedBy("title-full-error")"
+                       @bind-Value="_model.TitleFull"
+                       disabled="@IsLoading" />
+            <div id="title-full-error">
+                <ValidationMessage For="@(() => _model.TitleFull)" />
+            </div>
+        </div>
+
+        <div class="form-field">
+            <label class="form-label" for="country">Land</label>
+            <InputSelect id="country"
+                         class="form-input form-select"
+                         aria-required="true"
+                         aria-describedby="@GetAriaDescribedBy("country-error")"
+                         @bind-Value="_model.CountryId"
+                         disabled="@IsLoading">
+                <option value="0">-- Veldu land --</option>
+                @foreach (CountrySummary country in Countries)
+                {
+                    <option value="@country.Id">@country.Name</option>
+                }
+            </InputSelect>
+            <div id="country-error">
+                <ValidationMessage For="@(() => _model.CountryId)" />
+            </div>
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn-primary" disabled="@IsLoading" aria-busy="@IsLoading">
+                @if (IsLoading)
+                {
+                    <span>Augnablik...</span>
+                }
+                else
+                {
+                    <span>@SubmitLabel</span>
+                }
+            </button>
+
+            <a href="@BackUrl" class="btn-cancel">Til baka</a>
+        </div>
+
+        @if (!string.IsNullOrEmpty(ErrorMessage))
+        {
+            <div id="team-form-error" class="error-message" role="alert">@ErrorMessage</div>
+        }
+    </EditForm>
+</div>
+
+@code {
+    private readonly TeamFormModel _model = new();
+    private bool _initialized;
+
+    [Parameter, EditorRequired]
+    public IReadOnlyCollection<CountrySummary> Countries { get; set; } = [];
+
+    [Parameter, EditorRequired]
+    public EventCallback<TeamFormValues> OnSubmit { get; set; }
+
+    [Parameter, EditorRequired]
+    public bool IsLoading { get; set; }
+
+    [Parameter]
+    public string? ErrorMessage { get; set; }
+
+    [Parameter, EditorRequired]
+    public string SubmitLabel { get; set; } = string.Empty;
+
+    [Parameter, EditorRequired]
+    public string BackUrl { get; set; } = string.Empty;
+
+    [Parameter]
+    public TeamFormInitialValues? InitialValues { get; set; }
+
+    private bool HasError => !string.IsNullOrEmpty(ErrorMessage);
+
+    private string GetAriaDescribedBy(string fieldErrorId, string? hintId = null)
+    {
+        string baseIds = hintId is not null ? $"{fieldErrorId} {hintId}" : fieldErrorId;
+        return HasError ? $"{baseIds} team-form-error" : baseIds;
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (!_initialized && InitialValues is not null)
+        {
+            _model.Title = InitialValues.Title;
+            _model.TitleShort = InitialValues.TitleShort;
+            _model.TitleFull = InitialValues.TitleFull;
+            _model.CountryId = InitialValues.CountryId;
+            _initialized = true;
+        }
+    }
+
+    private async Task HandleValidSubmit()
+    {
+        TeamFormValues values = new(
+            _model.Title,
+            _model.TitleShort,
+            _model.TitleFull,
+            _model.CountryId);
+
+        await OnSubmit.InvokeAsync(values);
+    }
+
+    private sealed class TeamFormModel
+    {
+        [Required(ErrorMessage = "Nafn er skylda")]
+        [MaxLength(50, ErrorMessage = "Nafn má ekki vera lengra en 50 stafir")]
+        public string Title { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Skammstöfun er skylda")]
+        [StringLength(3, MinimumLength = 3, ErrorMessage = "Skammstöfun verður að vera nákvæmlega 3 stafir")]
+        public string TitleShort { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Fullt nafn er skylda")]
+        [MaxLength(100, ErrorMessage = "Fullt nafn má ekki vera lengra en 100 stafir")]
+        public string TitleFull { get; set; } = string.Empty;
+
+        [Range(1, int.MaxValue, ErrorMessage = "Vinsamlegast veldu land")]
+        public int CountryId { get; set; }
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamForm.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamForm.razor.css
@@ -53,6 +53,11 @@
     cursor: pointer;
 }
 
+::deep .form-input:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
 ::deep .form-select:disabled {
     cursor: not-allowed;
     opacity: 0.7;

--- a/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
@@ -21,6 +21,7 @@ internal sealed class GetTeamDetailsHandler
             x.Title,
             x.TitleShort,
             x.TitleFull,
+            x.CountryId,
             x.Athletes
                 .OrderBy(x => x.Firstname)
                 .ThenBy(x => x.Lastname)

--- a/src/KRAFT.Results.WebApi/Features/Teams/Team.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/Team.cs
@@ -8,6 +8,8 @@ namespace KRAFT.Results.WebApi.Features.Teams;
 
 internal sealed class Team
 {
+    internal const int TitleMaxLength = 50;
+    internal const int TitleFullMaxLength = 100;
     private const int ShortTitleLength = 3;
 
     // For EF core
@@ -50,6 +52,11 @@ internal sealed class Team
             return TeamErrors.EmptyTitle;
         }
 
+        if (title.Length > TitleMaxLength)
+        {
+            return TeamErrors.TitleTooLong;
+        }
+
         if (string.IsNullOrWhiteSpace(titleShort) || titleShort.Length != ShortTitleLength)
         {
             return TeamErrors.InvalidTitleShort;
@@ -58,6 +65,11 @@ internal sealed class Team
         if (string.IsNullOrWhiteSpace(titleFull))
         {
             return TeamErrors.EmptyTitleFull;
+        }
+
+        if (titleFull.Length > TitleFullMaxLength)
+        {
+            return TeamErrors.TitleFullTooLong;
         }
 
         Team team = new()
@@ -72,5 +84,42 @@ internal sealed class Team
         };
 
         return team;
+    }
+
+    internal Result Update(User modifier, string title, string titleShort, string titleFull, Country country)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return TeamErrors.EmptyTitle;
+        }
+
+        if (title.Length > TitleMaxLength)
+        {
+            return TeamErrors.TitleTooLong;
+        }
+
+        if (string.IsNullOrWhiteSpace(titleShort) || titleShort.Length != ShortTitleLength)
+        {
+            return TeamErrors.InvalidTitleShort;
+        }
+
+        if (string.IsNullOrWhiteSpace(titleFull))
+        {
+            return TeamErrors.EmptyTitleFull;
+        }
+
+        if (titleFull.Length > TitleFullMaxLength)
+        {
+            return TeamErrors.TitleFullTooLong;
+        }
+
+        Title = title;
+        TitleShort = titleShort;
+        TitleFull = titleFull;
+        Country = country;
+        ModifiedOn = DateTime.UtcNow;
+        ModifiedBy = modifier.Username;
+
+        return Result.Success();
     }
 }

--- a/src/KRAFT.Results.WebApi/Features/Teams/TeamEndpoints.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/TeamEndpoints.cs
@@ -1,6 +1,7 @@
 ﻿using KRAFT.Results.WebApi.Features.Teams.Create;
 using KRAFT.Results.WebApi.Features.Teams.Get;
 using KRAFT.Results.WebApi.Features.Teams.GetDetails;
+using KRAFT.Results.WebApi.Features.Teams.Update;
 
 namespace KRAFT.Results.WebApi.Features.Teams;
 
@@ -14,6 +15,7 @@ internal static class TeamEndpoints
         group.MapCreateTeamEndpoint();
         group.MapGetTeamsEndpoint();
         group.MapGetTeamDetailsEndpoint();
+        group.MapUpdateTeamEndpoint();
 
         return group;
     }

--- a/src/KRAFT.Results.WebApi/Features/Teams/TeamErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/TeamErrors.cs
@@ -1,20 +1,39 @@
-﻿using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Abstractions;
 
 namespace KRAFT.Results.WebApi.Features.Teams;
 
 internal static class TeamErrors
 {
-    internal static Error EmptyTitle => new(
-        "Teams.TitleIsEmpty",
+    internal const string TeamNotFoundCode = "Teams.NotFound";
+    internal const string EmptyTitleCode = "Teams.TitleIsEmpty";
+    internal const string InvalidTitleShortCode = "Teams.InvalidTitleShort";
+    internal const string EmptyTitleFullCode = "Teams.EmptyTitleFull";
+    internal const string TitleTooLongCode = "Teams.TitleTooLong";
+    internal const string TitleFullTooLongCode = "Teams.TitleFullTooLong";
+
+    internal static readonly Error EmptyTitle = new(
+        EmptyTitleCode,
         "Title cannot be empty.");
 
-    internal static Error InvalidTitleShort => new(
-        "Teams.InvalidTitleShort",
+    internal static readonly Error InvalidTitleShort = new(
+        InvalidTitleShortCode,
         "Short title must be exactly 3 alphabetic characters.");
 
-    internal static Error EmptyTitleFull => new(
-        "Teams.EmptyTitleFull",
+    internal static readonly Error EmptyTitleFull = new(
+        EmptyTitleFullCode,
         "Full title cannot be empty.");
+
+    internal static readonly Error TitleTooLong = new(
+        TitleTooLongCode,
+        $"Title cannot exceed {Team.TitleMaxLength} characters.");
+
+    internal static readonly Error TitleFullTooLong = new(
+        TitleFullTooLongCode,
+        $"Full title cannot exceed {Team.TitleFullMaxLength} characters.");
+
+    internal static readonly Error TeamNotFound = new(
+        TeamNotFoundCode,
+        "Team not found.");
 
     internal static Error ShortTitleExists(string titleShort) => new(
         "Athletes.ShortTitleExists",

--- a/src/KRAFT.Results.WebApi/Features/Teams/TeamServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/TeamServices.cs
@@ -1,6 +1,7 @@
 ﻿using KRAFT.Results.WebApi.Features.Teams.Create;
 using KRAFT.Results.WebApi.Features.Teams.Get;
 using KRAFT.Results.WebApi.Features.Teams.GetDetails;
+using KRAFT.Results.WebApi.Features.Teams.Update;
 
 namespace KRAFT.Results.WebApi.Features.Teams;
 
@@ -11,6 +12,7 @@ internal static class TeamServices
         services.AddScoped<CreateTeamHandler>();
         services.AddScoped<GetTeamsHandler>();
         services.AddScoped<GetTeamDetailsHandler>();
+        services.AddScoped<UpdateTeamHandler>();
 
         return services;
     }

--- a/src/KRAFT.Results.WebApi/Features/Teams/Update/UpdateTeamEndpoint.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/Update/UpdateTeamEndpoint.cs
@@ -1,0 +1,46 @@
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.WebApi.Abstractions;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace KRAFT.Results.WebApi.Features.Teams.Update;
+
+internal static class UpdateTeamEndpoint
+{
+    internal const string Name = "UpdateTeam";
+
+    internal static RouteGroupBuilder MapUpdateTeamEndpoint(this RouteGroupBuilder endpoints)
+    {
+        endpoints.MapPut("/{slug}", static async (
+            [FromRoute] string slug,
+            [FromBody] UpdateTeamCommand command,
+            [FromServices] UpdateTeamHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            Result result = await handler.Handle(slug, command, cancellationToken);
+
+            return result.Match<IResult>(
+                success: () => TypedResults.Ok(),
+                failure: error => error.Code switch
+                {
+                    TeamErrors.TeamNotFoundCode => TypedResults.NotFound(),
+                    TeamErrors.EmptyTitleCode => TypedResults.BadRequest(error.Description),
+                    TeamErrors.InvalidTitleShortCode => TypedResults.BadRequest(error.Description),
+                    TeamErrors.EmptyTitleFullCode => TypedResults.BadRequest(error.Description),
+                    TeamErrors.TitleTooLongCode => TypedResults.BadRequest(error.Description),
+                    TeamErrors.TitleFullTooLongCode => TypedResults.BadRequest(error.Description),
+                    _ => TypedResults.BadRequest("Invalid request."),
+                });
+        })
+        .WithName(Name)
+        .WithSummary("Updates a team.")
+        .WithDescription("Updates an existing team's details.")
+        .Produces(StatusCodes.Status200OK)
+        .ProducesProblem(StatusCodes.Status400BadRequest)
+        .ProducesProblem(StatusCodes.Status404NotFound)
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .RequireAuthorization(policy => policy.RequireRole("Admin"));
+
+        return endpoints;
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Teams/Update/UpdateTeamHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/Update/UpdateTeamHandler.cs
@@ -1,0 +1,71 @@
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Countries;
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.Services;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace KRAFT.Results.WebApi.Features.Teams.Update;
+
+internal sealed class UpdateTeamHandler
+{
+    private readonly ILogger<UpdateTeamHandler> _logger;
+    private readonly ResultsDbContext _dbContext;
+    private readonly IHttpContextService _httpContextService;
+
+    public UpdateTeamHandler(ILogger<UpdateTeamHandler> logger, ResultsDbContext dbContext, IHttpContextService httpContextService)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+        _httpContextService = httpContextService;
+    }
+
+    public async Task<Result> Handle(string slug, UpdateTeamCommand command, CancellationToken cancellationToken)
+    {
+        User modifier = await _dbContext.GetUserAsync(_httpContextService, cancellationToken);
+
+        Team? team = await _dbContext.Set<Team>()
+            .Where(x => x.Slug == slug)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (team is null)
+        {
+            _logger.LogWarning("Team with slug '{Slug}' was not found", slug);
+            return Result.Failure(TeamErrors.TeamNotFound);
+        }
+
+        if (await _dbContext.GetCountryAsync(command.CountryId, cancellationToken) is not Country country)
+        {
+            _logger.LogWarning(
+                "Failed to update team {Slug}: Country with Id {CountryId} does not exist",
+                slug,
+                command.CountryId);
+
+            return CountryErrors.CountryDoesNotExist(command.CountryId);
+        }
+
+        if (await IsDuplicateShortTitleAsync(slug, command.TitleShort, cancellationToken))
+        {
+            _logger.LogWarning("Short title {TitleShort} already exists", command.TitleShort);
+            return Result.Failure(TeamErrors.ShortTitleExists(command.TitleShort));
+        }
+
+        Result result = team.Update(modifier, command.Title, command.TitleShort, command.TitleFull, country);
+
+        if (result.IsFailure)
+        {
+            return result;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+
+    private Task<bool> IsDuplicateShortTitleAsync(string currentSlug, string titleShort, CancellationToken cancellationToken) =>
+        _dbContext.Set<Team>()
+        .Where(x => x.Slug != currentSlug)
+        .Where(x => x.TitleShort == titleShort)
+        .AnyAsync(cancellationToken);
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/UpdateTeamCommandBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/UpdateTeamCommandBuilder.cs
@@ -1,0 +1,38 @@
+using KRAFT.Results.Contracts.Teams;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Builders;
+
+internal sealed class UpdateTeamCommandBuilder
+{
+    private string _title = Guid.NewGuid().ToString();
+    private string _titleShort = Guid.NewGuid().ToString()[0..3];
+    private string _titleFull = Guid.NewGuid().ToString();
+    private int _countryId = 1;
+
+    public UpdateTeamCommandBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    public UpdateTeamCommandBuilder WithTitleShort(string titleShort)
+    {
+        _titleShort = titleShort;
+        return this;
+    }
+
+    public UpdateTeamCommandBuilder WithTitleFull(string titleFull)
+    {
+        _titleFull = titleFull;
+        return this;
+    }
+
+    public UpdateTeamCommandBuilder WithCountryId(int countryId)
+    {
+        _countryId = countryId;
+        return this;
+    }
+
+    public UpdateTeamCommand Build() =>
+        new(_title, _titleShort, _titleFull, _countryId);
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/UpdateTeamTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/UpdateTeamTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Teams;
+
+public sealed class UpdateTeamTests(IntegrationTestFixture fixture)
+{
+    private const string BasePath = "/teams";
+
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory.CreateClient();
+
+    [Fact]
+    public async Task ReturnsOk_WhenSuccessful()
+    {
+        // Arrange
+        string slug = await CreateTeamAsync();
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder()
+            .WithTitle("Updated Title")
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenTeamDoesNotExist()
+    {
+        // Arrange
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder().Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/non-existent-slug", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReturnsForbidden_WhenUserIsNotAdmin()
+    {
+        // Arrange
+        string slug = await CreateTeamAsync();
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder().Build();
+
+        // Act
+        HttpResponseMessage response = await _nonAdminHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ReturnsUnauthorized_WhenNotAuthenticated()
+    {
+        // Arrange
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder().Build();
+
+        // Act
+        HttpResponseMessage response = await _unauthorizedHttpClient.PutAsJsonAsync($"{BasePath}/some-slug", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequest_WhenTitleIsEmpty()
+    {
+        // Arrange
+        string slug = await CreateTeamAsync();
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder()
+            .WithTitle(string.Empty)
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequest_WhenFullTitleIsEmpty()
+    {
+        // Arrange
+        string slug = await CreateTeamAsync();
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder()
+            .WithTitleFull(string.Empty)
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("AB")]
+    [InlineData("ABCD")]
+    public async Task ReturnsBadRequest_WhenShortTitleIsInvalid(string value)
+    {
+        // Arrange
+        string slug = await CreateTeamAsync();
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder()
+            .WithTitleShort(value)
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequest_WhenCountryDoesNotExist()
+    {
+        // Arrange
+        string slug = await CreateTeamAsync();
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder()
+            .WithCountryId(int.MaxValue)
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequest_WhenShortTitleAlreadyExists()
+    {
+        // Arrange
+        string slug = await CreateTeamAsync();
+        string shortTitle = "ZZZ";
+        CreateTeamCommand otherTeam = new CreateTeamCommandBuilder()
+            .WithTitleShort(shortTitle)
+            .Build();
+        await _authorizedHttpClient.PostAsJsonAsync(BasePath, otherTeam, CancellationToken.None);
+
+        UpdateTeamCommand command = new UpdateTeamCommandBuilder()
+            .WithTitleShort(shortTitle)
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync($"{BasePath}/{slug}", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    private async Task<string> CreateTeamAsync()
+    {
+        CreateTeamCommand createCommand = new CreateTeamCommandBuilder().Build();
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync(BasePath, createCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        List<TeamSummary>? teams = await _authorizedHttpClient.GetFromJsonAsync<List<TeamSummary>>(BasePath, CancellationToken.None);
+        TeamSummary team = teams!.First(t => t.ShortTitle == createCommand.TitleShort);
+
+        return team.Slug;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PUT /teams/{slug}` endpoint for updating team information (name, abbreviation, full name, country)
- Extract shared `TeamForm.razor` component used by both create and edit pages, following the `MeetForm` pattern
- Add loading/error states to `TeamDetailsPage` with admin-only edit link (pencil icon)
- Add max-length validation on Title (50) and TitleFull (100) with Icelandic error messages
- Add 11 integration tests covering the update flow

## Test plan
- [x] Verify `PUT /teams/{slug}` returns 200 on valid update
- [x] Verify 404 for non-existent team, 403 for non-admin, 401 for unauthenticated
- [x] Verify 400 for empty title, invalid short title, duplicate short title
- [ ] Verify edit page pre-populates with existing team values
- [ ] Verify create page still works after TeamForm extraction
- [ ] Verify TeamDetailsPage shows loading state and handles errors

Closes #173