### PR TITLE
fix(tests): use non-IS country in RecordAttemptTests to avoid polluting rankings

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
@@ -257,7 +257,7 @@ public sealed class RecordAttemptTests
 
     private async Task<int> AddParticipantToSeedMeet()
     {
-        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().Build();
+        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
         HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
             "/athletes",
             athleteCommand,


### PR DESCRIPTION
Closes #237

## Summary
- `RecordAttemptTests.AddParticipantToSeedMeet()` was creating Icelandic (`CountryId=1`) athletes and recording good attempts for them in the 2025 seed meet (`MeetTypeId=1`), giving them `Total > 0`
- When these tests ran before `GetRankingsTests`, the IS athlete count for year=2025 became 2 instead of 1, failing `ExcludesDisqualified` and `ShowsBestResultPerAthlete`
- Fix: set `CountryId=2` (Norway, already seeded) so test athletes are non-IS and invisible to rankings queries

## Test plan
- [x] `GetRankingsTests.ExcludesDisqualified` passes consistently
- [x] `GetRankingsTests.ShowsBestResultPerAthlete` passes consistently
- [x] All other `RecordAttemptTests` still pass