### PR TITLE
chore(dependabot): group updates, run daily, and auto-merge on green

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,19 @@ updates:
   - package-ecosystem: nuget
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     target-branch: main
+    groups:
+      nuget-all:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     target-branch: main
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Groups all NuGet updates into a single PR and all Actions updates into a single PR
- Switches schedule from weekly to daily
- Adds auto-merge workflow that squash-merges Dependabot PRs once CI passes

## Test plan

- [ ] Verify Dependabot PRs are grouped (one for NuGet, one for Actions)
- [ ] Verify auto-merge triggers only for `dependabot[bot]` PRs
- [ ] Verify PR is squash-merged automatically after CI passes