### PR TITLE
fix(deploy): use docker compose plugin syntax instead of docker-compose

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ if [ "$LOCAL" != "$REMOTE" ]; then
     echo "$(date): Changes detected, deploying..."
     git reset --hard origin/main
     git clean -fd
-    docker-compose build api web
-    docker-compose up -d api web
+    docker compose build api web
+    docker compose up -d api web
     echo "$(date): Deploy complete"
 fi


### PR DESCRIPTION
## Summary
- Replace `docker-compose` with `docker compose` (plugin syntax) in `deploy.sh`
- The standalone `docker-compose` binary is not available on the server; the plugin-based `docker compose` is

## Test plan
- [ ] Verify cron job runs successfully on next push to main
- [ ] Confirm containers rebuild and restart as expected