### PR TITLE
fix: correct error code prefixes in TeamErrors

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Teams/TeamErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/TeamErrors.cs
@@ -41,10 +41,10 @@ internal static class TeamErrors
         "Cannot delete a team that has athletes assigned.");
 
     internal static Error ShortTitleExists(string titleShort) => new(
-        "Athletes.ShortTitleExists",
+        "Teams.ShortTitleExists",
         $"Team with short title {titleShort} already exists.");
 
     internal static Error TeamDoesNotExist(int id) => new(
-        "Athletes.TeamDoesNotExist",
+        "Teams.TeamDoesNotExist",
         $"Team with Id {id} does not exist.");
 }


### PR DESCRIPTION
## Summary
- Corrected `Athletes.ShortTitleExists` → `Teams.ShortTitleExists`
- Corrected `Athletes.TeamDoesNotExist` → `Teams.TeamDoesNotExist`

## Test plan
- [x] Build passes with zero warnings
- [x] Verify error codes returned by team endpoints use `Teams.*` prefix

Closes #243