### PR TITLE
Enforce aggregate boundary: route Attempt creation through Participation

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
@@ -89,16 +89,7 @@ internal sealed class RecordAttemptHandler
         }
         else
         {
-            Attempt attempt = Attempt.Create(
-                participationId,
-                discipline,
-                round,
-                command.Weight,
-                command.Good,
-                user.Username);
-
-            _dbContext.Set<Attempt>().Add(attempt);
-            participation.Attempts.Add(attempt);
+            participation.RecordAttempt(discipline, round, command.Weight, command.Good, user.Username);
         }
 
         participation.RecalculateTotals();

--- a/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
@@ -144,6 +144,12 @@ internal sealed class Participation
         return Result.Success();
     }
 
+    internal void RecordAttempt(Discipline discipline, short round, decimal weight, bool good, string createdBy)
+    {
+        Attempt attempt = Attempt.Create(ParticipationId, discipline, round, weight, good, createdBy);
+        Attempts.Add(attempt);
+    }
+
     internal void RecalculateTotals()
     {
         decimal bestSquat = BestGoodLift(Discipline.Squat);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
@@ -237,6 +237,34 @@ public sealed class RecordAttemptTests
         bombedOut.ShouldNotBeNull();
     }
 
+    [Fact]
+    public async Task AttemptPersistedThroughAggregate_WhenRecordedViaParticipation()
+    {
+        // Arrange
+        int participationId = await AddParticipantToSeedMeet();
+
+        // Act
+        await RecordAttempt(participationId, Discipline.Squat, 1, 120.0m, true);
+
+        // Assert — retrieve participation and verify attempt is persisted and retrievable
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{Constants.TestMeetSlug}/participations",
+                CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        MeetParticipation? participation = participations
+            .FirstOrDefault(p => p.ParticipationId == participationId);
+
+        participation.ShouldNotBeNull();
+        MeetAttempt? attempt = participation.Attempts
+            .FirstOrDefault(a => a.Discipline == Discipline.Squat && a.Round == 1);
+
+        attempt.ShouldNotBeNull();
+        attempt.Weight.ShouldBe(120.0m);
+        attempt.IsGood.ShouldBeTrue();
+    }
+
     private static string Path(int meetId, int participationId, Discipline discipline, int round) =>
         $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}";
 


### PR DESCRIPTION
## Summary
Routes `Attempt` creation through the `Participation` aggregate root by adding a `RecordAttempt()` method to `Participation`. Removes the redundant `_dbContext.Set<Attempt>().Add(attempt)` call and the direct `participation.Attempts.Add(attempt)` from the handler — EF Core auto-tracks child entities added to a tracked aggregate's navigation collection.

## Changes
- `Participation.cs` — new `internal RecordAttempt(Discipline, short, decimal, bool, string)` method
- `RecordAttemptHandler.cs` — 10 lines replaced with a single `participation.RecordAttempt(...)` call
- `RecordAttemptTests.cs` — new aggregate boundary integration test

## Test plan
- [x] All 14 existing `RecordAttempt` integration tests pass
- [x] New `AttemptPersistedThroughAggregate_WhenRecordedViaParticipation` test passes
- [x] No `_dbContext.Set<Attempt>().Add(...)` calls remain in handlers

Closes #350