### PR TITLE
test(value-objects): add AAA comments to all unit tests

### DIFF
--- a/tests/KRAFT.Results.WebApi.UnitTests/Abstractions/Equals.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Abstractions/Equals.cs
@@ -9,17 +9,24 @@ public sealed class Equals
     [Fact]
     public void ReturnsFalse_WhenOtherIsNull()
     {
+        // Arrange
         Email email = Email.Create("test@example.com").FromResult();
 
+        // Act & Assert
         email.Equals(null).ShouldBeFalse();
     }
 
     [Fact]
     public void ReturnsFalse_WhenComparingDifferentSubtypesWithSameUnderlyingValue()
     {
+        // Arrange
         Gender gender = Gender.Male;
         Slug slug = Slug.Create("m");
 
-        gender.Equals(slug).ShouldBeFalse();
+        // Act
+        bool result = gender.Equals(slug);
+
+        // Assert
+        result.ShouldBeFalse();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/EmailTests/EqualityOperators.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/EmailTests/EqualityOperators.cs
@@ -9,18 +9,22 @@ public sealed class EqualityOperators
     [Fact]
     public void EqualOperator_ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         Email a = Email.Create("test@example.com").FromResult();
         Email b = Email.Create("test@example.com").FromResult();
 
+        // Act & Assert
         (a == b).ShouldBeTrue();
     }
 
     [Fact]
     public void InequalityOperator_ReturnsTrue_WhenDifferentValue()
     {
+        // Arrange
         Email a = Email.Create("a@example.com").FromResult();
         Email b = Email.Create("b@example.com").FromResult();
 
+        // Act & Assert
         (a != b).ShouldBeTrue();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/EmailTests/Equals.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/EmailTests/Equals.cs
@@ -9,34 +9,42 @@ public sealed class Equals
     [Fact]
     public void ReturnsFalse_WhenOtherIsNull()
     {
+        // Arrange
         Email email = Email.Create("test@example.com").FromResult();
 
+        // Act & Assert
         email.Equals(null).ShouldBeFalse();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameInstance()
     {
+        // Arrange
         Email email = Email.Create("test@example.com").FromResult();
 
+        // Act & Assert
         email.Equals(email).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         Email a = Email.Create("test@example.com").FromResult();
         Email b = Email.Create("test@example.com").FromResult();
 
+        // Act & Assert
         a.Equals(b).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsFalse_WhenDifferentValue()
     {
+        // Arrange
         Email a = Email.Create("a@example.com").FromResult();
         Email b = Email.Create("b@example.com").FromResult();
 
+        // Act & Assert
         a.Equals(b).ShouldBeFalse();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/EmailTests/GetHashCode.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/EmailTests/GetHashCode.cs
@@ -9,9 +9,11 @@ public sealed class GetHashCode
     [Fact]
     public void ReturnsSameHashCode_WhenSameValue()
     {
+        // Arrange
         Email a = Email.Create("test@example.com").FromResult();
         Email b = Email.Create("test@example.com").FromResult();
 
+        // Act & Assert
         a.GetHashCode().ShouldBe(b.GetHashCode());
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/GenderTests/EqualityOperators.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/GenderTests/EqualityOperators.cs
@@ -9,15 +9,18 @@ public sealed class EqualityOperators
     [Fact]
     public void EqualOperator_ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         Gender a = Gender.Male;
         Gender b = Gender.Parse("m");
 
+        // Act & Assert
         (a == b).ShouldBeTrue();
     }
 
     [Fact]
     public void InequalityOperator_ReturnsTrue_WhenDifferentValue()
     {
+        // Act & Assert
         (Gender.Male != Gender.Female).ShouldBeTrue();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/GenderTests/Equals.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/GenderTests/Equals.cs
@@ -9,27 +9,32 @@ public sealed class Equals
     [Fact]
     public void ReturnsFalse_WhenOtherIsNull()
     {
+        // Act & Assert
         Gender.Male.Equals(null).ShouldBeFalse();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameInstance()
     {
+        // Act & Assert
         Gender.Male.Equals(Gender.Male).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         Gender a = Gender.Male;
         Gender b = Gender.Parse("m");
 
+        // Act & Assert
         a.Equals(b).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsFalse_WhenDifferentValue()
     {
+        // Act & Assert
         Gender.Male.Equals(Gender.Female).ShouldBeFalse();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/GenderTests/GetHashCode.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/GenderTests/GetHashCode.cs
@@ -9,9 +9,11 @@ public sealed class GetHashCode
     [Fact]
     public void ReturnsSameHashCode_WhenSameValue()
     {
+        // Arrange
         Gender a = Gender.Male;
         Gender b = Gender.Parse("m");
 
+        // Act & Assert
         a.GetHashCode().ShouldBe(b.GetHashCode());
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/IpfPointsTests/EqualityOperators.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/IpfPointsTests/EqualityOperators.cs
@@ -9,18 +9,22 @@ public sealed class EqualityOperators
     [Fact]
     public void EqualOperator_ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         IpfPoints a = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
         IpfPoints b = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
 
+        // Act & Assert
         (a == b).ShouldBeTrue();
     }
 
     [Fact]
     public void InequalityOperator_ReturnsTrue_WhenDifferentValue()
     {
+        // Arrange
         IpfPoints a = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
         IpfPoints b = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 300m);
 
+        // Act & Assert
         (a != b).ShouldBeTrue();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/IpfPointsTests/Equals.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/IpfPointsTests/Equals.cs
@@ -9,26 +9,32 @@ public sealed class Equals
     [Fact]
     public void ReturnsTrue_WhenSameInstance()
     {
+        // Arrange
         IpfPoints points = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
 
+        // Act & Assert
         points.Equals(points).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         IpfPoints a = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
         IpfPoints b = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
 
+        // Act & Assert
         a.Equals(b).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsFalse_WhenDifferentValue()
     {
+        // Arrange
         IpfPoints a = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
         IpfPoints b = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 300m);
 
+        // Act & Assert
         a.Equals(b).ShouldBeFalse();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/IpfPointsTests/GetHashCode.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/IpfPointsTests/GetHashCode.cs
@@ -9,9 +9,11 @@ public sealed class GetHashCode
     [Fact]
     public void ReturnsSameHashCode_WhenSameValue()
     {
+        // Arrange
         IpfPoints a = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
         IpfPoints b = IpfPoints.Create(true, Gender.Male, "Powerlifting", 83m, 200m);
 
+        // Act & Assert
         a.GetHashCode().ShouldBe(b.GetHashCode());
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/PasswordTests/EqualityOperators.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/PasswordTests/EqualityOperators.cs
@@ -9,18 +9,22 @@ public sealed class EqualityOperators
     [Fact]
     public void EqualOperator_ReturnsTrue_WhenSameHashedValue()
     {
+        // Arrange
         Password password = Password.Hash("secret123").FromResult();
         Password same = Password.Parse(password.Value);
 
+        // Act & Assert
         (password == same).ShouldBeTrue();
     }
 
     [Fact]
     public void InequalityOperator_ReturnsTrue_WhenDifferentHashedValues()
     {
+        // Arrange
         Password a = Password.Hash("secret123").FromResult();
         Password b = Password.Hash("secret456").FromResult();
 
+        // Act & Assert
         (a != b).ShouldBeTrue();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/PasswordTests/Equals.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/PasswordTests/Equals.cs
@@ -9,34 +9,42 @@ public sealed class Equals
     [Fact]
     public void ReturnsFalse_WhenOtherIsNull()
     {
+        // Arrange
         Password password = Password.Hash("secret123").FromResult();
 
+        // Act & Assert
         password.Equals(null).ShouldBeFalse();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameInstance()
     {
+        // Arrange
         Password password = Password.Hash("secret123").FromResult();
 
+        // Act & Assert
         password.Equals(password).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameHashedValue()
     {
+        // Arrange
         Password password = Password.Hash("secret123").FromResult();
         Password same = Password.Parse(password.Value);
 
+        // Act & Assert
         password.Equals(same).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsFalse_WhenDifferentHashedValues()
     {
+        // Arrange
         Password a = Password.Hash("secret123").FromResult();
         Password b = Password.Hash("secret456").FromResult();
 
+        // Act & Assert
         a.Equals(b).ShouldBeFalse();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/PasswordTests/GetHashCode.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/PasswordTests/GetHashCode.cs
@@ -9,9 +9,11 @@ public sealed class GetHashCode
     [Fact]
     public void ReturnsSameHashCode_WhenSameHashedValue()
     {
+        // Arrange
         Password password = Password.Hash("secret123").FromResult();
         Password same = Password.Parse(password.Value);
 
+        // Act & Assert
         password.GetHashCode().ShouldBe(same.GetHashCode());
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/SlugTests/EqualityOperators.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/SlugTests/EqualityOperators.cs
@@ -9,18 +9,22 @@ public sealed class EqualityOperators
     [Fact]
     public void EqualOperator_ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         Slug a = Slug.Create("hello-world");
         Slug b = Slug.Create("hello-world");
 
+        // Act & Assert
         (a == b).ShouldBeTrue();
     }
 
     [Fact]
     public void InequalityOperator_ReturnsTrue_WhenDifferentValue()
     {
+        // Arrange
         Slug a = Slug.Create("hello");
         Slug b = Slug.Create("world");
 
+        // Act & Assert
         (a != b).ShouldBeTrue();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/SlugTests/Equals.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/SlugTests/Equals.cs
@@ -9,26 +9,32 @@ public sealed class Equals
     [Fact]
     public void ReturnsTrue_WhenSameInstance()
     {
+        // Arrange
         Slug slug = Slug.Create("hello-world");
 
+        // Act & Assert
         slug.Equals(slug).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsTrue_WhenSameValue()
     {
+        // Arrange
         Slug a = Slug.Create("hello-world");
         Slug b = Slug.Create("hello-world");
 
+        // Act & Assert
         a.Equals(b).ShouldBeTrue();
     }
 
     [Fact]
     public void ReturnsFalse_WhenDifferentValue()
     {
+        // Arrange
         Slug a = Slug.Create("hello");
         Slug b = Slug.Create("world");
 
+        // Act & Assert
         a.Equals(b).ShouldBeFalse();
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/SlugTests/GetHashCode.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/ValueObjects/SlugTests/GetHashCode.cs
@@ -9,9 +9,11 @@ public sealed class GetHashCode
     [Fact]
     public void ReturnsSameHashCode_WhenSameValue()
     {
+        // Arrange
         Slug a = Slug.Create("hello-world");
         Slug b = Slug.Create("hello-world");
 
+        // Act & Assert
         a.GetHashCode().ShouldBe(b.GetHashCode());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `// Arrange`, `// Act`, `// Assert` comments to every test method in `KRAFT.Results.WebApi.UnitTests`
- No logic changes — tests remain identical, comments only

## Test plan
- [x] `dotnet test` passes (35 tests)

Closes #349