### PR TITLE
fix(abstractions): add value equality to ValueObject<T>

### DIFF
--- a/KRAFT.Results.slnx
+++ b/KRAFT.Results.slnx
@@ -20,5 +20,6 @@
     <Project Path="tests/KRAFT.Results.Web.E2ETests/KRAFT.Results.Web.E2ETests.csproj" />
     <Project Path="tests/KRAFT.Results.Web.Client.Tests/KRAFT.Results.Web.Client.Tests.csproj" />
     <Project Path="tests/KRAFT.Results.WebApi.IntegrationTests/KRAFT.Results.WebApi.IntegrationTests.csproj" />
+    <Project Path="tests/KRAFT.Results.WebApi.Tests/KRAFT.Results.WebApi.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/KRAFT.Results.WebApi/Abstractions/ValueObject.cs
+++ b/src/KRAFT.Results.WebApi/Abstractions/ValueObject.cs
@@ -1,6 +1,6 @@
 ﻿namespace KRAFT.Results.WebApi.Abstractions;
 
-internal abstract class ValueObject<T>
+internal abstract class ValueObject<T> : IEquatable<ValueObject<T>>
 {
     protected ValueObject(T value)
     {
@@ -10,6 +10,60 @@ internal abstract class ValueObject<T>
     public T Value { get; }
 
     public static implicit operator T(ValueObject<T> title) => title.Value;
+
+    public static bool operator ==(ValueObject<T>? left, ValueObject<T>? right)
+    {
+        if (left is null)
+        {
+            return right is null;
+        }
+
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(ValueObject<T>? left, ValueObject<T>? right) => !(left == right);
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((ValueObject<T>)obj);
+    }
+
+    public bool Equals(ValueObject<T>? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (other.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return EqualityComparer<T>.Default.Equals(Value, other.Value);
+    }
+
+    public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode(Value!);
 
     public override string ToString() => Value?.ToString() ?? string.Empty;
 }

--- a/src/KRAFT.Results.WebApi/KRAFT.Results.WebApi.csproj
+++ b/src/KRAFT.Results.WebApi/KRAFT.Results.WebApi.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="KRAFT.Results.WebApi.IntegrationTests" />
+    <InternalsVisibleTo Include="KRAFT.Results.WebApi.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KRAFT.Results.WebApi.Tests/KRAFT.Results.WebApi.Tests.csproj
+++ b/tests/KRAFT.Results.WebApi.Tests/KRAFT.Results.WebApi.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KRAFT.Results.WebApi\KRAFT.Results.WebApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KRAFT.Results.WebApi.Tests/ValueObjects/ValueObjectEqualityTests.cs
+++ b/tests/KRAFT.Results.WebApi.Tests/ValueObjects/ValueObjectEqualityTests.cs
@@ -1,0 +1,168 @@
+using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.ValueObjects;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.Tests.ValueObjects;
+
+public sealed class ValueObjectEqualityTests
+{
+    [Fact]
+    public void Email_SameValue_AreEqual()
+    {
+        // Arrange
+        Email email1 = Email.Create("test@example.com").FromResult();
+        Email email2 = Email.Create("test@example.com").FromResult();
+
+        // Act & Assert
+        email1.ShouldBe(email2);
+        (email1 == email2).ShouldBeTrue();
+        email1.GetHashCode().ShouldBe(email2.GetHashCode());
+    }
+
+    [Fact]
+    public void Email_DifferentValue_AreNotEqual()
+    {
+        // Arrange
+        Email email1 = Email.Create("a@example.com").FromResult();
+        Email email2 = Email.Create("b@example.com").FromResult();
+
+        // Act & Assert
+        (email1 != email2).ShouldBeTrue();
+        email1.Equals(email2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Password_SameHashedValue_AreEqual()
+    {
+        // Arrange
+        Password password = Password.Hash("secret123").FromResult();
+        Password same = Password.Parse(password.Value);
+
+        // Act & Assert
+        password.ShouldBe(same);
+        (password == same).ShouldBeTrue();
+        password.GetHashCode().ShouldBe(same.GetHashCode());
+    }
+
+    [Fact]
+    public void Password_DifferentHashedValues_AreNotEqual()
+    {
+        // Arrange
+        Password password1 = Password.Hash("secret123").FromResult();
+        Password password2 = Password.Hash("secret456").FromResult();
+
+        // Act & Assert
+        (password1 != password2).ShouldBeTrue();
+        password1.Equals(password2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Gender_SameValue_AreEqual()
+    {
+        // Arrange
+        Gender gender1 = Gender.Male;
+        Gender gender2 = Gender.Parse("m");
+
+        // Act & Assert
+        gender1.ShouldBe(gender2);
+        (gender1 == gender2).ShouldBeTrue();
+        gender1.GetHashCode().ShouldBe(gender2.GetHashCode());
+    }
+
+    [Fact]
+    public void Gender_DifferentValue_AreNotEqual()
+    {
+        // Arrange
+        Gender male = Gender.Male;
+        Gender female = Gender.Female;
+
+        // Act & Assert
+        (male != female).ShouldBeTrue();
+        male.Equals(female).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Slug_SameValue_AreEqual()
+    {
+        // Arrange
+        Slug slug1 = Slug.Create("hello-world");
+        Slug slug2 = Slug.Create("hello-world");
+
+        // Act & Assert
+        slug1.ShouldBe(slug2);
+        (slug1 == slug2).ShouldBeTrue();
+        slug1.GetHashCode().ShouldBe(slug2.GetHashCode());
+    }
+
+    [Fact]
+    public void Slug_DifferentValue_AreNotEqual()
+    {
+        // Arrange
+        Slug slug1 = Slug.Create("hello");
+        Slug slug2 = Slug.Create("world");
+
+        // Act & Assert
+        (slug1 != slug2).ShouldBeTrue();
+        slug1.Equals(slug2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IpfPoints_SameValue_AreEqual()
+    {
+        // Arrange
+        IpfPoints points1 = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
+        IpfPoints points2 = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
+
+        // Act & Assert
+        points1.ShouldBe(points2);
+        (points1 == points2).ShouldBeTrue();
+        points1.GetHashCode().ShouldBe(points2.GetHashCode());
+    }
+
+    [Fact]
+    public void IpfPoints_DifferentValue_AreNotEqual()
+    {
+        // Arrange
+        IpfPoints points1 = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
+        IpfPoints points2 = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 300m);
+
+        // Act & Assert
+        (points1 != points2).ShouldBeTrue();
+        points1.Equals(points2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CrossType_SameUnderlyingValue_AreNotEqual()
+    {
+        // Arrange
+        Gender gender = Gender.Male;
+        Slug slug = Slug.Create("m");
+
+        // Act
+        bool result = gender.Equals(slug);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WithNull_ReturnsFalse()
+    {
+        // Arrange
+        Email email = Email.Create("test@example.com").FromResult();
+
+        // Act & Assert
+        email.Equals(null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WithSameInstance_ReturnsTrue()
+    {
+        // Arrange
+        Email email = Email.Create("test@example.com").FromResult();
+
+        // Act & Assert
+        email.Equals(email).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Equals(object?)`, `Equals(ValueObject<T>?)`, `GetHashCode()`, and `==`/`!=` operators to `ValueObject<T>`
- Uses `EqualityComparer<T>.Default` for null-safe, boxing-free comparisons across all concrete types
- Adds a new unit test project (`KRAFT.Results.WebApi.Tests`) with 13 tests covering all five value object types

## Test plan
- [ ] Two value objects of the same type wrapping the same value are equal (`==`, `.Equals()`, same hash code)
- [ ] Two value objects wrapping different values are not equal (`!=`)
- [ ] Cross-type: different `ValueObject<T>` subtypes wrapping the same string value are not equal
- [ ] `dotnet test` passes on all projects

Closes #349