### PR TITLE
Add delete button to athlete details page (admin only)

### DIFF
--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
@@ -7,6 +7,7 @@
 @using Microsoft.AspNetCore.Components.Routing
 
 @inject HttpClient HttpClient
+@inject NavigationManager NavigationManager
 
 <div class="page-header">
     <h1>@Athlete?.Name</h1>
@@ -19,6 +20,16 @@
                 </svg>
                 Breyta
             </a>
+            <button class="btn-action btn-danger" aria-label="Eyða keppanda" @onclick="ShowDeleteDialog">
+                <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M3 6h18"/>
+                    <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
+                    <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
+                    <line x1="10" x2="10" y1="11" y2="17"/>
+                    <line x1="14" x2="14" y1="11" y2="17"/>
+                </svg>
+                Eyða
+            </button>
         </div>
     </AuthorizeView>
 </div>
@@ -196,7 +207,20 @@
     }
 }
 
+<ConfirmDialog @ref="_deleteDialog"
+               Id="delete-athlete-dialog"
+               Title="Eyða keppanda"
+               Message="Ertu viss um að þú viljir eyða þessum keppanda?"
+               ConfirmLabel="Eyða keppanda"
+               OnConfirm="HandleDelete"
+               ErrorMessage="@_deleteErrorMessage"
+               IsLoading="_isDeleting" />
+
 @code {
+    private ConfirmDialog _deleteDialog = null!;
+    private bool _isDeleting;
+    private string? _deleteErrorMessage;
+
     [Parameter]
     public string Slug { get; set; } = string.Empty;
 
@@ -205,6 +229,49 @@
     private IReadOnlyList<AthletePersonalBest> PersonalBests = [];
     private IReadOnlyList<AthleteRecord> Records = [];
     private IReadOnlyList<AthleteParticipation> Participations = [];
+
+    private async Task ShowDeleteDialog()
+    {
+        _deleteErrorMessage = null;
+        await _deleteDialog.ShowAsync();
+    }
+
+    private async Task HandleDelete()
+    {
+        try
+        {
+            _isDeleting = true;
+            _deleteErrorMessage = null;
+
+            HttpResponseMessage response = await HttpClient.DeleteAsync($"/athletes/{Slug}");
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                _deleteErrorMessage = "Ekki er hægt að eyða keppanda sem hefur mótaskráningu.";
+            }
+            else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                _deleteErrorMessage = "Keppandi fannst ekki.";
+            }
+            else if (!response.IsSuccessStatusCode)
+            {
+                _deleteErrorMessage = "Villa kom upp. Reyndu aftur síðar.";
+            }
+            else
+            {
+                NavigationManager.NavigateTo("/athletes");
+                return;
+            }
+        }
+        catch (HttpRequestException)
+        {
+            _deleteErrorMessage = "Villa kom upp. Reyndu aftur síðar.";
+        }
+        finally
+        {
+            _isDeleting = false;
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
@@ -45,6 +45,14 @@
     align-items: center;
 }
 
+.btn-danger {
+    background: var(--color-danger);
+}
+
+.btn-danger:hover {
+    background: #b91c1c;
+}
+
 @media (prefers-reduced-motion: reduce) {
     .btn-action {
         transition: none;

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteEndpoint.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteEndpoint.cs
@@ -10,12 +10,12 @@ internal static class DeleteAthleteEndpoint
 
     internal static RouteGroupBuilder MapDeleteAthleteEndpoint(this RouteGroupBuilder endpoints)
     {
-        endpoints.MapDelete("/{id:int}", static async (
-            [FromRoute] int id,
+        endpoints.MapDelete("/{slug}", static async (
+            [FromRoute] string slug,
             [FromServices] DeleteAthleteHandler handler,
             CancellationToken cancellationToken) =>
         {
-            Result result = await handler.Handle(id, cancellationToken);
+            Result result = await handler.Handle(slug, cancellationToken);
 
             return result.Match<IResult>(
                 success: () => TypedResults.NoContent(),

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Delete/DeleteAthleteHandler.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Text.RegularExpressions;
 
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Participations;
@@ -8,8 +9,10 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace KRAFT.Results.WebApi.Features.Athletes.Delete;
 
-internal sealed class DeleteAthleteHandler
+internal sealed partial class DeleteAthleteHandler
 {
+    private const int SlugMaxLength = 200;
+
     private readonly ILogger<DeleteAthleteHandler> _logger;
     private readonly ResultsDbContext _dbContext;
 
@@ -19,9 +22,9 @@ internal sealed class DeleteAthleteHandler
         _dbContext = dbContext;
     }
 
-    public async Task<Result> Handle(int id, CancellationToken cancellationToken)
+    public async Task<Result> Handle(string slug, CancellationToken cancellationToken)
     {
-        if (id <= 0)
+        if (string.IsNullOrEmpty(slug) || slug.Length > SlugMaxLength || !ValidSlugPattern().IsMatch(slug))
         {
             return Result.Failure(AthleteErrors.AthleteNotFound);
         }
@@ -34,21 +37,21 @@ internal sealed class DeleteAthleteHandler
                 await _dbContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
 
             Athlete? athlete = await _dbContext.Set<Athlete>()
-                .Where(a => a.AthleteId == id)
+                .Where(a => a.Slug == slug)
                 .FirstOrDefaultAsync(cancellationToken);
 
             if (athlete is null)
             {
-                _logger.LogWarning("Athlete with id '{AthleteId}' was not found", id);
+                _logger.LogWarning("Athlete with slug '{Slug}' was not found", slug);
                 return Result.Failure(AthleteErrors.AthleteNotFound);
             }
 
             bool hasParticipations = await _dbContext.Set<Participation>()
-                .AnyAsync(p => p.AthleteId == id, cancellationToken);
+                .AnyAsync(p => p.AthleteId == athlete.AthleteId, cancellationToken);
 
             if (hasParticipations)
             {
-                _logger.LogWarning("Cannot delete athlete with id '{AthleteId}' because they have participations", id);
+                _logger.LogWarning("Cannot delete athlete with slug '{Slug}' because they have participations", slug);
                 return Result.Failure(AthleteErrors.AthleteHasParticipations);
             }
 
@@ -59,4 +62,7 @@ internal sealed class DeleteAthleteHandler
             return Result.Success();
         });
     }
+
+    [GeneratedRegex(@"^[a-z0-9-]+$")]
+    private static partial Regex ValidSlugPattern();
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/DeleteAthleteTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/DeleteAthleteTests.cs
@@ -20,10 +20,10 @@ public sealed class DeleteAthleteTests(IntegrationTestFixture fixture)
     public async Task ReturnsNoContent_WhenSuccessful()
     {
         // Arrange
-        int athleteId = await CreateAthleteAsync();
+        string slug = await CreateAthleteAsync();
 
         // Act
-        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{athleteId}", CancellationToken.None);
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{slug}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
@@ -33,7 +33,7 @@ public sealed class DeleteAthleteTests(IntegrationTestFixture fixture)
     public async Task ReturnsNotFound_WhenAthleteDoesNotExist()
     {
         // Act
-        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{int.MaxValue}", CancellationToken.None);
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/non-existent-slug", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -43,10 +43,10 @@ public sealed class DeleteAthleteTests(IntegrationTestFixture fixture)
     public async Task ReturnsConflict_WhenAthleteHasParticipations()
     {
         // Arrange — the seeded athlete has participations
-        int seededAthleteId = 1;
+        string seededAthleteSlug = Constants.TestAthleteSlug;
 
         // Act
-        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{seededAthleteId}", CancellationToken.None);
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{seededAthleteSlug}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
@@ -56,10 +56,10 @@ public sealed class DeleteAthleteTests(IntegrationTestFixture fixture)
     public async Task ReturnsForbidden_WhenUserIsNotAdmin()
     {
         // Arrange
-        int athleteId = await CreateAthleteAsync();
+        string slug = await CreateAthleteAsync();
 
         // Act
-        HttpResponseMessage response = await _nonAdminHttpClient.DeleteAsync($"{BasePath}/{athleteId}", CancellationToken.None);
+        HttpResponseMessage response = await _nonAdminHttpClient.DeleteAsync($"{BasePath}/{slug}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
@@ -69,21 +69,21 @@ public sealed class DeleteAthleteTests(IntegrationTestFixture fixture)
     public async Task ReturnsUnauthorized_WhenNotAuthenticated()
     {
         // Act
-        HttpResponseMessage response = await _unauthorizedHttpClient.DeleteAsync($"{BasePath}/1", CancellationToken.None);
+        HttpResponseMessage response = await _unauthorizedHttpClient.DeleteAsync($"{BasePath}/some-slug", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 
-    private async Task<int> CreateAthleteAsync()
+    private async Task<string> CreateAthleteAsync()
     {
-        CreateAthleteCommand command = new CreateAthleteCommandBuilder().Build();
-        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(BasePath, command, CancellationToken.None);
-        response.EnsureSuccessStatusCode();
+        CreateAthleteCommand createCommand = new CreateAthleteCommandBuilder().Build();
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync(BasePath, createCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
 
-        string? location = response.Headers.Location?.ToString();
-        location.ShouldNotBeNull();
+        List<AthleteSummary>? athletes = await _authorizedHttpClient.GetFromJsonAsync<List<AthleteSummary>>(BasePath, CancellationToken.None);
+        AthleteSummary athlete = athletes!.First(a => a.Name == $"{createCommand.FirstName} {createCommand.LastName}");
 
-        return int.Parse(location.TrimStart('/'), System.Globalization.CultureInfo.InvariantCulture);
+        return athlete.Slug!;
     }
 }


### PR DESCRIPTION
## Summary
- Refactor delete athlete API endpoint from `/{id:int}` to `/{slug}` for consistency with teams and meets
- Add delete button with confirmation dialog to athlete details page, visible only to admin users
- Update integration tests to use slug-based delete URLs

## Test plan
- [x] Verify delete button is visible for admin users on athlete details page
- [x] Verify delete button is hidden for non-admin and unauthenticated users
- [x] Verify confirmation dialog appears when clicking delete
- [x] Verify successful deletion redirects to `/athletes`
- [x] Verify conflict error for athletes with participations
- [x] Verify all integration tests pass (`dotnet test`)

Closes #208