### PR TITLE
fix(deploy): detect docker-compose vs docker compose at runtime

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -e
+
+if command -v docker-compose &>/dev/null; then
+    COMPOSE="docker-compose"
+else
+    COMPOSE="docker compose"
+fi
 cd /mnt/user/appdata/kraft-src
 git fetch origin main
 LOCAL=$(git rev-parse main)
@@ -8,7 +14,7 @@ if [ "$LOCAL" != "$REMOTE" ]; then
     echo "$(date): Changes detected, deploying..."
     git reset --hard origin/main
     git clean -fd
-    docker-compose build api web
-    docker-compose up -d api web
+    $COMPOSE build api web
+    $COMPOSE up -d api web
     echo "$(date): Deploy complete"
 fi


### PR DESCRIPTION
## Summary
- `deploy.sh` was hardcoded to `docker-compose` (v1), which is not installed on tower
- Script now detects whichever is available at runtime and uses that
- Works on any system regardless of Docker Compose version