### PR TITLE
Remove duplicate body weight validation from AddParticipantHandler

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Meets/AddParticipant/AddParticipantHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/AddParticipant/AddParticipantHandler.cs
@@ -68,16 +68,6 @@ internal sealed class AddParticipantHandler
             }
         }
 
-        if (command.BodyWeight <= 0)
-        {
-            return new Result<int>(ParticipationErrors.BodyWeightMustBePositive);
-        }
-
-        if (command.BodyWeight > Participation.MaxBodyWeight)
-        {
-            return new Result<int>(ParticipationErrors.BodyWeightTooHigh);
-        }
-
         if (command.AgeCategorySlug is not null && command.AgeCategorySlug.Length > AgeCategory.SlugMaxLength)
         {
             return new Result<int>(MeetErrors.AgeCategorySlugTooLong);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
@@ -352,6 +352,13 @@ public sealed class DatabaseFixture : IAsyncLifetime
             INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
             VALUES (2, 1, 1, 5, 130.0, '2025-03-15', 1, 2, 1, 0, 'seed');
 
+            -- Body weight validation test meets (MeetId=7, MeetId=8)
+            INSERT INTO Meets (Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+            VALUES ('BW Exceeds Max Meet', 'bw-exceeds-max-meet', '2025-11-01', '2025-11-01', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1);
+
+            INSERT INTO Meets (Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+            VALUES ('BW Just Above Max Meet', 'bw-just-above-max-meet', '2025-11-02', '2025-11-02', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1);
+
             -- Roles
             INSERT INTO Roles (RoleId, RoleName)
             VALUES (1, 'Admin'), (2, 'Editor'), (3, 'User');

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
@@ -15,6 +15,8 @@ public sealed class AddParticipantTests(IntegrationTestFixture fixture)
     private const int NonExistentMeetId = 99999;
     private const int MeetForTeamTest = 5;
     private const int NegativeBodyWeightTestMeetId = 4;
+    private const int BodyWeightExceedsMaxMeetId = 7;
+    private const int BodyWeightJustAboveMaxMeetId = 8;
     private const int ExistingTeamId = 1;
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
@@ -131,7 +133,7 @@ public sealed class AddParticipantTests(IntegrationTestFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{BodyWeightExceedsMaxMeetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -148,7 +150,7 @@ public sealed class AddParticipantTests(IntegrationTestFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{BodyWeightJustAboveMaxMeetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);


### PR DESCRIPTION
## Summary
- Removes the body weight pre-validation from `AddParticipantHandler` (`> 0` and `<= 400` checks) that duplicated rules already enforced by `Participation.Create()`
- Fixes test isolation issue in `AddParticipantTests` — body weight boundary tests now use dedicated meet IDs to avoid interference from prior registrations in the same fixture

## Test plan
- [x] All 482 tests pass (verified locally)
- [x] `AddParticipantTests` body weight boundary cases (`ReturnsBadRequest_WhenBodyWeightExceedsMaximum`, `ReturnsBadRequest_WhenBodyWeightIsJustAboveMaximum`, `ReturnsBadRequest_WhenBodyWeightIsZeroOrNegative`) still return 400

Closes #352