### PR TITLE
fix(test): use unique meet ID in RemoveParticipantTests

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
@@ -13,7 +13,7 @@ public sealed class RemoveParticipantTests(IntegrationTestFixture fixture)
 {
     private const int NonExistentMeetId = 99999;
     private const int NonExistentParticipationId = 99999;
-    private const int ExistingMeetId = 2;
+    private const int ExistingMeetId = 4;
     private const int ExistingWeightCategoryId = 1;
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();


### PR DESCRIPTION
## Summary
- `RemoveParticipantTests` and `AddParticipantTests` shared the same Athlete 1 + Meet 2 combination, causing a 409 Conflict when `AddParticipantTests` ran first and the participant already existed
- Changed `RemoveParticipantTests` to use Meet 4 (TC Meet 1 2026) which has no existing participation for Athlete 1

## Test plan
- [x] All 14 participant tests pass (both Add and Remove)
- [x] Full test suite passes (361 tests)

Closes #294