### PR TITLE
Fix team index card member count label

### DIFF
--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
@@ -28,7 +28,7 @@
             <div class="team-short">@team.ShortTitle</div>
             <div class="team-count">
                 <span class="count-value">@team.AthleteCount</span>
-                <span class="count-label">keppendur</span>
+                <span class="count-label">meðlimir</span>
             </div>
         </Card>
     }


### PR DESCRIPTION
## Summary
- Changed label on team index cards from "keppendur" (competitors) to "meðlimir" (members)

## Test plan
- [x] Verify team index page shows "meðlimir" on each team card's member count

Closes #265