### PR TITLE
fix(deploy): use docker-compose instead of docker compose plugin

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ if [ "$LOCAL" != "$REMOTE" ]; then
     echo "$(date): Changes detected, deploying..."
     git reset --hard origin/main
     git clean -fd
-    docker compose build api web
-    docker compose up -d api web
+    docker-compose build api web
+    docker-compose up -d api web
     echo "$(date): Deploy complete"
 fi


### PR DESCRIPTION
## Summary
- Tower server has `docker-compose` (standalone v5.1.1) but not the `docker compose` plugin
- The cron job was silently failing with `docker: 'compose' is not a docker command`
- Replace `docker compose` with `docker-compose` in deploy.sh

## Test plan
- [ ] Merge and confirm next cron run on tower completes successfully (`tail -f /var/log/kraft-deploy.log`)