### PR TITLE
chore(ci): simplify deploy script to use git reset instead of checkout/pull

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cd /mnt/user/appdata/kraft.results
+cd /mnt/user/appdata/kraft-src
 git fetch origin main
 LOCAL=$(git rev-parse main)
 REMOTE=$(git rev-parse origin/main)


### PR DESCRIPTION
## Summary

- Replaced the git checkout main + git pull origin main sequence in deploy.sh with git reset --hard origin/main + git clean -fd.
- This is simpler and prevents deploy failures when local files have been edited directly on the server, since git pull would refuse to overwrite uncommitted changes.