### PR TITLE
Add MaxLength(50) constraint on AgeCategorySlug in AddParticipantCommand

### DIFF
--- a/src/KRAFT.Results.Contracts/Meets/AddParticipantCommand.cs
+++ b/src/KRAFT.Results.Contracts/Meets/AddParticipantCommand.cs
@@ -1,7 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace KRAFT.Results.Contracts.Meets;
 
 public sealed record class AddParticipantCommand(
     string AthleteSlug,
     decimal BodyWeight,
     int? TeamId,
+    [MaxLength(50, ErrorMessage = "Aldursflokkur má ekki vera lengri en 50 stafir")]
     string? AgeCategorySlug);

--- a/src/KRAFT.Results.WebApi/Features/AgeCategories/AgeCategory.cs
+++ b/src/KRAFT.Results.WebApi/Features/AgeCategories/AgeCategory.cs
@@ -5,6 +5,8 @@ namespace KRAFT.Results.WebApi.Features.AgeCategories;
 
 internal sealed class AgeCategory
 {
+    internal const int SlugMaxLength = 50;
+
     public int AgeCategoryId { get; private set; }
 
     public string Title { get; private set; } = null!;

--- a/src/KRAFT.Results.WebApi/Features/AgeCategories/AgeCategoryConfiguration.cs
+++ b/src/KRAFT.Results.WebApi/Features/AgeCategories/AgeCategoryConfiguration.cs
@@ -14,7 +14,7 @@ internal sealed class AgeCategoryConfiguration : IEntityTypeConfiguration<AgeCat
             .HasColumnType("datetime");
 
         builder.Property(e => e.Slug)
-            .HasMaxLength(50);
+            .HasMaxLength(AgeCategory.SlugMaxLength);
 
         builder.Property(e => e.Title)
             .HasMaxLength(50);

--- a/src/KRAFT.Results.WebApi/Features/Meets/AddParticipant/AddParticipantHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/AddParticipant/AddParticipantHandler.cs
@@ -78,6 +78,11 @@ internal sealed class AddParticipantHandler
             return new Result<int>(ParticipationErrors.BodyWeightTooHigh);
         }
 
+        if (command.AgeCategorySlug is not null && command.AgeCategorySlug.Length > AgeCategory.SlugMaxLength)
+        {
+            return new Result<int>(MeetErrors.AgeCategorySlugTooLong);
+        }
+
         bool alreadyRegistered = await _dbContext.Set<Participation>()
             .AnyAsync(p => p.MeetId == meetId && p.AthleteId == athlete.AthleteId, cancellationToken);
 

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetErrors.cs
@@ -1,4 +1,5 @@
 using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.AgeCategories;
 
 namespace KRAFT.Results.WebApi.Features.Meets;
 
@@ -57,6 +58,10 @@ internal static class MeetErrors
     internal static readonly Error NoMatchingWeightCategory = new(
         NoMatchingWeightCategoryCode,
         "No matching weight category found for the given body weight.");
+
+    internal static readonly Error AgeCategorySlugTooLong = new(
+        "Meets.AgeCategorySlugTooLong",
+        $"Age category slug cannot exceed {AgeCategory.SlugMaxLength} characters.");
 
     internal static readonly Error AttemptOutOfOrder = new(
         "Meets.AttemptOutOfOrder",

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/AddParticipantCommandBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/AddParticipantCommandBuilder.cs
@@ -7,6 +7,7 @@ internal sealed class AddParticipantCommandBuilder
     private string _athleteSlug = Constants.TestAthleteSlug;
     private decimal _bodyWeight = 80.5m;
     private int? _teamId;
+    private string? _ageCategorySlug;
 
     public AddParticipantCommandBuilder WithAthleteSlug(string slug)
     {
@@ -26,6 +27,12 @@ internal sealed class AddParticipantCommandBuilder
         return this;
     }
 
+    public AddParticipantCommandBuilder WithAgeCategorySlug(string? ageCategorySlug)
+    {
+        _ageCategorySlug = ageCategorySlug;
+        return this;
+    }
+
     public AddParticipantCommand Build() =>
-        new(_athleteSlug, _bodyWeight, _teamId, null);
+        new(_athleteSlug, _bodyWeight, _teamId, _ageCategorySlug);
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
@@ -189,6 +189,24 @@ public sealed class AddParticipantTests(IntegrationTestFixture fixture)
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
     }
 
+    [Fact]
+    public async Task ReturnsBadRequest_WhenAgeCategorySlugIsTooLong()
+    {
+        // Arrange
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(Constants.TestAthleteSlug)
+            .WithBodyWeight(82.5m)
+            .WithAgeCategorySlug(new string('a', 51))
+            .Build();
+
+        // Act
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
     [Theory]
     [InlineData(-1)]
     [InlineData(0)]


### PR DESCRIPTION
## Summary
- Add `[MaxLength(50)]` annotation on `AgeCategorySlug` in `AddParticipantCommand`, matching the `AgeCategory.Slug` DB column and slug conventions elsewhere
- Add `AgeCategory.SlugMaxLength = 50` constant and reference it from `AgeCategoryConfiguration` and `MeetErrors`
- Add explicit handler guard in `AddParticipantHandler` (consistent with BodyWeight guards) since `[MaxLength]` annotations are not enforced automatically in minimal APIs
- Add `WithAgeCategorySlug()` builder method and `ReturnsBadRequest_WhenAgeCategorySlugIsTooLong` integration test

## Test plan
- [ ] `ReturnsBadRequest_WhenAgeCategorySlugIsTooLong` — POST with 51-char slug returns 400
- [ ] All existing `AddParticipantTests` continue to pass

Closes #343