### PR TITLE
Fix timing oracle in plaintext password migration path

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Users/Login/LoginHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Users/Login/LoginHandler.cs
@@ -36,8 +36,7 @@ internal sealed class LoginHandler
             return UserErrors.InvalidUsernameOrPassword;
         }
 
-        // Hash old password if stored as plain text
-        if (command.Password == user.Password)
+        if (!user.Password.IsHashed)
         {
             _logger.LogInformation("Migrating password hash for user: {Username}", command.Username);
             user.Password = Password.Hash(user.Password);

--- a/src/KRAFT.Results.WebApi/ValueObjects/Password.cs
+++ b/src/KRAFT.Results.WebApi/ValueObjects/Password.cs
@@ -18,6 +18,34 @@ internal sealed class Password : ValueObject<string>
     {
     }
 
+    internal bool IsHashed
+    {
+        get
+        {
+            string[] parts = Value.Split(Separator, 2);
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            if (parts[0].Length != SaltSize * 2 || parts[1].Length != HashSize * 2)
+            {
+                return false;
+            }
+
+            try
+            {
+                Convert.FromHexString(parts[0]);
+                Convert.FromHexString(parts[1]);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+    }
+
     internal static Password Parse(string value) => new(value);
 
     internal static Result<Password> Hash(string value)


### PR DESCRIPTION
## Summary
- Detects legacy plaintext passwords structurally via `Password.IsHashed` (checks for `'.'` separator) instead of comparing user input against stored plaintext
- Eliminates timing side-channel: no user-submitted value is ever compared against the stored password in the migration branch
- `Password.Verify()` (PBKDF2 + `CryptographicOperations.FixedTimeEquals`) handles all actual password verification

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~LoginTests"` — all 6 tests pass including `ReturnsOk_WhenSuccessful` which exercises the migration path
- [x] Security re-review confirmed: previous blocking finding resolved, no new blocking findings

Closes #141