### PR TITLE
fix(meets): validate body weight before checking existing participation

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Meets/AddParticipant/AddParticipantHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/AddParticipant/AddParticipantHandler.cs
@@ -68,6 +68,11 @@ internal sealed class AddParticipantHandler
             }
         }
 
+        if (command.BodyWeight < 0)
+        {
+            return new Result<int>(ParticipationErrors.BodyWeightMustNotBeNegative);
+        }
+
         bool alreadyRegistered = await _dbContext.Set<Participation>()
             .AnyAsync(p => p.MeetId == meetId && p.AthleteId == athlete.AthleteId, cancellationToken);
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
@@ -14,6 +14,7 @@ public sealed class AddParticipantTests(IntegrationTestFixture fixture)
     private const int MeetWithExistingParticipationId = 1;
     private const int NonExistentMeetId = 99999;
     private const int MeetForTeamTest = 5;
+    private const int NegativeBodyWeightTestMeetId = 4;
     private const int ExistingTeamId = 1;
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
@@ -182,7 +183,7 @@ public sealed class AddParticipantTests(IntegrationTestFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{NegativeBodyWeightTestMeetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);


### PR DESCRIPTION
## Summary
- Add early `bodyWeight < 0` guard in `AddParticipantHandler` before the conflict check, ensuring input validation runs before business-logic state checks
- Fix test isolation in `ReturnsBadRequest_WhenBodyWeightIsNegative` by using a dedicated `NegativeBodyWeightTestMeetId = 4` instead of the shared `ExistingMeetId = 2`

## Test plan
- [ ] `ReturnsBadRequest_WhenBodyWeightIsNegative` now passes
- [ ] All `AddParticipantTests` pass (no regressions)

Closes #329