### PR TITLE
Delete athlete endpoint

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Athletes/AthleteEndpoints.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/AthleteEndpoints.cs
@@ -1,4 +1,5 @@
 ﻿using KRAFT.Results.WebApi.Features.Athletes.Create;
+using KRAFT.Results.WebApi.Features.Athletes.Delete;
 using KRAFT.Results.WebApi.Features.Athletes.Get;
 using KRAFT.Results.WebApi.Features.Athletes.GetDetails;
 using KRAFT.Results.WebApi.Features.Athletes.GetEditDetails;
@@ -17,6 +18,7 @@ internal static class AthleteEndpoints
             .WithTags("Athletes");
 
         group.MapCreateAthleteEndpoint();
+        group.MapDeleteAthleteEndpoint();
         group.MapGetAthletesEndpoint();
         group.MapGetAthleteDetailsEndpoint();
         group.MapGetAthleteEditDetailsEndpoint();

--- a/src/KRAFT.Results.WebApi/Features/Athletes/AthleteErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/AthleteErrors.cs
@@ -6,6 +6,7 @@ internal static class AthleteErrors
 {
     internal const string AlreadyExistsCode = "Athletes.AlreadyExists";
     internal const string AthleteNotFoundCode = "Athletes.NotFound";
+    internal const string AthleteHasParticipationsCode = "Athletes.HasParticipations";
 
     internal static Error FirstNameIsEmpty => new(
         "Athletes.FirstNameIsEmpty",
@@ -26,6 +27,10 @@ internal static class AthleteErrors
     internal static Error AthleteNotFound => new(
         AthleteNotFoundCode,
         "Athlete not found.");
+
+    internal static Error AthleteHasParticipations => new(
+        AthleteHasParticipationsCode,
+        "Cannot delete an athlete that has participations.");
 
     internal static Error AlreadyExists(string firstName, string lastName, DateOnly dateOfBirth) => new(
         AlreadyExistsCode,

--- a/src/KRAFT.Results.WebApi/Features/Athletes/AthleteServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/AthleteServices.cs
@@ -1,4 +1,5 @@
 ﻿using KRAFT.Results.WebApi.Features.Athletes.Create;
+using KRAFT.Results.WebApi.Features.Athletes.Delete;
 using KRAFT.Results.WebApi.Features.Athletes.Get;
 using KRAFT.Results.WebApi.Features.Athletes.GetDetails;
 using KRAFT.Results.WebApi.Features.Athletes.GetEditDetails;
@@ -14,6 +15,7 @@ internal static class AthleteServices
     internal static IServiceCollection AddAthletes(this IServiceCollection services)
     {
         services.AddScoped<CreateAthleteHandler>();
+        services.AddScoped<DeleteAthleteHandler>();
         services.AddScoped<GetAthletesHandler>();
         services.AddScoped<GetAthleteDetailsHandler>();
         services.AddScoped<GetAthletePersonalBestsHandler>();

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteEndpoint.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteEndpoint.cs
@@ -1,0 +1,40 @@
+using KRAFT.Results.WebApi.Abstractions;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace KRAFT.Results.WebApi.Features.Athletes.Delete;
+
+internal static class DeleteAthleteEndpoint
+{
+    internal const string Name = "DeleteAthlete";
+
+    internal static RouteGroupBuilder MapDeleteAthleteEndpoint(this RouteGroupBuilder endpoints)
+    {
+        endpoints.MapDelete("/{id:int}", static async (
+            [FromRoute] int id,
+            [FromServices] DeleteAthleteHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            Result result = await handler.Handle(id, cancellationToken);
+
+            return result.Match<IResult>(
+                success: () => TypedResults.NoContent(),
+                failure: error => error.Code switch
+                {
+                    AthleteErrors.AthleteNotFoundCode => TypedResults.NotFound(),
+                    AthleteErrors.AthleteHasParticipationsCode => TypedResults.Conflict(),
+                    _ => TypedResults.BadRequest(),
+                });
+        })
+        .WithName(Name)
+        .WithSummary("Deletes an athlete.")
+        .WithDescription("Deletes an athlete if they have no participations.")
+        .Produces(StatusCodes.Status204NoContent)
+        .ProducesProblem(StatusCodes.Status404NotFound)
+        .ProducesProblem(StatusCodes.Status409Conflict)
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .RequireAuthorization(policy => policy.RequireRole("Admin"));
+
+        return endpoints;
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteHandler.cs
@@ -1,0 +1,62 @@
+using System.Data;
+
+using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Participations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace KRAFT.Results.WebApi.Features.Athletes.Delete;
+
+internal sealed class DeleteAthleteHandler
+{
+    private readonly ILogger<DeleteAthleteHandler> _logger;
+    private readonly ResultsDbContext _dbContext;
+
+    public DeleteAthleteHandler(ILogger<DeleteAthleteHandler> logger, ResultsDbContext dbContext)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+    }
+
+    public async Task<Result> Handle(int id, CancellationToken cancellationToken)
+    {
+        if (id <= 0)
+        {
+            return Result.Failure(AthleteErrors.AthleteNotFound);
+        }
+
+        IExecutionStrategy strategy = _dbContext.Database.CreateExecutionStrategy();
+
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using IDbContextTransaction transaction =
+                await _dbContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
+
+            Athlete? athlete = await _dbContext.Set<Athlete>()
+                .Where(a => a.AthleteId == id)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (athlete is null)
+            {
+                _logger.LogWarning("Athlete with id '{AthleteId}' was not found", id);
+                return Result.Failure(AthleteErrors.AthleteNotFound);
+            }
+
+            bool hasParticipations = await _dbContext.Set<Participation>()
+                .AnyAsync(p => p.AthleteId == id, cancellationToken);
+
+            if (hasParticipations)
+            {
+                _logger.LogWarning("Cannot delete athlete with id '{AthleteId}' because they have participations", id);
+                return Result.Failure(AthleteErrors.AthleteHasParticipations);
+            }
+
+            _dbContext.Set<Athlete>().Remove(athlete);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+
+            return Result.Success();
+        });
+    }
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/DeleteAthleteTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/DeleteAthleteTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Athletes;
+
+public sealed class DeleteAthleteTests(IntegrationTestFixture fixture)
+{
+    private const string BasePath = "/athletes";
+
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory.CreateClient();
+
+    [Fact]
+    public async Task ReturnsNoContent_WhenSuccessful()
+    {
+        // Arrange
+        int athleteId = await CreateAthleteAsync();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{athleteId}", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenAthleteDoesNotExist()
+    {
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{int.MaxValue}", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReturnsConflict_WhenAthleteHasParticipations()
+    {
+        // Arrange — the seeded athlete has participations
+        int seededAthleteId = 1;
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{seededAthleteId}", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task ReturnsForbidden_WhenUserIsNotAdmin()
+    {
+        // Arrange
+        int athleteId = await CreateAthleteAsync();
+
+        // Act
+        HttpResponseMessage response = await _nonAdminHttpClient.DeleteAsync($"{BasePath}/{athleteId}", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ReturnsUnauthorized_WhenNotAuthenticated()
+    {
+        // Act
+        HttpResponseMessage response = await _unauthorizedHttpClient.DeleteAsync($"{BasePath}/1", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<int> CreateAthleteAsync()
+    {
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder().Build();
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(BasePath, command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string? location = response.Headers.Location?.ToString();
+        location.ShouldNotBeNull();
+
+        return int.Parse(location.TrimStart('/'), System.Globalization.CultureInfo.InvariantCulture);
+    }
+}


### PR DESCRIPTION
## Summary
- Add admin-only DELETE `/api/athletes/{id}` endpoint
- Returns 204 on success, 404 if not found, 409 if athlete has participations
- Integration tests cover success, not-found, conflict, forbidden, and unauthorized scenarios

## Test plan
- [x] Integration test: successful deletion returns 204
- [x] Integration test: non-existent athlete returns 404
- [x] Integration test: athlete with participations returns 409
- [x] Integration test: non-admin user returns 403
- [x] Integration test: unauthenticated request returns 401

Closes #171