### PR TITLE
Fix meet results: bombed-out placement and tie handling

### DIFF
--- a/src/KRAFT.Results.Contracts/Meets/MeetParticipation.cs
+++ b/src/KRAFT.Results.Contracts/Meets/MeetParticipation.cs
@@ -13,4 +13,5 @@ public sealed record class MeetParticipation(
     decimal BodyWeight,
     decimal Total,
     decimal IpfPoints,
+    bool Disqualified,
     IEnumerable<MeetAttempt> Attempts);

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -144,9 +144,13 @@
                             }
                         </tr>
 
-                        @foreach (var p in weightCategory.OrderBy(x => x.Rank))
+                        @foreach (var p in weightCategory
+                            .OrderBy(x => x.Disqualified)
+                            .ThenBy(x => x.Rank <= 0)
+                            .ThenBy(x => x.Rank)
+                            .ThenBy(x => x.Athlete))
                         {
-                            <tr>
+                            <tr class="@(p.Disqualified ? "bombed-out" : null)">
                                 <RankCell Rank="p.Rank"/>
                                 <AthleteCell Athlete="@p.Athlete" Slug="@p.AthleteSlug" />
                                 <td>

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -93,6 +93,10 @@
     text-align: center;
 }
 
+.bombed-out {
+    color: #6b7280;
+}
+
 @media (prefers-reduced-motion: reduce) {
     .btn-action {
         transition: none;

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetParticipations/GetMeetParticipationsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetParticipations/GetMeetParticipationsHandler.cs
@@ -1,4 +1,4 @@
-﻿using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.Mappers;
 using KRAFT.Results.WebApi.ValueObjects;
 
@@ -8,29 +8,38 @@ namespace KRAFT.Results.WebApi.Features.Meets.GetParticipations;
 
 internal sealed class GetMeetParticipationsHandler(ResultsDbContext dbContext)
 {
-    public Task<List<MeetParticipation>> Handle(string slug, CancellationToken cancellationToken) =>
-        dbContext.Set<Meet>()
-        .Where(meet => meet.Slug == slug)
-        .SelectMany(meet => meet.Participations.Select(p => new MeetParticipation(
-            p.Place,
-            $"{p.Athlete.Firstname} {p.Athlete.Lastname}",
-            p.Athlete.Slug,
-            p.Athlete.Gender == "f" ? "Konur" : "Karlar",
-            p.Athlete.DateOfBirth != null ? p.Athlete.DateOfBirth.Value.Year : 0,
-            p.AgeCategory != null && p.AgeCategory.TitleShort != null ? p.AgeCategory.Title : string.Empty,
-            p.WeightCategory != null ? p.WeightCategory.Title : string.Empty,
-            p.Team != null ? p.Team.TitleShort : string.Empty,
-            p.Team != null ? p.Team.Slug : string.Empty,
-            p.Weight,
-            p.Total,
-            IpfPoints.Create(p.Meet.IsRaw, p.Athlete.Gender, p.Meet.MeetType.Title, p.Weight, p.Total),
-            p.Attempts
-                .Where(a => a.Round < 4)
-                .Select(a => new MeetAttempt(
-                    $"{DisciplineMapper.Map(a.DisciplineId)[0]}{a.Round}",
-                    a.Round,
-                    a.Weight,
-                    a.Good,
-                    a.Records.Count != 0)))))
-        .ToListAsync(cancellationToken);
+    public async Task<List<MeetParticipation>> Handle(string slug, CancellationToken cancellationToken)
+    {
+        List<MeetParticipation> participations = await dbContext.Set<Meet>()
+            .Where(meet => meet.Slug == slug)
+            .SelectMany(meet => meet.Participations.Select(p => new MeetParticipation(
+                p.Place,
+                $"{p.Athlete.Firstname} {p.Athlete.Lastname}",
+                p.Athlete.Slug,
+                p.Athlete.Gender == "f" ? "Konur" : "Karlar",
+                p.Athlete.DateOfBirth != null ? p.Athlete.DateOfBirth.Value.Year : 0,
+                p.AgeCategory != null && p.AgeCategory.TitleShort != null ? p.AgeCategory.Title : string.Empty,
+                p.WeightCategory != null ? p.WeightCategory.Title : string.Empty,
+                p.Team != null ? p.Team.TitleShort : string.Empty,
+                p.Team != null ? p.Team.Slug : string.Empty,
+                p.Weight,
+                p.Total,
+                IpfPoints.Create(p.Meet.IsRaw, p.Athlete.Gender, p.Meet.MeetType.Title, p.Weight, p.Total),
+                p.Disqualified,
+                p.Attempts
+                    .Where(a => a.Round < 4)
+                    .Select(a => new MeetAttempt(
+                        $"{DisciplineMapper.Map(a.DisciplineId)[0]}{a.Round}",
+                        a.Round,
+                        a.Weight,
+                        a.Good,
+                        a.Records.Count != 0)))))
+            .ToListAsync(cancellationToken);
+
+        return participations
+            .OrderBy(p => p.Rank <= 0)
+            .ThenBy(p => p.Rank)
+            .ThenBy(p => p.Athlete, StringComparer.Ordinal)
+            .ToList();
+    }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
@@ -25,4 +25,9 @@ internal static class Constants
         internal const string Password = "testuser";
         internal const string Email = "test@email.com";
     }
+
+    internal static class OrderingMeet
+    {
+        internal const string Slug = "ordering-meet-2025";
+    }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
@@ -285,6 +285,32 @@ public sealed class DatabaseFixture : IAsyncLifetime
             VALUES (5, 5, 82.0, 1, 2, 1, 2, 0, 190.0, 120.0, 240.0, 550.0, 380.0, 81.0, 2, 9);
             INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
             VALUES (6, 5, 82.0, 1, 2, 1, 3, 0, 185.0, 115.0, 235.0, 535.0, 370.0, 79.0, 3, 8);
+
+            -- Ordering test: athletes with controlled names for alphabetical sorting
+            INSERT INTO Athletes (Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
+            VALUES ('Delta', 'Test', '1992-01-01', 'm', 2, 'delta-test');
+            INSERT INTO Athletes (Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
+            VALUES ('Charlie', 'Test', '1993-01-01', 'm', 2, 'charlie-test');
+
+            -- Ordering test meet (MeetId=6)
+            INSERT INTO Meets (Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+            VALUES ('Ordering Meet 2025', {Constants.OrderingMeet.Slug}, '2025-10-01', '2025-10-01', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1);
+
+            -- Participation: Place=1, not DQ (Delta Test, AthleteId=10)
+            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
+            VALUES (10, 6, 82.0, 1, 1, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 85.0, 1);
+
+            -- Participation: Place=1 (tied), not DQ (Charlie Test, AthleteId=11)
+            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
+            VALUES (11, 6, 82.0, 1, 1, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 85.0, 2);
+
+            -- Participation: Place=3, not DQ (Bob Test, AthleteId=3)
+            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
+            VALUES (3, 6, 82.0, 1, 1, 3, 0, 180.0, 120.0, 230.0, 530.0, 370.0, 78.0, 3);
+
+            -- Participation: Place=-1, DQ (Anna Test, AthleteId=2)
+            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
+            VALUES (2, 6, 82.0, 1, 1, -1, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4);
         """);
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts.Meets;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
+
+public sealed class GetMeetParticipationsTests
+{
+    private const string Path = $"/meets/{Constants.OrderingMeet.Slug}/participations";
+
+    private readonly HttpClient _httpClient;
+
+    public GetMeetParticipationsTests(IntegrationTestFixture fixture)
+    {
+        _httpClient = fixture.Factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ReturnsOk()
+    {
+        // Arrange
+
+        // Act
+        HttpResponseMessage response = await _httpClient.GetAsync(Path, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task PlacedParticipantsAppearBeforeDisqualified()
+    {
+        // Arrange
+
+        // Act
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        participations.Count.ShouldBe(4);
+
+        List<MeetParticipation> placed = participations.Where(p => p.Rank > 0).ToList();
+        List<MeetParticipation> unplaced = participations.Where(p => p.Rank <= 0).ToList();
+
+        int lastPlacedIndex = participations.IndexOf(placed[^1]);
+        int firstUnplacedIndex = participations.IndexOf(unplaced[0]);
+
+        lastPlacedIndex.ShouldBeLessThan(firstUnplacedIndex);
+    }
+
+    [Fact]
+    public async Task DisqualifiedParticipantAppearsLast()
+    {
+        // Arrange
+
+        // Act
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        MeetParticipation last = participations[^1];
+        last.Disqualified.ShouldBeTrue();
+        last.Athlete.ShouldBe("Anna Test");
+    }
+
+    [Fact]
+    public async Task ParticipantsWithSameRankAreSortedAlphabetically()
+    {
+        // Arrange
+
+        // Act
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        List<MeetParticipation> tiedAtFirst = participations.Where(p => p.Rank == 1).ToList();
+        tiedAtFirst.Count.ShouldBe(2);
+        tiedAtFirst[0].Athlete.ShouldBe("Charlie Test");
+        tiedAtFirst[1].Athlete.ShouldBe("Delta Test");
+    }
+
+    [Fact]
+    public async Task ParticipationsAreOrderedByRankAscending()
+    {
+        // Arrange
+
+        // Act
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        List<MeetParticipation> placed = participations.Where(p => p.Rank > 0).ToList();
+        List<int> ranks = placed.Select(p => p.Rank).ToList();
+        ranks.ShouldBe(ranks.OrderBy(r => r).ToList());
+    }
+
+    [Fact]
+    public async Task DisqualifiedFieldIsTrueForDisqualifiedParticipant()
+    {
+        // Arrange
+
+        // Act
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        MeetParticipation disqualified = participations.Single(p => p.Athlete == "Anna Test");
+        disqualified.Disqualified.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DisqualifiedFieldIsFalseForPlacedParticipant()
+    {
+        // Arrange
+
+        // Act
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        MeetParticipation placed = participations.First(p => p.Athlete == "Bob Test");
+        placed.Disqualified.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Participants with no total (bombed out / disqualified) now appear at the bottom of their weight category
- Ties handled correctly: same place shown, alphabetical by name as tiebreaker
- Added `bool Disqualified` to `MeetParticipation` contract (non-breaking, additive)
- Bombed-out rows styled with muted text (`#6b7280`, WCAG AA compliant)

## Test plan
- [x] 7 new integration tests in `GetMeetParticipationsTests.cs` covering ordering, DQ-at-bottom, tie-alphabetical, and `Disqualified` field
- [x] Build passes with zero warnings
- [ ] No vulnerable packages

Closes #149