### PR TITLE
fix(deploy): cd into repo dir before --build to fix missing compose file

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,7 @@ else
     exit 1
 fi
 
-cd /mnt/user/appdata/kraft-src
+cd "$(dirname "$0")"
 
 if [ "$1" = "--build" ]; then
     echo "$(date): Building and starting containers..."


### PR DESCRIPTION
## Summary
- The `--build` handler ran before the `cd`, so docker-compose couldn't find `docker-compose.yml`
- Moved `cd /mnt/user/appdata/kraft-src` to the top, before both the `--build` check and the git logic