### PR TITLE
fix(meets): exclude zero-weight attempts from pending records

### DIFF
--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -347,7 +347,8 @@ else
             {
                 try
                 {
-                    _pendingRecords = await HttpClient.GetFromJsonAsync<List<PendingRecordEntry>>($"/meets/{Slug}/pending-records") ?? [];
+                    List<PendingRecordEntry> allPendingRecords = await HttpClient.GetFromJsonAsync<List<PendingRecordEntry>>($"/meets/{Slug}/pending-records") ?? [];
+                    _pendingRecords = allPendingRecords.Where(r => r.Weight > 0).ToList();
                 }
                 catch (HttpRequestException)
                 {

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetPendingRecords/GetMeetPendingRecordsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetPendingRecords/GetMeetPendingRecordsHandler.cs
@@ -40,6 +40,7 @@ internal sealed class GetMeetPendingRecordsHandler(ResultsDbContext dbContext)
 
         List<AttemptCandidate> goodAttempts = await dbContext.Set<Attempt>()
             .Where(a => a.Good)
+            .Where(a => a.Weight > 0)
             .Where(a => a.Participation.Meet.Slug == slug)
             .Where(a => a.Discipline != Discipline.None)
             .Select(a => new AttemptCandidate(

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
@@ -18,6 +18,7 @@ internal static class Constants
         internal const int RecordBreakingAttemptId = 4;
         internal const int NonRecordBreakingAttemptId = 5;
         internal const int ApproveAttemptId = 6;
+        internal const int ZeroWeightAttemptId = 7;
     }
 
     internal static class TeamCompetition

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
@@ -216,6 +216,11 @@ public sealed class DatabaseFixture : IAsyncLifetime
             INSERT INTO Attempts (ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
             VALUES (@FemaleTestMeetParticipationId, 1, 3, 110.0, 1, 'seed', 'seed');
 
+            -- Attempt 7: zero-weight good bench attempt (should be excluded from pending records)
+            -- Uses bench (DisciplineId=2) in a raw slot with no existing record, so only Weight check filters it
+            INSERT INTO Attempts (ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
+            VALUES (1, 2, 1, 0.0, 1, 'seed', 'seed');
+
             -- Male athlete 2 (non-IS country to avoid ranking interference)
             INSERT INTO Athletes (Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
             VALUES ('Bob', 'Test', '1988-05-10', 'm', 2, 'bob-test');

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetPendingRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetPendingRecordsTests.cs
@@ -80,6 +80,26 @@ public sealed class GetMeetPendingRecordsTests(IntegrationTestFixture fixture)
     }
 
     [Fact]
+    public async Task DoesNotInclude_AttemptsWithZeroWeight()
+    {
+        // Arrange
+        string slug = Constants.TestMeetSlug;
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.GetAsync(
+            $"{BasePath}/{slug}/pending-records",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        List<PendingRecordEntry>? records = await response.Content
+            .ReadFromJsonAsync<List<PendingRecordEntry>>(CancellationToken.None);
+        records.ShouldNotBeNull();
+        records.ShouldNotContain(r => r.AttemptId == Constants.PendingRecords.ZeroWeightAttemptId);
+        records.ShouldAllBe(r => r.Weight > 0);
+    }
+
+    [Fact]
     public async Task ReturnsNotFound_WhenMeetDoesNotExist()
     {
         // Arrange & Act


### PR DESCRIPTION
## Summary

- Added `.Where(a => a.Weight > 0)` to the EF query in `GetMeetPendingRecordsHandler` to exclude zero-weight attempts at the database level
- Added a client-side safety net filter in `MeetDetailsPage.razor` after deserializing the pending records response
- Added integration test `DoesNotInclude_AttemptsWithZeroWeight` to verify the behaviour

## Test plan

- [x] Zero-weight attempts do not appear in the pending records section on the meet details page
- [x] Valid (weight > 0) pending records still appear and can be approved as before
- [x] `GetMeetPendingRecordsTests.DoesNotInclude_AttemptsWithZeroWeight` passes