### PR TITLE
fix(deploy): detect docker compose by running version instead of checking PATH

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -e
 
-if command -v docker-compose &>/dev/null; then
+if docker-compose version &>/dev/null 2>&1; then
     COMPOSE="docker-compose"
-else
+elif docker compose version &>/dev/null 2>&1; then
     COMPOSE="docker compose"
+else
+    echo "Error: docker compose not found" >&2
+    exit 1
 fi
 
 if [ "$1" = "--build" ]; then


### PR DESCRIPTION
## Summary
- `command -v docker-compose` was unreliable in the cron environment despite the binary existing
- Now detects by actually running `docker-compose version` or `docker compose version` — whichever succeeds first wins
- More portable: works on Windows, Linux, and any system where the command is in PATH