### PR TITLE
feat(rankings): redesign rankings page with mobile-friendly cards

### DIFF
--- a/src/KRAFT.Results.Contracts/Rankings/RankingEntry.cs
+++ b/src/KRAFT.Results.Contracts/Rankings/RankingEntry.cs
@@ -12,4 +12,5 @@ public sealed record class RankingEntry(
     decimal Wilks,
     string MeetTitle,
     string MeetSlug,
-    bool IsClassic);
+    bool IsClassic,
+    DateOnly MeetDate);

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
@@ -5,30 +5,19 @@
         <div class="r-rank @_rankClass" aria-hidden="true">@_rankDisplay</div>
         <div class="r-name-col">
             <NavLink class="r-name" href="@($"/athletes/{Entry.AthleteSlug}")">@Entry.Athlete</NavLink>
-            <span class="r-meta">@Entry.WeightCategory kg · @Entry.BodyWeight.ToString("F2") kg</span>
+            <span class="r-meta">@Entry.WeightCategory kg · @Entry.BodyWeight.ToString("F2") kg · @Entry.Result.ToString("F1") @DisciplineLabel</span>
         </div>
-        <div class="r-right">
-            <div class="r-secondary">
-                <span class="r-score-item">
-                    <span class="r-score-label">@DisciplineLabel</span>
-                    <span class="r-score-val">@Entry.Result.ToString("F1")</span>
-                </span>
-                <span class="r-score-item">
-                    <span class="r-score-label">Wilks</span>
-                    <span class="r-score-val">@Entry.Wilks.ToString("F2")</span>
-                </span>
+        @if (Entry.IpfPoints.HasValue)
+        {
+            <div class="r-ipf-col">
+                <span class="r-ipf-label">IPF stig</span>
+                <span class="r-ipf">@Entry.IpfPoints.Value.ToString("F2")</span>
             </div>
-            @if (Entry.IpfPoints.HasValue)
-            {
-                <div class="r-ipf-col">
-                    <span class="r-ipf-label">IPF stig</span>
-                    <span class="r-ipf">@Entry.IpfPoints.Value.ToString("F2")</span>
-                </div>
-            }
-        </div>
+        }
     </div>
     <div class="r-footer-row">
         <NavLink class="r-meet-link" href="@($"/meets/{Entry.MeetSlug}")">@Entry.MeetTitle</NavLink>
+        <span class="r-meet-date">@Entry.MeetDate.ToString("dd.MM.yyyy")</span>
     </div>
 </div>
 

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor.css
@@ -69,43 +69,6 @@
     margin-block-start: 1px;
 }
 
-/* ── Right group: secondary scores + big IPF ── */
-
-.r-right {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    gap: 16px;
-}
-
-.r-secondary {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    align-items: flex-end;
-}
-
-.r-score-item {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-}
-
-.r-score-label {
-    font-size: 9px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--color-text-muted);
-}
-
-.r-score-val {
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--color-text);
-    font-variant-numeric: tabular-nums;
-}
-
 .r-ipf-col {
     flex-shrink: 0;
     display: flex;
@@ -123,7 +86,7 @@
 
 .r-ipf {
     font-weight: 800;
-    font-size: 36px;
+    font-size: 26px;
     color: var(--color-primary);
     font-variant-numeric: tabular-nums;
     line-height: 1;
@@ -134,6 +97,8 @@
 .r-footer-row {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding-block-start: 6px;
     border-block-start: 1px solid var(--color-border);
 }
@@ -153,6 +118,13 @@
     color: var(--color-primary);
 }
 
+.r-meet-date {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+}
+
 /* ===== Desktop: flatten to grid row ===== */
 
 @container (min-width: 680px) {
@@ -161,7 +133,7 @@
         grid-template-columns: 30px 1fr auto;
         grid-template-rows: auto auto;
         align-items: center;
-        column-gap: 12px;
+        column-gap: 16px;
         row-gap: 0;
         padding: 8px 14px;
         flex-direction: unset;
@@ -189,9 +161,10 @@
         grid-row: 1;
     }
 
-    .r-right {
+    .r-ipf-col {
         grid-column: 3;
         grid-row: 1;
+        align-items: flex-end;
     }
 
     .r-name {

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor
@@ -68,51 +68,11 @@ else if (_hasError)
 }
 else if (_response is not null && _response.Items.Count > 0)
 {
-    <div class="table-wrapper">
-        <table aria-label="Stigatafla">
-            <colgroup>
-                <col class="col-rank" />
-                <col class="col-athlete" />
-                <col class="col-numeric" />
-                <col class="col-numeric" />
-                <col class="col-numeric" />
-                <col class="col-numeric" />
-                <col class="col-numeric" />
-                <col class="col-meet" />
-            </colgroup>
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Keppandi</th>
-                    <th class="text-center">Þyngdarfl.</th>
-                    <th class="text-end hide-mobile">Líkamsþ.</th>
-                    <th class="text-end">@DisciplineLabel</th>
-                    <th class="text-end hide-mobile">IPF stig</th>
-                    <th class="text-end hide-mobile">Wilks</th>
-                    <th>Mót</th>
-                </tr>
-            </thead>
-
-            <tbody>
-                @foreach (RankingEntry entry in _response.Items)
-                {
-                    <tr>
-                        <RankCell Rank="@entry.Rank" />
-                        <AthleteCell Athlete="@entry.Athlete" Slug="@entry.AthleteSlug" />
-                        <td class="text-center numeric-value">@entry.WeightCategory</td>
-                        <td class="text-end hide-mobile numeric-value">@entry.BodyWeight.ToString("F2")</td>
-                        <td class="text-end numeric-value">@entry.Result.ToString("F1")</td>
-                        <td class="text-end hide-mobile numeric-value">@(entry.IpfPoints?.ToString("F2") ?? "-")</td>
-                        <td class="text-end hide-mobile numeric-value">@entry.Wilks.ToString("F2")</td>
-                        <td>
-                            <NavLink class="nav-link" href="@($"/meets/{entry.MeetSlug}")">
-                                @entry.MeetTitle
-                            </NavLink>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+    <div class="rankings-list">
+        @foreach (RankingEntry entry in _response.Items)
+        {
+            <RankingCard Entry="entry" DisciplineLabel="@DisciplineLabel" />
+        }
     </div>
 
     @if (TotalPages > 1)

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor.css
@@ -38,39 +38,10 @@
     outline-offset: 2px;
 }
 
-.table-wrapper {
-    overflow-x: auto;
-}
-
-table {
-    table-layout: fixed;
-}
-
-.col-rank {
-    width: 3.5rem;
-}
-
-.col-athlete {
-    width: 18rem;
-}
-
-.col-numeric {
-    width: 6rem;
-}
-
-.col-meet {
-}
-
-.numeric-value {
-    font-variant-numeric: tabular-nums;
-}
-
-.text-end {
-    text-align: end;
-}
-
-.text-center {
-    text-align: center;
+.rankings-list {
+    max-width: 720px;
+    margin-inline: auto;
+    container-type: inline-size;
 }
 
 .pagination {
@@ -190,21 +161,11 @@ table {
         min-width: auto;
         flex: 1;
     }
-
-    .hide-mobile {
-        display: none;
-    }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .filter-select {
-        transition: none;
-    }
-
-    .page-btn {
-        transition: none;
-    }
-
+    .filter-select,
+    .page-btn,
     .retry-btn {
         transition: none;
     }

--- a/src/KRAFT.Results.WebApi/Features/Rankings/Get/GetRankingsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Rankings/Get/GetRankingsHandler.cs
@@ -92,7 +92,8 @@ internal sealed class GetRankingsHandler
                 p.Wilks,
                 p.Meet.Title,
                 p.Meet.Slug,
-                p.Meet.IsRaw)),
+                p.Meet.IsRaw,
+                DateOnly.FromDateTime(p.Meet.StartDate))),
             "bench" => query.Select(p => new RawRankingData(
                 p.AthleteId,
                 p.Athlete.Firstname + " " + p.Athlete.Lastname,
@@ -104,7 +105,8 @@ internal sealed class GetRankingsHandler
                 p.Wilks,
                 p.Meet.Title,
                 p.Meet.Slug,
-                p.Meet.IsRaw)),
+                p.Meet.IsRaw,
+                DateOnly.FromDateTime(p.Meet.StartDate))),
             "deadlift" => query.Select(p => new RawRankingData(
                 p.AthleteId,
                 p.Athlete.Firstname + " " + p.Athlete.Lastname,
@@ -116,7 +118,8 @@ internal sealed class GetRankingsHandler
                 p.Wilks,
                 p.Meet.Title,
                 p.Meet.Slug,
-                p.Meet.IsRaw)),
+                p.Meet.IsRaw,
+                DateOnly.FromDateTime(p.Meet.StartDate))),
             _ => query.Select(p => new RawRankingData(
                 p.AthleteId,
                 p.Athlete.Firstname + " " + p.Athlete.Lastname,
@@ -128,7 +131,8 @@ internal sealed class GetRankingsHandler
                 p.Wilks,
                 p.Meet.Title,
                 p.Meet.Slug,
-                p.Meet.IsRaw)),
+                p.Meet.IsRaw,
+                DateOnly.FromDateTime(p.Meet.StartDate))),
         };
 
         List<RawRankingData> rawData = await rawQuery.ToListAsync(cancellationToken);
@@ -166,7 +170,8 @@ internal sealed class GetRankingsHandler
                 r.Wilks,
                 r.MeetTitle,
                 r.MeetSlug,
-                r.IsRaw))
+                r.IsRaw,
+                r.MeetDate))
             .ToList();
 
         return new PagedResponse<RankingEntry>(items, page, pageSize, totalCount);
@@ -183,7 +188,8 @@ internal sealed class GetRankingsHandler
         decimal Wilks,
         string MeetTitle,
         string MeetSlug,
-        bool IsRaw)
+        bool IsRaw,
+        DateOnly MeetDate)
     {
         public decimal CalculatedIpfPoints { get; set; }
     }


### PR DESCRIPTION
## Summary

- Replaces the horizontal-scroll table with mobile-first cards matching the `MeetDetailsPage` aesthetic (crimson left border, rank medals, `ParticipationCard` design language)
- IPF points are the focal value on each card (26px, bold, crimson); discipline result and body weight folded into the meta line
- Meet date added to `RankingEntry` contract and displayed in card footer alongside meet link
- Cards constrained to `max-width: 720px` (appropriate for the content density vs. 1100px for meet results)
- Desktop layout flattens to a grid row via container query at 680px

## Test plan

- [x] Visit `/rankings` and verify cards render correctly on mobile and desktop
- [x] Check rank medals (🥇🥈🥉) appear for top 3, numeric badge for others
- [x] Verify IPF points display for classic meets, card renders gracefully when `IpfPoints` is null
- [x] Confirm meet date appears in footer in `dd.MM.yyyy` format
- [x] Check filter bar (discipline, year, equipment type, gender) still works
- [x] Verify pagination still functions