### PR TITLE
Fix missing and incorrect records on the records page

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Records/Get/GetRecordsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Records/Get/GetRecordsHandler.cs
@@ -9,6 +9,16 @@ namespace KRAFT.Results.WebApi.Features.Records.Get;
 
 internal sealed class GetRecordsHandler(ResultsDbContext dbContext)
 {
+    private static readonly RecordCategory[] DisplayCategories =
+    [
+        RecordCategory.Squat,
+        RecordCategory.Bench,
+        RecordCategory.Deadlift,
+        RecordCategory.Total,
+        RecordCategory.BenchSingle,
+        RecordCategory.DeadliftSingle,
+    ];
+
     public async Task<List<RecordGroup>> Handle(
         string gender,
         string ageCategory,
@@ -24,21 +34,36 @@ internal sealed class GetRecordsHandler(ResultsDbContext dbContext)
         bool excludeJuniorsOnly = !string.Equals(ageCategory, "junior", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(ageCategory, "subjunior", StringComparison.OrdinalIgnoreCase);
 
-        List<RawRecordData> rawData = await dbContext.Set<Record>()
-            .Where(r => r.IsCurrent)
+        // Query 1: Fetch all active weight categories for this era/gender/date
+        List<ActiveWeightCategory> activeWeightCategories = await dbContext.Set<EraWeightCategory>()
+            .Where(ewc => ewc.EraId == eraId)
+            .Where(ewc => ewc.FromDate <= referenceDate)
+            .Where(ewc => ewc.ToDate >= referenceDate)
+            .Where(ewc => ewc.WeightCategory.Gender == Gender.Parse(genderLower))
+            .Where(ewc => !excludeJuniorsOnly || !ewc.WeightCategory.JuniorsOnly)
+            .OrderBy(ewc => ewc.WeightCategory.MinWeight)
+            .Select(ewc => new ActiveWeightCategory(
+                ewc.WeightCategoryId,
+                ewc.WeightCategory.Title,
+                ewc.WeightCategory.MinWeight))
+            .ToListAsync(cancellationToken);
+
+        if (activeWeightCategories.Count == 0)
+        {
+            return [];
+        }
+
+        List<int> activeWeightCategoryIds = activeWeightCategories
+            .Select(wc => wc.WeightCategoryId)
+            .ToList();
+
+        // Query 2: Fetch all candidate records (no IsCurrent filter)
+        List<RawRecordData> candidateRecords = await dbContext.Set<Record>()
             .Where(r => r.EraId == eraId)
-            .Where(r => r.WeightCategory.Gender == Gender.Parse(genderLower))
+            .Where(r => activeWeightCategoryIds.Contains(r.WeightCategoryId))
             .Where(r => r.AgeCategory.Slug == ageCategory)
             .Where(r => r.IsRaw == isClassic)
             .Where(r => r.RecordCategoryId != RecordCategory.TotalWilks && r.RecordCategoryId != RecordCategory.TotalIpfPoints)
-            .Where(r => dbContext.Set<EraWeightCategory>()
-                .Any(ewc => ewc.EraId == r.EraId
-                    && ewc.WeightCategoryId == r.WeightCategoryId
-                    && ewc.FromDate <= referenceDate
-                    && ewc.ToDate >= referenceDate))
-            .Where(r => !excludeJuniorsOnly || !r.WeightCategory.JuniorsOnly)
-            .OrderBy(r => r.RecordCategoryId)
-            .ThenBy(r => r.WeightCategory.MinWeight)
             .Select(r => new RawRecordData(
                 r.RecordId,
                 r.RecordCategoryId,
@@ -57,23 +82,57 @@ internal sealed class GetRecordsHandler(ResultsDbContext dbContext)
                 r.IsStandard))
             .ToListAsync(cancellationToken);
 
-        List<RecordGroup> groups = rawData
-            .GroupBy(r => r.RecordCategoryId)
-            .Select(g => new RecordGroup(
-                MapCategoryName(g.Key),
-                g.Select(r => new RecordEntry(
-                    r.RecordId,
-                    r.WeightCategory,
-                    r.Athlete,
-                    r.AthleteSlug,
-                    r.BirthYear,
-                    r.Club,
-                    r.BodyWeight,
-                    r.Weight,
-                    r.Date,
-                    r.Meet,
-                    r.MeetSlug,
-                    r.IsStandard)).ToList()))
+        // C# step: Group by (WeightCategoryId, RecordCategoryId), pick highest Weight (then RecordId as tiebreaker)
+        Dictionary<(int WeightCategoryId, RecordCategory RecordCategoryId), RawRecordData> bestRecords = candidateRecords
+            .GroupBy(r => (r.WeightCategoryId, r.RecordCategoryId))
+            .ToDictionary(
+                g => g.Key,
+                g => g
+                    .OrderByDescending(r => r.Weight)
+                    .ThenByDescending(r => r.RecordId)
+                    .First());
+
+        // Cross-product: For each record category × each weight category, emit the best record or a placeholder
+        List<RecordGroup> groups = DisplayCategories
+            .Select(category => new RecordGroup(
+                MapCategoryName(category),
+                activeWeightCategories
+                    .Select(wc =>
+                    {
+                        (int WeightCategoryId, RecordCategory RecordCategoryId) key = (wc.WeightCategoryId, category);
+
+                        if (bestRecords.TryGetValue(key, out RawRecordData? record))
+                        {
+                            return new RecordEntry(
+                                record.RecordId,
+                                record.WeightCategory,
+                                record.Athlete,
+                                record.AthleteSlug,
+                                record.BirthYear,
+                                record.Club,
+                                record.BodyWeight,
+                                record.Weight,
+                                record.Date,
+                                record.Meet,
+                                record.MeetSlug,
+                                record.Athlete is null);
+                        }
+
+                        return new RecordEntry(
+                            0,
+                            wc.Title,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            0m,
+                            default,
+                            null,
+                            null,
+                            false);
+                    })
+                    .ToList()))
             .ToList();
 
         return groups;
@@ -89,6 +148,11 @@ internal sealed class GetRecordsHandler(ResultsDbContext dbContext)
         : category == RecordCategory.DeadliftSingle ? "R\u00e9ttst\u00f6\u00f0ulyfta (st\u00f6k grein)"
         : string.Empty;
 #pragma warning restore S3358 // Ternary operators should not be nested
+
+    private sealed record ActiveWeightCategory(
+        int WeightCategoryId,
+        string Title,
+        decimal MinWeight);
 
     private sealed record RawRecordData(
         int RecordId,

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
@@ -311,6 +311,19 @@ public sealed class DatabaseFixture : IAsyncLifetime
             -- Participation: Place=-1, DQ (Anna Test, AthleteId=2)
             INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
             VALUES (2, 6, 82.0, 1, 1, -1, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4);
+
+            -- IsCurrent corruption test data: bench record for 93kg where IsCurrent=1 is on a LOWER weight
+            -- The higher-weight row (150.0) has IsCurrent=0, the lower-weight row (140.0) has IsCurrent=1
+            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+            VALUES (2, 1, 2, 2, 150.0, '2025-06-01', 0, 2, 0, 0, 'seed');
+
+            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+            VALUES (2, 1, 2, 2, 140.0, '2025-05-01', 0, 2, 1, 0, 'seed');
+
+            -- IsStandard flag corruption: record with IsStandard=1 but linked to a real athlete via AttemptId
+            -- BenchSingle (RecordCategoryId=5) for 83kg equipped open male
+            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+            VALUES (2, 1, 1, 5, 130.0, '2025-03-15', 1, 2, 1, 0, 'seed');
         """);
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/GetRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/GetRecordsTests.cs
@@ -67,10 +67,14 @@ public sealed class GetRecordsTests(IntegrationTestFixture fixture)
         femaleGroups.ShouldNotBeNull();
         femaleGroups.ShouldNotBeEmpty();
 
-        int maleRecordCount = maleGroups.Sum(g => g.Records.Count);
-        int femaleRecordCount = femaleGroups.Sum(g => g.Records.Count);
+        int maleNonEmptyCount = maleGroups
+            .SelectMany(g => g.Records)
+            .Count(r => r.Athlete is not null);
+        int femaleNonEmptyCount = femaleGroups
+            .SelectMany(g => g.Records)
+            .Count(r => r.Athlete is not null);
 
-        maleRecordCount.ShouldBeGreaterThan(femaleRecordCount);
+        maleNonEmptyCount.ShouldBeGreaterThan(femaleNonEmptyCount);
     }
 
     [Fact]
@@ -94,10 +98,14 @@ public sealed class GetRecordsTests(IntegrationTestFixture fixture)
         juniorGroups.ShouldNotBeNull();
         juniorGroups.ShouldNotBeEmpty();
 
-        int openCount = openGroups.Sum(g => g.Records.Count);
-        int juniorCount = juniorGroups.Sum(g => g.Records.Count);
+        int openNonEmptyCount = openGroups
+            .SelectMany(g => g.Records)
+            .Count(r => r.Athlete is not null);
+        int juniorNonEmptyCount = juniorGroups
+            .SelectMany(g => g.Records)
+            .Count(r => r.Athlete is not null);
 
-        openCount.ShouldBeGreaterThan(juniorCount);
+        openNonEmptyCount.ShouldBeGreaterThan(juniorNonEmptyCount);
     }
 
     [Fact]
@@ -114,14 +122,16 @@ public sealed class GetRecordsTests(IntegrationTestFixture fixture)
         classicGroups.ShouldNotBeNull();
         classicGroups.ShouldNotBeEmpty();
 
-        int classicCount = classicGroups.Sum(g => g.Records.Count);
-        classicCount.ShouldBe(1);
+        int classicNonEmptyCount = classicGroups
+            .SelectMany(g => g.Records)
+            .Count(r => r.Athlete is not null);
+        classicNonEmptyCount.ShouldBe(1);
     }
 
     [Fact]
-    public async Task ReturnsEmpty_WhenNoMatchingRecords()
+    public async Task ReturnsAllRecordCategories_EvenWithNoRecords()
     {
-        // Arrange
+        // Arrange — female junior equipped has no records but has active weight categories
 
         // Act
         List<RecordGroup>? groups = await _httpClient.GetFromJsonAsync<List<RecordGroup>>(
@@ -130,7 +140,8 @@ public sealed class GetRecordsTests(IntegrationTestFixture fixture)
 
         // Assert
         groups.ShouldNotBeNull();
-        groups.ShouldBeEmpty();
+        groups.Count.ShouldBe(6);
+        groups.SelectMany(g => g.Records).ShouldAllBe(r => r.Athlete == null);
     }
 
     [Fact]
@@ -229,5 +240,81 @@ public sealed class GetRecordsTests(IntegrationTestFixture fixture)
         List<string> weightCategories = squatGroup.Records.Select(r => r.WeightCategory).ToList();
         weightCategories.Count.ShouldBeGreaterThanOrEqualTo(2);
         weightCategories.ShouldBe(weightCategories.OrderBy(w => decimal.Parse(w, System.Globalization.CultureInfo.InvariantCulture)).ToList());
+    }
+
+    [Fact]
+    public async Task ReturnsHighestWeight_WhenIsCurrentFlagIsCorrupt()
+    {
+        // Arrange — bench record for 93kg: 150.0 (IsCurrent=0) vs 140.0 (IsCurrent=1)
+        // The handler should return 150.0 (highest weight) regardless of IsCurrent flag
+
+        // Act
+        List<RecordGroup>? groups = await _httpClient.GetFromJsonAsync<List<RecordGroup>>(
+            $"{Path}?gender=m&ageCategory=open&equipmentType=equipped",
+            CancellationToken.None);
+
+        // Assert
+        groups.ShouldNotBeNull();
+        RecordGroup benchGroup = groups.First(g => g.Category == "Bekkpressa");
+        RecordEntry benchRecord93 = benchGroup.Records.First(r => r.WeightCategory == "93");
+        benchRecord93.Weight.ShouldBe(150.0m);
+    }
+
+    [Fact]
+    public async Task ReturnsIsStandardFalse_WhenRecordHasAthleteEvenIfDbFlagIsTrue()
+    {
+        // Arrange — BenchSingle 83kg has IsStandard=1 in DB but is linked to a real athlete via AttemptId
+
+        // Act
+        List<RecordGroup>? groups = await _httpClient.GetFromJsonAsync<List<RecordGroup>>(
+            $"{Path}?gender=m&ageCategory=open&equipmentType=equipped",
+            CancellationToken.None);
+
+        // Assert
+        groups.ShouldNotBeNull();
+        RecordGroup benchSingleGroup = groups.First(g => g.Category == "Bekkpressa (stök grein)");
+        RecordEntry benchSingleRecord83 = benchSingleGroup.Records.First(r => r.WeightCategory == "83");
+        benchSingleRecord83.Athlete.ShouldNotBeNull();
+        benchSingleRecord83.IsStandard.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyEntries_ForWeightCategoriesWithNoRecords()
+    {
+        // Arrange — 93kg has no deadlift record (equipped, open, male)
+
+        // Act
+        List<RecordGroup>? groups = await _httpClient.GetFromJsonAsync<List<RecordGroup>>(
+            $"{Path}?gender=m&ageCategory=open&equipmentType=equipped",
+            CancellationToken.None);
+
+        // Assert
+        groups.ShouldNotBeNull();
+        RecordGroup deadliftGroup = groups.First(g => g.Category == "R\u00e9ttst\u00f6\u00f0ulyfta");
+        RecordEntry deadliftRecord93 = deadliftGroup.Records.First(r => r.WeightCategory == "93");
+        deadliftRecord93.Athlete.ShouldBeNull();
+        deadliftRecord93.Weight.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task ReturnsAllActiveWeightCategories_EvenWithNoRecords()
+    {
+        // Arrange — open equipped male: active weight categories are 83kg and 93kg
+        // 93kg only has standard squat record + corrupt bench records, other categories have no records
+
+        // Act
+        List<RecordGroup>? groups = await _httpClient.GetFromJsonAsync<List<RecordGroup>>(
+            $"{Path}?gender=m&ageCategory=open&equipmentType=equipped",
+            CancellationToken.None);
+
+        // Assert
+        groups.ShouldNotBeNull();
+
+        foreach (RecordGroup group in groups)
+        {
+            List<string> weightCategories = group.Records.Select(r => r.WeightCategory).ToList();
+            weightCategories.ShouldContain("83");
+            weightCategories.ShouldContain("93");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Restructured `GetRecordsHandler` to drive from active weight categories (EraWeightCategories) rather than from the Records table, so all active weight classes appear even when no record has been set
- Removed `IsCurrent` filter — the flag is corrupt in the DB for some combinations; instead picks the highest-weight record per (WeightCategoryId, RecordCategoryId), matching the live site's behavior
- Fixed `IsStandard` propagation: records linked to a real athlete via AttemptId are never treated as standard placeholders regardless of the DB flag

## Test plan

- [x] All 16 `GetRecordsTests` pass (including 4 new tests covering IsCurrent corruption, IsStandard corruption, empty weight category placeholders, and all-active-weight-categories)
- [x] `https://localhost:7106/records/f/open?equipmentType=classic` matches `https://results.kraft.is/records/classic/women/open`
- [x] Bench press 76kg (Matthildur Óskarsdóttir, 102.0) visible on women/open/classic page
- [x] Masters categories show all active weight classes even where no record exists

Closes #230