### PR TITLE
Pass returnUrl from login links so users return to previous page

### DIFF
--- a/src/KRAFT.Results.Web/Components/Layout/NavMenu.razor
+++ b/src/KRAFT.Results.Web/Components/Layout/NavMenu.razor
@@ -1,4 +1,5 @@
 @inject IJSRuntime JS
+@inject NavigationManager NavigationManager
 @implements IAsyncDisposable
 
 @code {
@@ -9,6 +10,25 @@
 
     private void ToggleNav() => _isOpen = !_isOpen;
     private void CloseNav() => _isOpen = false;
+
+    private void NavigateToLogin()
+    {
+        string relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        string returnUrl = string.Concat("/", relativePath);
+        if (returnUrl.StartsWith("/login", StringComparison.OrdinalIgnoreCase))
+        {
+            NavigationManager.NavigateTo("login");
+            return;
+        }
+        string encodedReturnUrl = Uri.EscapeDataString(returnUrl);
+        NavigationManager.NavigateTo($"login?returnUrl={encodedReturnUrl}");
+    }
+
+    private void NavigateToLoginAndClose()
+    {
+        CloseNav();
+        NavigateToLogin();
+    }
 
     [JSInvokable]
     public void CloseFromJs()
@@ -141,9 +161,9 @@
                 <div class="nav-separator mobile-only"></div>
 
                 <div class="nav-item mobile-only">
-                    <NavLink class="nav-link" href="login" @onclick="CloseNav">
+                    <a class="nav-link" href="login" @onclick="NavigateToLoginAndClose" @onclick:preventDefault>
                         <span class="bi bi-login-nav-menu" aria-hidden="true"></span> Innskrá
-                    </NavLink>
+                    </a>
                 </div>
             </NotAuthorized>
         </AuthorizeView>

--- a/src/KRAFT.Results.Web/Components/Layout/TopBar.razor
+++ b/src/KRAFT.Results.Web/Components/Layout/TopBar.razor
@@ -1,5 +1,6 @@
 @inject IJSRuntime JS
 @inject AuthenticationStateProvider AuthStateProvider
+@inject NavigationManager NavigationManager
 @implements IAsyncDisposable
 
 @code {
@@ -12,6 +13,19 @@
     protected override void OnInitialized()
     {
         AuthStateProvider.AuthenticationStateChanged += OnAuthStateChanged;
+    }
+
+    private void NavigateToLogin()
+    {
+        string relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        string returnUrl = string.Concat("/", relativePath);
+        if (returnUrl.StartsWith("/login", StringComparison.OrdinalIgnoreCase))
+        {
+            NavigationManager.NavigateTo("login");
+            return;
+        }
+        string encodedReturnUrl = Uri.EscapeDataString(returnUrl);
+        NavigationManager.NavigateTo($"login?returnUrl={encodedReturnUrl}");
     }
 
     private void OnAuthStateChanged(Task<AuthenticationState> _)
@@ -96,7 +110,7 @@
             </div>
         </Authorized>
         <NotAuthorized>
-            <a class="login-link" href="login">Innskrá</a>
+            <a class="login-link" href="login" @onclick="NavigateToLogin" @onclick:preventDefault>Innskrá</a>
         </NotAuthorized>
     </AuthorizeView>
 </div>


### PR DESCRIPTION
## Summary
- `TopBar.razor` and `NavMenu.razor` hardcoded `href="login"` with no `returnUrl`, so users always landed on `/` after login regardless of where they came from
- Both components now inject `NavigationManager` and compute `login?returnUrl={encodedCurrentPath}`, following the same pattern already used by `RedirectToLogin.razor`
- A `/login` guard prevents a redirect loop when the user is already on the login page

## Test plan
- [x] Navigate to `/meets` while logged out, click Innskrá — confirm URL is `/login?returnUrl=%2Fmeets`
- [x] Log in — confirm redirect lands on `/meets`
- [x] Repeat via mobile nav (hamburger menu)
- [x] Navigate directly to `/login` while logged out — confirm login link href has no `returnUrl`

Closes #318