### PR TITLE
fix(ci): use rebase merge for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes the dependabot auto-merge workflow which was using `--squash` merge strategy
- The repository only allows rebase merging, so squash was rejected by GitHub
- Switches to `--rebase` to match the repo's allowed merge method

## Test plan

- [ ] Verify PR #310 (or next dependabot PR) triggers auto-merge successfully after this merges