### PR TITLE
Add IPF Technical Rules 2026

### DIFF
--- a/docs/ipf-technical-rules-2026.md
+++ b/docs/ipf-technical-rules-2026.md
@@ -1,0 +1,1943 @@
+# IPF Technical Rules 2026
+
+**International Powerlifting Federation — Technical Rule Book**
+Effective: 01 March 2026 (Version 3)
+
+Source: [powerlifting.sport](https://www.powerlifting.sport/rules/codes/info/technical-rules)
+
+The official text shall be maintained by the IPF and published in English. In the event of any conflict between the English and other language versions, the English version shall prevail.
+
+---
+
+## Table of Contents
+
+1. General Rules of Powerlifting
+   - 1.1 Age Categories
+   - 1.2 Bodyweight Categories
+2. Equipment and Specifications
+3. Personal Equipment
+4. Powerlifting and Rules of Performance
+   - 4.1 Squat
+   - 4.2 Bench Press
+   - 4.3 Deadlift
+5. Weighing In
+6. Order of Competition
+7. Referees
+8. Jury and Technical Committee
+9. World and International Records
+10. Coach Responsibilities
+
+---
+
+1 ) Throughout this rulebook , for reasons of brevity , wherever the words “ he ” or “ his ” occur , such
+reference is deemed to apply to either sex . All references to gender shall ensure equal rights for
+both sexes and shall not present women as requiring separate rules unless explicitly necessary .
+In competitions in which both sexes are competing 
+( a ) The International Powerlifting Federation recognizes the following lifts which must be taken
+in the same sequence in all competitions conducted under IPF rules : 
+A . Squat 
+B . Bench Press 
+C . Deadlift 
+D . Total 
+( b ) Competition takes place between lifters in categories defined by sex , body weight and age .
+The Men ’ s and Women ’ s Open Championships permit lifters from 1 January in the calendar year
+he / she reaches 1 9 years and upwards . 
+( c ) In the event of a Powerlifting or Bench Press Championships being combined e . g . with a Sub -
+Junior , Junior Open & Master ' s Championships having both Classic ( 1 category ) and Equipped ( 1
+category ) , a lifter has the option of competing in both Championships . The athlete shall be
+required to pay the entry fee for both championships and will be required to compete twice . No
+lifter is allowed to compete 2 times in Classic or 2 times in Equipped . Masters 3 and 4 are not
+permitted to compete in the Open Class . Once the athlete is entered on the Preliminary
+Nomination , he / she may not change their age division . The lifter may only change the weight
+class on the Final Nomination . 
+( d ) The rules apply to all levels of competition . 
+( e ) Each competitor is allowed three attempts on each lift . The lifter ’ s best valid attempt on each
+lift counts toward his competition total . If two or more lifters achieve the same total , the lighter
+lifter ranks above the heavier lifter . 
+( f ) If two lifters register the same body weight at the weigh in and eventually achieve the same
+total at the end of the competition , the lifter making the total first will take precedence over the
+other lifter . Where awards are presented for best squat , bench press and deadlift or if a world
+record is broken , the same procedure will apply . 
+2 ) The IPF , through its member federations , conducts and sanctions the following World
+Championships . The major events on the IPF calendar are as follows : 
+Equipped World Open Powerlifting Championship
+Equipped World Sub - Junior and Junior Powerlifting Championship
+Equipped World Masters Powerlifting Championship
+Equipped World Bench Press Championship ( Open , Sub - Junior / Junior and Master )
+Classic World Open Powerlifting Championship
+Classic World Sub - Junior and Junior Powerlifting Championship
+Classic World Masters Powerlifting Championship
+Classic World Bench Press Championship ( Open , Sub - Junior / Junior and Master )
+University World Cup
+Other international events as approved by the EC . 
+
+0 1 . 0 3 . 2 0 2 6
+General rules of Powerlifting
+
+OPENfrom 1 January in the calendar year , he / she reaches 1 9 years and upwards 
+SUB - JUNIORS
+from the day he / she reaches 1 4 years and throughout the full calendar year in
+which he / she reaches 1 8 years of age .
+JUNIORS
+ from 1 January in the calendar year , he / she reaches 1 9 years and throughout
+the full calendar year in which he / she reaches 2 3 years of age . 
+MASTER 1
+from 1 January in the calendar year , he / she reaches 4 0 years and throughout
+the full calendar year in which he / she reaches 4 9 years of age . 
+MASTER 2
+ from 1 January in the calendar year , he / she reaches 5 0 years and throughout
+the full calendar year in which he / she reaches 5 9 years of age . 
+MASTER 3
+from 1 January in the calendar year , he / she reaches 6 0 years and throughout
+the full calendar year in which he / she reaches 6 9 years of age . 
+MASTER 4 from 1 January in the calendar year , he / she reaches 7 0 years and upwards . 
+Sub - Junior & Junior only - up to 5 3 . 0 kg 
+5 9 . 0  k g  C l a s s  u p  t o  5 9 . 0  k g
+6 6 . 0  k g  C l a s s  f r o m  5 9 . 0 1  k g  u p  t o  6 6 . 0  k g  
+7 4 . 0  k g  C l a s s  f r o m  6 6 . 0 1  k g  u p  t o  7 4 . 0  k g  
+8 3 . 0  k g  C l a s s  f r o m  7 4 . 0 1  k g  u p  t o  8 3 . 0  k g  
+9 3 . 0  k g  C l a s s  f r o m  8 3 . 0 1  k g  u p  t o  9 3 . 0  k g  
+1 0 5 . 0  k g  C l a s s  f r o m  9 3 . 0 1  k g  u p  t o  1 0 5 . 0  k g  
+1 2 0 . 0  k g  C l a s s  f r o m  1 0 5 . 0 1  k g  u p  t o  1 2 0 . 0  k g  
+1 2 0 . 0 + kg Class from 1 2 0 . 0 1 kg up to unlimited 
+The Championship Secretary , in consult with the Executive Committee , shall ensure that major
+international events do not clash . If necessary , sanction ( s ) may be refused to achieve an orderly
+Calendar . If necessary , the events on the Calendar may be combined into one championship . 
+3 ) The IPF also recognizes and registers world records for the same lifts within the categories
+described hereunder : 
+1 . 1 . AGE CATEGORIES
+MEN & WOMEN
+Competitive lifting for lifters below the age of 1 4 is only allowed at National competitions . 
+1 . 2 . BODYWEIGHT CATEGORIES
+MENWOMEN
+Sub - Junior & Junior only - up to 4 3 . 0 kg 
+4 7 . 0  k g  C l a s s  u p  t o  4 7 . 0  k g  
+5 2 . 0  k g  C l a s s  f r o m  4 7 . 0 1  k g  u p  t o  5 2 . 0  k g  
+5 7 . 0  k g  C l a s s  f r o m  5 2 . 0 1  k g  u p  t o  5 7 . 0  k g  
+6 3 . 0  k g  C l a s s  f r o m  5 7 . 0 1  k g  u p  t o  6 3 . 0  k g  
+6 9 . 0  k g  C l a s s  f r o m  6 3 . 0 1  k g  u p  t o  6 9 . 0  k g  
+7 6 . 0  k g  C l a s s  f r o m  6 9 . 0 1  k g  u p  t o  7 6 . 0  k g  
+8 4 . 0  k g  C l a s s  f r o m  7 6 . 0 1  k g  u p  t o  8 4 . 0  k g  
+8 4 . 0 + kg Class from 8 4 . 0 1 kg up to unlimited 
+
+4 ) Placing for all age groupings shall be determined by the totals of the lifters in accordance with
+the standard rules of lifting . Medals for 1 st , 2 nd , and 3 rd place shall be awarded In each weight
+class across all age divisions . . 
+0 1 . 0 3 . 2 0 2 6
+General rules of Powerlifting
+
+6 ) Each nation is allowed a maximum of five alternates or reserves . To take part in the
+competition they must have been nominated 6 0 days before the date of the championships on
+the preliminary nomination with the bodyweight categories and best totals achieved at National
+or international championships during the last 1 2 months . 
+7 ) Each Nation must submit a team roster giving the name of each lifter and his / her body weight
+category . Best totals from National or International Championships during the previous 1 2
+months shall be stated . This may include his / her result achieved at last year ’ s International
+Championships in the same bodyweight category . The date and title of the competition in which
+the total was achieved must also be stated . These details must be submitted to the
+Championship Secretary of the IPF or of the Region and also to the Meet Director at least 6 0 days
+before the date of the Championships on the preliminary nomination . Final selection , submitted
+not later than 2 1 days before the date of the Championship , must be made from those
+nominated 6 0 days before the date of the Championships . This includes reserve or alternate
+lifters . At this point in time each lifter must nominate the bodyweight category in which they
+wish to lift in these Championships . After the final selection ( final nomination ) no changes in the
+weight category in which the lifter is nominated will be allowed . Nominated lifters without results
+from any of the above Championships will be ranked in the first lifting group if his / her
+bodyweight category is divided into multiple groups . Failure to comply with any of these
+requirements may result in disqualification of the offending team . A lifter cannot produce a
+qualifying total via his national federation for entry to World , International or Regional
+Championships while he is under suspension by the IPF or Region . 
+8 ) Point scoring for all World , Continental and Regional Championships shall be : 1 2 , 9 , 8 , 7 , 6 , 5 , 4 ,
+3 , and 2 points for the first nine places in any bodyweight category . Thereafter , each lifter who
+makes a total in the competition shall be awarded one point . Point scoring for all national
+competitions shall be at the discretion of the national federation . 
+9 ) Only the point scores of the five best placed lifters of each nation will be counted for the team
+competition at all international championships . In case of a tie in points scored , final team
+placing shall be decided for team awards as in item 1 1 . If a member of a team is found to have
+committed a violation of the IPF Anti - Doping Rules during an Event where a team ranking is
+based on the addition of individual results ( points ) , the points of the Athlete committing the
+violation will be subtracted from the team result and may not be repeated by the resulting points
+of another team member . 
+1 0 ) Any nation having been a member of the IPF for more than three years should include at least
+one international referee among its team officials at World Championships . If a referee from that
+nation is not present or , if present , makes himself unavailable to act in the capacity of either
+referee or member for jury during the championships , then only the four best placed lifters from
+that nation will be counted for the team competition . 
+1 1 ) Team awards shall be given for the first three places with Medals , 5 Gold to the Best Team , 5
+Silver to the 2 nd Best Team and 5 Bronze to the 3 rd Best Team . In the case of a tie for the
+classification of a team or a nation , the team having the largest number of first places will be
+ranked first . 
+
+5 ) Each nation is allowed a maximum of eight ( 8 ) competitors spread throughout the range of
+the eight ( 8 ) bodyweight categories for men and eight ( 8 ) competitors throughout the range of
+eight ( 8 ) bodyweight categories for women . In the Junior and Sub - Junior age categories nine ( 9 )
+for men and nine ( 9 ) for women . There must not be more than two competitors from any one
+nation in any particular bodyweight category . 
+0 1 . 0 3 . 2 0 2 6
+General rules of Powerlifting
+
+1 2 ) At all IPF Championships a “ Best lifter ” award shall be given to the lifter who produces the
+best performance based upon the IPF formula . Awards will also be presented to second and third
+places . Categories with less than 3 Lifters will not receive any “ Best Lifter ” awards . 
+1 3 ) At International Championships , medals will be presented for first , second and third places for
+each category based upon totals . In addition , medals or merit award certificates shall be
+presented for first , second and third places in the individual lifts of squat , bench press and
+deadlift in each category . Each lifter must receive a Participation medal / memento from the
+Meet Organizer ( By - Laws 1 3 . 3 ) . Should a lifter fail to succeed in either or both of the squat or
+bench press disciplines he / she may continue to compete for the remainder of the contest , and
+the lifter will be eligible for awards in any discipline in which he / she records a successful lift or
+lifts . To receive this award the lifter must make a bona fide attempt on each of the three
+disciplines . 
+Dress code for athletes at World Championships medal ceremonies is – full team track suit , t -
+shirt , athletic footwear . Compliance will be monitored by the Technical Controller for the session .
+Failure to adhere to these requirements shall disqualify the lifter from receiving the medal ( s ) on
+the platform , although their place in contest results will stand . 
+1 4 ) It is forbidden to whip and smash the lifter in front of the audience and media . 
+1 5 ) At all IPF events , the organizer must provide for the safety of athletes and officials a qualified
+medical person on duty throughout the championships
+2 . EQUIPMENT AND SPECIFICATIONS 
+Scales must be of an electronic digital type and register to the second place of decimals . They
+must have the capacity to weigh up to 1 8 0 kg . A certificate verifying the calibration of the scales
+must be valid within one year of the competition date . 
+All lifts shall be carried out on a platform measuring between 2 . 5 m x 2 . 5 m minimum and 4 . 0 m x
+4 . 0 m maximum . It must not exceed 1 0 cm in height from the surrounding stage or floor . The
+surface of the platform must be flat , firm and level and covered with a material of non - slip
+smooth carpet ( i . e . free from irregularities and projections ) . Rubber matting or similar sheeting
+materials are not permitted .
+For all powerlifting contests organized under the rules of the IPF , only disc barbells are permitted .
+The use of discs which do not meet the current specifications will invalidate the contest and any
+records accomplished . Only those bars and discs that meet all specifications may be used
+throughout the entire competition and for all lifts . The bar shall not be changed during the
+competition unless it is bent or damaged in some way as determined by the Technical
+Committee , Jury or Referees . 
+
+In the case of a tie between two nations having the same number of first places , the one having
+the most second places will be classified first , and so on through the placing of the maximum of
+five scoring lifters . Should teams or Nations finish equally after this procedure has been applied ,
+then the team or Nation with the greater total number of IPF points will be declared the higher
+placed . Teams with less than 3 lifters will not receive medals . 
+0 1 . 0 3 . 2 0 2 6
+General rules of Powerlifting
+2 . 1 . SCALES
+2 . 2 . PLATFORM
+2 . 3 . BARS AND DISCS
+
+Face Value in KilosMaximumMinimum 
+2 5 2 5 . 0 6 2 5 2 4 . 9 3 7 5  
+2 0 2 0 . 0 5  1 9 . 9 5  
+1 5 1 5 . 0 3 7 5  1 4 . 9 6 2 5  
+1 0 1 0 . 0 2 5  9 . 9 7 5  
+5 5 . 0 1 2 5  4 . 9 8 7 5  
+2 . 5 2 . 5 1  2 . 4 9  
+1 . 2 5 1 . 2 6  1 . 2 4  
+1 1 . 0 1  0 . 9 9
+0 . 5 0 . 5 1 0 . 4 9
+0 . 2 5 0 . 2 5 5  0 . 2 4 5
+
+IPF RECOGNIZED POWERLIFTING BAR 
+GUIDELINE OF KNURLING DISTANCES 
+Bars to be used at all IPF Championships shall not be chromed on the knurling . Only bars and
+discs that have official IPF approval may be used at IPF World Championships or the setting of
+World Records . As from 2 0 0 8 the “ knurling ” distances on IPF approved bars will become
+universal / standard based on one of the originally approved bars . 
+( a ) The bar shall be straight and well knurled and grooved and shall conform to the following
+dimensions : 
+1 . Total overall length not to exceed 2 . 2 m . 
+2 . Distance between the collar faces is not to exceed 1 . 3 2 m or be less than 1 . 3 1 m . 
+3 . Diameter of the bar is not to exceed 2 9 mm or be less than 2 8 mm . 
+4 . Weight of the bar and collars are to be 2 5 kg . 
+5 . Diameter of the sleeve not to exceed 5 2 mm or be less than 5 0 mm . 
+6 . The bar shall have machined diameter markings spaced 8 1 cm apart . 
+Measurements in mm ( knurling distances inside the collar sleeves ) 
+( b ) Discs shall conform as follows : 
+1 ) All discs used in competition must weigh within 0 . 2 5 percent or 1 0 grams of their face value . 
+0 1 . 0 3 . 2 0 2 6
+Equipment and specifications
+xxxxxxxxxxxxx
+xxxxxxxxxxxxx
+xxxx
+xxxxxxxxxxxxx
+xxxxxxxxxxxxx
+x x x
+1 2 0
+-
+1 6 0
+2 4 0
+2 4 5
+4 4 0
+8 1 0
+1 3 2 0
+
+2 ) The hole size in the middle of the disc must not exceed 5 3 mm or be less than 5 2 mm . 
+3 ) Discs must be within the following range : 1 . 2 5 kg , 2 . 5 kg , 5 kg , 1 0 kg , 1 5 kg , 2 0 kg , and 2 5 kg . 
+4 ) For record purposes , lighter discs may be used to achieve a weight of at least 0 . 2 5 kg , 0 . 5 kg , 1 . 0
+kg , 1 . 5 kg or a ) 2 kg more than the existing record . 
+5 ) Discs weighing 2 0 kg and over must not exceed 6 cm in thickness . Discs weighing 1 5 kg and
+under must not exceed 3 cm in thickness . 
+6 ) Discs must conform to the following color code : 1 0 kg and under - any color , 1 5 kg - yellow , 2 0
+k g  -  b l u e ,  2 5  k g  -  r e d .  
+7 ) All discs must be clearly marked with their weight and loaded in the sequence of heavier discs
+innermost with the smaller discs in descending weight arranged so that the referees can read
+the weight on each disc . 
+8 ) The first and heaviest discs loaded on the bar must be loaded face in ; with the rest of the discs
+loaded face out . 
+9 ) The diameter of the largest discs shall not be more than 4 5 cm . 
+( a ) Shall always be used . 
+( b ) Must weigh 2 . 5 kg each . 
+1 ) Only Squat Racks from commercial Manufacturers officially registered and approved by the
+Technical Committee shall be permitted for use in the International Powerlifting Championships . 
+2 ) The squat racks shall be designed to adjust from a minimum height of 1 . 0 0 m in the lowest
+position to extend to a height of at least 1 . 7 0 m in 2 . 5 cm increments . 
+3 ) All racks must be capable of being secured at the required height by means of pins . 
+Only Bench Racks and Benches from Commercial Manufacturers officially registered and
+approved by the Technical Committee shall be permitted for use in International Powerlifting
+Championships . The bench shall conform to the following dimensions :
+Length - not less than 1 . 2 2 m and shall be flat and level . 
+Width - not less than 2 9 cm and not exceeding 3 2 cm . 
+Height - not less than 4 2 cm and not exceeding 4 5 cm measured from the floor to the top of
+the padded surface of the bench without it being depressed or compacted . The height of the
+uprights , which must be adjustable , shall be a minimum of 7 5 cm to a maximum of 1 1 0 cm
+measured from the floor to the bar rest position . 
+Minimum width between insides of bar rests shall be 1 . 1 0 m 
+The head of the bench shall extend 2 2 cm beyond the center of the uprights with a tolerance
+of 5 cm either way . 
+Attached safety stands must be used in all events . Minimum Height of Safety Racks shall be
+5 0 cm , having 1 0 holes in increments of 2 . 5 cm and 5 0 cm in length . 
+Timing clocks visible to all ( venue , platform , warm - up area ) must be used which operate
+continuously up to a minimum of twenty minutes and display elapsed time . Additionally , a clock
+displaying time left in which to enter the next attempts should also be made visible to the coach
+or lifter . 
+0 1 . 0 3 . 2 0 2 6
+Equipment and specifications
+2 . 4 . COLLARS
+2 . 5 . SQUAT RACKS
+2 . 6 .  B E N C H
+2 . 7 . CLOCKS
+
+SQUATBENCH PRESSDEADLIFT
+1 . RED
+Failure to bend the knees and
+lower the body until the top
+surface of the legs at the hip
+joint is lower than the top of
+the knees . 
+Bar is not lowered to chest or
+abdominal area i . e . , not
+reaching the chest or
+abdominal area , or is
+touching the belt . 
+Failure to lower the underside
+of both elbow joints level with
+or below the top surface of
+each respective shoulder joint 
+Failure to lock the knees straight
+at the completion of the lift . 
+The front bundle of the deltoid
+muscle should be placed
+behind the imaginary
+projection of the bar 
+Failure to stand erect 
+1 0
+A system of lights shall be provided whereby the referees make known their decisions . Each
+referee will control a white and a red light . The white light indicates a “ good lift , ” and the red light
+indicates a “ no lift . ” The lights shall be arranged horizontally to correspond with the positions of
+the three referees . They must be wired or electronic / wireless in such a way that they light up
+together and not separately when activated by the three referees . For emergency purposes , i . e . , a
+breakdown in the electrical system , the referees will be provided with small white or red flags or
+paddles with which to make known their decisions on the Chief Referee ’ s audible command
+“ f l a g s ” .  
+After the lights have been activated and appeared , the referee ( s ) shall raise a card or paddle , or
+activate the light system , to indicate the reason ( s ) for the failed lift . 
+Referees numbered card system - reason for failure . 
+Color of the cards : 
+Failure no . 1 = red card 
+Failure no . 2 = blue card 
+Failure no . 3 = yellow card 
+0 1 . 0 3 . 2 0 2 6
+Equipment and specifications
+2 . 8 . LIGHTS
+2 . 9 . FAILURE CARDS / PADDLES
+
+1 1
+SQUATBENCH PRESSDEADLIFT
+2 . BLUE
+Failure to assume an upright
+position with the knees locked
+at the commencement and at
+the completion of the lift .
+ Double bouncing or more
+than one recovery attempt at
+the bottom of the lift or any
+downward movement during
+the ascent . 
+Any downward movement of
+the whole of the bar in the
+course of being pressed out . 
+Failure to press the bar to
+straight arm ’ s length elbows
+locked at the completion of
+the lift . 
+Failure to lock the arms
+before the “ START ”
+command . 
+Any downward movement of
+the bar before it reaches the
+final position . If the bar settles as
+the shoulders come back this
+shall not be a reason for
+disqualification . 
+Supporting the bar on the
+thighs during the performance
+of the lift . If the bar edges up the
+thighs but is not supported , this
+is not reason for disqualification . 
+3 . YELLOW
+Stepping backward or forward
+or moving the feet laterally .
+Rocking the feet between the
+ball and heel is permitted . 
+ Failure to observe the Chief
+Referees signals at the
+commencement or
+completion of the lift . 
+Contact with bar or lifter by
+the spotters / loaders between
+the Chief Referees ’ signals , in
+order to make the lift easier . 
+Contact of elbows or upper
+arms with the legs , which has
+supported and been of aid to
+the lifter . 
+Slight contact that is of no aid
+may be ignored . 
+Any dropping or dumping of
+the bar after completion of the
+lift . 
+Heaving , or Sinking the bar
+after it has been motionless
+on the chest or abdominal
+area , in such a way as to aid
+the lifter . 
+Failure to observe the Chief
+Referees signals at the
+commencement , during or
+completion of the lift .
+ Utilizing upper body thrust
+to initiate upward
+movement of the bar from
+the chest . 
+Any change in the elected
+lifting position during the lift
+proper , i . e . , any raising
+movement of the head ,
+shoulders , or buttocks from
+their original points of
+contact with the bench , or
+lateral movement of the
+hands on the bar . 
+ 
+Lowering the bar before
+receiving the Chief Referees
+signal . 
+Allowing the bar to return to the
+platform without maintaining
+control with both hands , i . e .
+releasing the bar from the
+palms of the hand . 
+Stepping backward or forward
+or moving the feet laterally .
+Rocking the feet between the
+ball and heel is permitted . Foot
+movement after the command
+“ Down ” will not be cause for
+failure .
+Failure to comply with any of
+the requirements contained in
+the general description of the
+lift , which precedes this list of
+disqualification . 
+0 1 . 0 3 . 2 0 2 6
+Equipment and specifications
+
+Failure to comply with any of
+the requirements contained in
+the general description of the
+lift , which precedes this list of
+disqualification . 
+Incomplete lift 
+Contact with the bar or the
+lifter by the spotters / loaders
+between the Chief Referees
+signals , in order to make the
+lift easier . 
+Any contact of the lifter ’ s feet
+with the bench or its
+supports . Deliberate contact
+between the bar and the bar
+rest supports during the lift in
+order to make the lift easier . 
+Failure to comply with any of
+the requirements contained
+in the general description of
+the lift , which precedes this
+list of disqualification . 
+Incomplete lift
+Incomplete lift 
+1 2
+A clearly visible and detailed scoreboard must be provided for spectators , officials , and all parties
+involved in the competition . The lifters names should be arranged by lot numbers for each
+session . The current record must be displayed and up - dated as necessary
+0 1 . 0 3 . 2 0 2 6
+Equipment and specifications
+CHAMPIONSHIPS SCOREBOARD
+GROUP : SQUATBENCH PRESSDEADLIFT
+LOTNAMENAT
+B D /  
+W T
+RD 1 RD 2 RD 3 RD 1 RD 2 RD 3
+S U B
+T O T
+RD 1 RD 2 RD 3 TOTPLACE
+
+. .
+1 4
+2 . 1 0 . SCOREBOARD
+
+1 3
+3 . PERSONAL EQUIPMENT
+3 . 1 .  S U I T S
+SUPPORTIVE
+A supportive lifting suit may be worn only in competitions which are designated as Equipped . A
+supportive lifting suit may be worn for all lifts in competitions which are designated as an
+Equipped ( in which a non - supportive lifting suit may instead be worn ) . 
+The suit - straps must be worn over the lifter ’ s shoulders at all times in all lifts in all competitions .
+Only supportive lifting suits from manufacturers accepted onto the “ Approved List of Apparel
+and Equipment for Use at IPF Competitions ” shall be permitted for use in competitions . In
+addition , any such supportive suits from Approved manufacturers must meet all the
+specifications of the IPF Technical Rules ; supportive suits from Approved manufacturers which
+breach any IPF Technical Rule shall not be permitted for use in competitions . 
+The supportive lifting suit must conform to the following specifications : 
+( a ) The suit ’ s material shall be of a single thickness . 
+( b ) There must be legs to the suit , extending a minimum of 3 cm and a maximum of 1 5 cm , from
+the top of the crutch down the inside of the leg , as measured when worn by the lifter in a
+standing position . 
+( c ) Any alteration to the costume which exceeds the established widths , lengths or thickness
+previously stated shall make the suit illegal for competition . 
+( d ) Alterations in the form of pleats made to tighten suits or supportive shirts are permitted ,
+provided they are made only along the manufacturer ’ s original seams . Non - factory alterations to
+tighten suits and shirts are not illegal when done in the form of pleats . However , the pleats must
+be made only on the manufacturer ’ s original seams . These pleats must be made on the inside of
+the suit or shirt . Any alterations made on areas other than the manufacturer ’ s seams are illegal .
+Pleats may not be sewn back onto the body of the garment . 
+( e ) Where a tightening has been made in the shoulder straps and the excess material is longer
+than 3 cm ’ s , this must then be turned inside the suit and not sewn back onto the straps . No more
+than 3 cm length may protrude outside the suit .
+( f ) The suit may bear the logos or emblems
+ of the approved manufacturer of the suit 
+of the lifter ’ s nation 
+of the lifter ’ s name 
+as per the rule “ Sponsor ’ s Logos ” 
+In national and lower - level contests only , of the lifter ’ s club or individual sponsor , where that
+logo or emblem has not otherwise been approved by the IPF . 
+0 1 . 0 3 . 2 0 2 6
+Personal equipment
+
+1 4
+SINGLET ( NON - SUPPORTIVE )
+A singlet ( non - supportive lifting suit ) shall be worn in competitions which are designated as
+Classic / Raw and may be worn in competitions which are designated as Equipped ( in which a
+supportive lifting suit may instead be worn ) . 
+The singlet straps must be worn over the lifter ’ s shoulders at all times in all lifts in all
+competitions . Only singlets ( non - supportive ) from manufacturers accepted onto the “ Approved
+List of Apparel and Equipment for Use at IPF Competitions ” shall be permitted for use in
+competitions . In addition , any such singlets ( non - supportive ) from approved manufacturers must
+meet all the specifications of the IPF Technical Rules ; any singlets from an approved
+manufacturer that breaches an IPF Technical Rule and shall not be permitted for use in
+competitions . 
+The singlet ( non - supportive ) must 
+conform to the following specifications : 
+( a ) The singlet shall be one - piece and form fitting 
+without any looseness when worn . Lifters can 
+wear approved long - legged singlets . 
+Whichever type of singlet a lifter wears for squat , 
+they must wear the same singlet throughout
+ all disciplines . 
+( b ) It is permitted to wear knee sleeves over a long - legged singlet ; however , knee sleeves
+may not be worn under the singlet . The Technical Controller must verify that no knee
+sleeves are worn beneath the singlet . Deadlift socks may be worn over a long - legged
+singlet but are not mandatory . 
+( c ) The singlet must be constructed entirely of fabric or a synthetic textile material , such that no
+support is given to the lifter by the singlet in the execution of any lift . 
+( d ) The singlet ’ s material shall be of a single thickness , other than a second thickness of material
+of up to 1 2 cm x 2 4 cm allowed in the area of crotch . 
+( e ) There must be legs to the singlet , extending a minimum of 3 cm and a maximum of 2 5 cm ,
+from the top of the crotch down the inside of the leg , as measured when worn by the lifter in a
+standing position . 
+( f ) The singlet may bear the logos or emblems :
+ of the approved manufacturer of the singlet
+of the lifter ’ s nation of the lifter ’ s name 
+as per rule “ Sponsor ’ s Logos ” 
+in national and lower - level contests only , of the lifter ’ s club or individual sponsor , where that
+logo or emblem has not otherwise been approved by the IPF .
+3 . 2 .  T - S H I R T
+A t - shirt must be worn under the lifting singlet by all lifters in the Squat , Bench Press and
+Deadlift . The only exception to those requirements is that a Supportive shirt is permitted to be
+worn instead of a t - shirt as per rule “ Supportive Shirts ” below ; a combination of t - shirt and
+supportive shirt is not allowed . 
+0 1 . 0 3 . 2 0 2 6
+Personal equipment
+
+1 5
+The t - shirt must conform to the following specifications : 
+( a ) the shirt must be constructed entirely of fabric or a synthetic textile and shall not consist , in
+whole or part , of any rubberized or similar stretch material , nor have any reinforced seams or
+pockets , buttons , zippers or other than a round neck collar . 
+( b ) the t - shirt must have tight fit “ Form Fitting ” sleeves . Those sleeves must terminate below the
+lifter ’ s deltoid and must not extend onto or below the lifter ’ s elbow . The sleeves may not be
+pushed or rolled up onto the deltoid when the lifter is competing . See pictures below . 
+ 
+3 . 3 . SUPPORTIVE SHIRTS
+A supportive shirt which has been accepted onto the “ Approved List of Apparel and Equipment
+for Use at IPF Competitions ” may be worn only at competitions designated as Equipped . 
+The supportive shirt must be conformed to the following specifications : 
+( a ) the shirt must be constructed entirely of fabric or a synthetic textile and shall not consist , in
+whole or part , of any rubberized on similar stretch material , nor have any reinforced seams or
+pockets , buttons , zippers or other than a round neck collar 
+( b ) the shirt must have sleeves . Those sleeves must terminate below the lifter ’ s deltoid and must
+not extend onto or below the lifter ’ s elbow . The sleeves may not be pushed or rolled up onto the
+deltoid when the lifter is competing . 
+( c ) the t - shirt may be plain i . e . , of a multi - color
+and with no logos or emblems , or may bear
+the logo or emblem
+of the lifter ’ s name
+ of the lifter ’ s nation
+of the lifter ’ s IPF region 
+of the event in which the lifter is
+competing
+ as per the rule “ Sponsor ’ s Logos ” 
+in national and lower - level contests only ,
+the lifter ’ s club or individual sponsor , where
+that logo or emblem has not otherwise
+been approved by the IPF .
+( c ) the shirt may be plain i . e . of a single color and
+with no logos or emblems , or may bear the logo or
+emblem :
+of the lifter ’ s nation 
+of the lifter ’ s name 
+of the event in which the lifter is competing 
+in national and lower - level contests only , the
+lifter ’ s club or individual sponsor , where that
+logo or emblem has not otherwise been
+approved by the IPF . 
+( d ) any manipulation or doctoring of the supportive shirt from the original design as supplied by
+the manufacturer and approved by The Technical Committee will render the shirt illegal for use
+in competition . The material must cover the whole of the deltoid area as arrowed 2 .
+NOYES
+0 1 . 0 3 . 2 0 2 6
+Personal equipment
+
+1 6
+A standard commercial “ athletic supporter ” or standard commercial briefs of any mixture of
+cotton , nylon or polyester shall be worn under the lifting suit . Women may also wear a
+commercial or sports bra . 
+Swimming trunks or any garment consisting of rubberized or similar stretch material except in
+the waistband , shall not be worn under the lifting costume . 
+Any supportive undergarment is not legal for use in IPF competition . 
+3 . 4 . BRIEFS
+3 . 5 .  S O C K S
+Socks may be worn . 
+( a ) They may be of any color or colors and may have manufacturer ’ s logos . 
+( b ) They shall not be of such length on the leg that they come into contact with the knee wraps
+or knee cap supporter . 
+( c ) Full length leg stockings , tights or hose are strictly forbidden . 
+Shin length socks must be worn to cover and protect the shins while performing the deadlift . 
+3 . 6 .  B E L T
+Competitors may wear a belt . If worn , it shall be on the outside of the lifting suit . Only belts from
+manufacturers accepted onto the “ Approved List of Apparel and Equipment for Use at IPF
+Competitions ” shall be permitted for use in competitions . 
+Materials and Construction : 
+( a ) The main body shall be made of leather , vinyl or other similar non - stretch material in one or
+more laminations which may be glued and / or stitched together . 
+( b ) It shall not have additional padding , bracing or supports of any material either on the surface
+or concealed within the laminations of the belt . 
+( c ) The buckle shall be attached at one end of the belt by means of studs and / or stitching . 
+( d ) The belt may have a buckle with one or two prongs or “ quick release ” type ( “ quick release ”
+referring to lever . ) 
+( e ) A tongue loop shall be attached close to the buckle by means of studs / or stitching . of the
+lifter ’ s nation 
+( f ) The belt may be plain i . e . of a single or two or more colors and with no logos , or may bear the
+logo or emblem 
+of the lifter ’ s name 
+as per the rule “ Sponsor ’ s Logos ” 
+in national and lower - level contests only , the lifter ’ s club or individual sponsor , where the logo
+or emblem has not otherwise been approved by the IPF . 
+0 1 . 0 3 . 2 0 2 6
+Personal equipment
+
+1 7
+Dimensions : 
+1 . Width of belt maximum 1 0 cm . 
+2 . Thickness of belt maximum 1 3 mm along
+the main length . 
+3 . Inside width of buckle maximum 1 1 cm . 
+4 . Outside width of buckle maximum 1 3 cm . 
+5 . Tongue loop maximum width 5 cm . 
+6 . Distance between end of belt and far end
+of tongue loop maximum 2 5 cm .
+Shoes or boots shall be worn . 
+( a ) Shoes shall be taken to include only indoor sports shoes / sports boots ;
+Weightlifting / Powerlifting boots or Deadlift slippers . The above is referring to indoor sports e . g .
+wrestling / basketball . Hiking boots do not fall into this category 
+( b ) The sole thickness shall not exceed 5 cm at any point . 
+( c ) The underside must be flat i . e . no projections , irregularities , or modification of the standard
+design 
+( d ) Loose inner soles that are not part of the manufactured shoe shall be limited to one -
+centimeter thickness . 
+( e ) Socks with a rubber outside sole lining are not allowed in disciplines - Squat / Bench
+Press / Deadlift . 
+( f ) Shoes must be properly fastened ( laces tied or velcro straps secured ) when the lifter is on the
+platform . 
+3 . 7 . SHOES OR BOOTS
+3 . 8 . KNEE SLEEVES
+Sleeves , being cylinders of neoprene , may be worn only on the knees by the lifter in the
+performance of any lift in competition ; sleeves cannot be worn or used on any part of the body
+other than the knees . Knee sleeves cannot be worn where the lifter also wears knee wraps , as
+per the rule “ Wraps ” below . Only knee sleeves from manufacturers accepted onto the “ Approved
+List of Apparel and Equipment for Use at IPF Competitions ” shall be permitted for use in
+competitions . In addition , any such sleeves from approved manufacturers must meet all the
+specifications of the IPF Technical Rules ; knee sleeves which breach any IPF Technical Rule shall
+not be permitted for use in competitions . 
+Knee sleeves must conform to the following specifications : 
+( a ) The sleeves must be constructed entirely of a single ply of neoprene , or predominantly of a
+single ply of neoprene plus a non - supportive single layer of fabric over the neoprene . There may
+be stitched seams of the fabric and / or of the fabric onto the neoprene . The entire construction of
+the sleeves may not be such as to provide any appreciable support or rebound to the lifter ’ s
+knees ; 
+( b ) Knee sleeves shall be of a maximum thickness of 7 mm and a maximum length of 3 0 cm . 
+( c ) Knee sleeves shall not have any additional strapping , Velcro , drawstrings , padding or similar
+supportive devices in or on them . Knee sleeves must be continuous cylinders , without holes in
+the neoprene or in any covering material ; 
+( d ) When worn by the lifter in competition , knee sleeves must not be in contact with the lifter ’ s
+suit ( other than long - legged ) or socks and must be centered over the knee joint . 
+( e ) Athletes are permitted to receive personal assistance in the application of their knee
+sleeves . 
+( f ) It is permitted to wear knee sleeves over a long sleeve singlet , but not under the singlet . 
+0 1 . 0 3 . 2 0 2 6
+Personal equipment
+
+1 8
+Only wraps of one ply commercially woven elastic that is covered with polyester , cotton or a
+combination of both of those materials or medical crepe are permitted . Supportive wraps : Only
+wraps from commercial manufacturers officially registered and approved by the Technical
+Committee shall be permitted for use in powerlifting competitions . 
+Non - supportive wraps : Wraps made of medical crepe or bandage do not require Technical
+Committee approval .
+3 . 9 .  W R A P S
+WRIST
+ Wrists wraps shall not exceed 1 m in length and 8 cm in width . Any sleeves and Velcro
+patches / tabs for securing must be incorporated within the one - meter length . A loop may be
+attached as an aid to securing . The loop shall not remain over the thumb or fingers during the
+actual lift . A combination of wrist wraps and sweat bands is not allowed 
+A wrist covering shall not extend beyond 1 0 cm above and 2 cm below the center of the wrist
+joint and shall not exceed a covering width of 1 2 cm . 
+KNEE
+Wraps not exceeding 2 m in length and 8 cm in width may be worn only in competitions
+which are designated as Equipped . A knee wrap shall not extend beyond 1 5 cm above and 1 5
+cm below the center of the knee joint and shall not exceed a total covering width of 3 0 cm .
+IPF approved knee sleeves are allowed . A combination of the two is strictly forbidden .
+Neoprene may be “ synthetic rubber ” , but is only acceptable in the knee sleeve . 
+Wraps shall not be in contact with socks or lifting suit . 
+Wraps shall not be used elsewhere on the body . 
+3 . 1 0 . HEAD WEAR
+ Hats are strictly forbidden to be worn on the platform during lifting . 
+Lifters may wear Hijab ( head scarf ) while lifting . In Bench Press the Jury or Referees may
+require the lifter to affix her hair accordingly to the performance of the Bench Press . 
+Standard commercial sweat bands one color ( Black or White ) may be worn , not exceeding 1 2
+cm in width . A combination of wrist wraps and sweat bands is not allowed . 
+3 . 1 1 . MEDICAL TAPE
+Two layers of medical tape may be worn around the thumbs . Medical tape or its like may not
+be worn anywhere else on the body without official permission of the Jury , or Chief Referee .
+Medical tape may not be used as aids to the lifter in holding the bar . 
+Contingent upon prior approval by the Jury , Official Doctor , Paramedic or Paramedical
+personnel on duty medical tape may be applied to bodily injuries in a fashion that would not
+grant the lifter an undue advantage . 
+At all competitions where a jury may not be present and no medical personnel are on duty .
+The Chief Referee shall have jurisdiction over the use of medical tape . 
+0 1 . 0 3 . 2 0 2 6
+Personal equipment
+
+1 9
+( a ) The inspection of personal equipment for each and every lifter in the competition may take
+place at any time ( times may be announced at the Technical Meeting ) throughout the meet prior
+to within thirty minutes of the start for their particular bodyweight category . 
+( b ) A minimum of two referees shall be appointed to fulfill this duty . All items shall be examined
+and approved before being officially stamped or marked . 
+( c ) Wraps over permitted length shall be rejected but may be cut to the correct length and
+resubmitted . 
+( d ) Any item considered unclean or torn shall be rejected . 
+( e ) The signed inspection sheet shall be handed to the president of the Jury at the end of the
+inspection period . 
+( f ) If after the inspection a lifter appears on the platform wearing or using any illegal item , other
+than that which may have inadvertently been passed by the referees , the lifter shall immediately
+be disqualified from the competition . 
+( g ) Referees shall also reject any knee sleeves that have been put on the lifter with the
+assistance of any other person or method , such as the use of plastic sliding devices , the use
+of lubricants etc . Socks are however permitted to put knee sleeves on . 
+Athletes are permitted to receive personal assistance in the application of their knee
+sleeves . 
+( g ) All items mentioned previously under personal equipment shall be inspected . ( i ) Items such
+as watches , costume jewelry , mouthpieces , eye wear and feminine hygiene articles need not be
+inspected . 
+( h ) Before attempting a world record the lifter will be inspected by the Technical Controller . If the
+lifter is found to be wearing or using any illegal item , other than that which may have
+inadvertently been passed by the referees , the lifter shall be disqualified from the competition . 
+( i ) Referees and the Technical Controller for their particular bodyweight category must assemble
+five minutes prior to the start of the inspection of personal equipment . 
+3 . 1 2 . INSPECTION OF PERSONAL EQUIPMENT 
+3 . 1 3 . SPONSOR ’ S LOGOS
+( a ) Over and above manufacturers logos and emblems listed on the “ Approved List of Apparel
+and Equipment for Use at IPF Competitions ” , a nation or lifter may apply to the IPF Secretary
+General for permission for an additional logo or emblem to be listed as approved for display on
+items or personal equipment , for that applicant nation or lifter only . Such logo or emblem
+applications must be accompanied by a fee of an amount determined by the IPF Executive . The
+IPF , via the Executive , may approve the logo or emblem , but shall have the right to decline
+approval should , in the Executive ’ s opinion , the logo or emblem compromise any commercial
+interest of the IPF or to fail to meet standards of good taste . The Executive shall also have the
+right , in its approval , to limit the size . or position on any item of personal equipment , or a logo or
+emblem . 
+Any approval given shall remain in place from the date of that approval through the remainder of
+that calendar year and for the whole of the following calendar year , after which time a further
+application and fee payment must be made if the logo or emblem to remain approved . 
+0 1 . 0 3 . 2 0 2 6
+Personal equipment
+
+2 0
+Logos or emblems approved under this rule shall be listed in an addendum to the “ Approved List
+of Apparel and Equipment for Use at IPF Competitions ” ; also , the IPF Secretary General shall issue
+a letter of approval to successful applicants , that letter illustrating the approved logo or emblem
+and stating the date of approval and any limitations on the approval , such letter being
+acceptable proof for Referees at competitions of a valid approval . The logos or emblems of
+manufacturers not on the “ Approved List of Apparel and Equipment for Use at IPF Competitions ”
+nor on the addendum of approved logos or emblems established by this rule “ Sponsor ’ s Logos ” ,
+may be worn only on t - shirts , shoes or socks , where the logo or emblem is printed or
+embroidered and is no more than 5 cm x 2 cm in size . 
+3 . 1 4 . GENERAL
+( a ) The use of oil , grease or other lubricants on the body , or personal equipment is strictly
+forbidden . 
+( b ) Baby powder , resin , talc or magnesium carbonates are the only substances that may be
+added to the body and attire , but not to the wraps . 
+( c ) The use of any form of adhesive on the underside of footwear is strictly forbidden . This applies
+to any built - in adhesive , e . g . glass paper , emery cloth , etc . and to include resin and magnesium
+carbonate . A spray of water is acceptable . 
+( d ) No foreign substances may be applied to the powerlifting equipment . This takes into account
+all substances other than that which may be used periodically as a sterile agent in the cleaning of
+the bar , bench , or platform . 
+( e ) Light protective guards between sock and shin may be worn . 
+( f ) Athletes are allowed to wear necklaces and similar accessories . No part of the necklace or
+accessory shall be placed In the mouth while on the platform . A pendant or charm may be
+worn either over or under the T - shrt ; however , If deemed to create a safety concern or
+Interfere with the lift , the Referee may require It to be secured under the T - shirt or removed .
+4 . POWERLIFTING AND RULES OF PERFORMANCE 
+4 . 1 .  S Q U A T
+1 ) The lifter shall face the front of the platform , with the
+barbell placed horizontally across the shoulders , at a
+height no lower than the posterior deltoid level . hands
+and fingers gripping the bar The lifter ’ s hands , thumbs , and
+fingers must be in complete contact with the bar while it
+is positioned in the rack stands and starting and lift
+completion position . The thumbs are not required to
+wrap around the bar . However , the hands , thumb , and
+fingers must remain in complete contact with the bar or
+the duration of the lift . The hands may be positioned
+anywhere on the bar inside and or in contact with the inner
+collars . 
+NOYES
+NOYES
+0 1 . 0 3 . 2 0 2 6
+Powerlifting and rules of performance
+
+2 1
+2 ) After removing the bar from the racks , ( the lifter may be aided in removal of the bar from the
+racks by the spotter / loaders ) the lifter must move backwards to establish the starting position .
+When the lifter is motionless , erect ( slight deviation is allowable ) with knees locked the Chief
+Referee will give the signal to begin the lift . The signal shall consist of a downward movement of
+the arm and the audible command “ Squat ” . Before receiving the signal to “ squat ” the lifter may
+make any position adjustments within the rules , without penalty . For reasons of safety the lifter
+will be requested to “ Replace ” the bar , together with a backward movement of the arm , if after a
+period of five seconds he is not in the correct position to begin the lift . The Chief Referee will then
+convey the reason why the signal was not given . 
+3 ) Upon receiving the Chief Referee ’ s signal , the lifter must bend the knees and lower the body
+until the top surface of the legs at the hip joint is lower than the top of the knees . Only one
+descent attempt is allowed . The attempt is deemed to have commenced when the lifters knees
+have unlocked . 
+4 ) The lifter must recover at will to an upright position with the knees locked . Double bouncing at
+the bottom of the squat attempt or any downward movement is not permitted . When the lifter is
+motionless ( in the apparent final position ) the Chief Referee will give the signal to rack the bar . 
+5 ) The signal to rack the bar will consist of a backward motion of the arm and the audible
+command “ Rack ” . The lifter must then return the bar to the racks . Foot movement after the rack
+signal will not be cause for failure . For reasons of safety the lifter may request the aid of the
+spotter / loaders in returning the bar to , and replacing it in the racks . The lifter must stay with the
+bar during this process . The lifter is not allowed to walk out through the front of the rack after
+completion of the lift . 
+6 ) Not more than five and not less than two spotter / loaders shall be on the platform at any time .
+The Referees may decide the number of spotter / loaders required on the platform at any time 2 , 3 ,
+4 ,  o r  5 .  
+4 . 1 . 1 . CAUSES FOR DISQUALIFICATION OF A SQUAT
+The diagrams below indicate the typical bar position 
+but not obligatory and required depth in the squat : 
+1 ) Failure to observe the Chief Referee ’ s signals at the commencement or completion of a lift .
+2 ) Double bouncing at the bottom of the lift , or any downward movement during the ascent .
+3 ) Failure to assume an upright position with the knees locked at the commencement or
+completion of the lift .
+4 ) Stepping backward or forward or moving the feet laterally . Rocking the feet between the ball
+and heel is permitted . 
+5 ) Failure to bend the knees and lower the body until the top surface of the legs at the hip joint is
+lower than the top of the knees , as in the diagram . 
+6 ) Contact with the bar or the lifter by the spotter / loaders between the Chief Referee ’ s signals in
+order to make the lift easier . 
+7 ) Contact of the elbows or upper arms
+with the legs . Slight contact is permitted
+if there is no supporting that might aid
+the lifter . 
+8 ) Any dropping or dumping of the bar
+after completion of the lift . 
+9 ) Failure to comply with any of the items
+outlined under Rules of Performance for
+the squat .
+0 1 . 0 3 . 2 0 2 6
+Powerlifting and rules of performance
+
+2 2
+4 . 2 . BENCH PRESS
+1 ) The bench shall be placed on the platform with the head facing the front or angled up to 4 5
+degrees . The Chief Referee shall position himself on the head side of the bench press rack . The
+lifter is not allowed to enter the rack from the head side of the bench press rack . 
+2 ) The lifter must lie on their back with the head , shoulders , and buttocks ( the picture PROPER
+STARTING POSITION & SETUP show the minimum acceptable ) in contact with the bench surface .
+The feet must be flat on the floor ( as flat as the shape of the shoe will allow ) . Hands , thumbs and
+fingers must completely grip the bar positioned in the rack stands with a thumb around
+grip . This position shall be maintained throughout the lift . Foot movement is permissible but
+must remain flat on the platform . During the set - up on the bench , the athlete is not allowed to
+place his / her feet on the bench . The hair must not hide the back of the head when lying down on
+the bench . The Jury or Referees may require the lifter to affix his / her hair accordingly . 
+3 ) To achieve firm footing the lifter may use flat surfaced plates , or blocks not exceeding 3 0 cm in
+total height and a minimum dimension of 6 0 cm x 4 0 cm , to build up the surface of the platform .
+Blocks in the range of 5 cm , 1 0 cm , 2 0 cm , and 3 0 cm , should be made available for foot
+placement at all international competitions . 
+4 ) Not more than five and not less than two spotter / loaders shall be on the platform at any time .
+After correctly positioning himself , the lifter may enlist the help of the spotter / loaders in
+removing the bar from the racks . If assisted , the lift - off by the spotter / loaders must bring the bar
+to arm ’ s length . 
+5 ) The spacing of the hands shall not exceed 8 1 cm measured between the forefingers ( both
+forefingers must be within the 8 1 cm marks and the whole of the forefingers must be in contact
+with the 8 1 cm marks if maximum grip is used ) . The use of the reverse grip is forbidden . 
+6 ) After removing the bar from the racks , with or without the help of the spotter / loaders , the
+lifter shall wait with straight arms elbows locked for the Chief Referee ’ s signal . The signal shall be
+given as soon as the lifter is motionless and the bar properly positioned . For reasons of safety the
+lifter will be requested to “ Replace ” the bar , together with a backward movement of the arm , if
+after a period of five seconds he is not in the correct position to begin the lift . The Chief Referee
+will then convey the reason why the signal was not given . 
+7 ) The signal to begin the attempt shall consist of a downward movement of the arm together
+with the audible command “ Start ” . 
+8 ) After receiving the signal , the lifter must lower the bar to the chest or abdominal area whereby
+the underside of both elbow joints is lowered level with or below the top surface of each
+respective shoulder joint ( the bar shall not touch the belt ) , hold it motionless , after which the
+Chief Referee will signal the audible command “ Press ” . The lifter must then return the bar to
+straight arms ’ length elbows locked . When held motionless in this position the audible
+command “ Rack ” shall be given together with a backward motion of the arm . If the bar is lowered
+to the belt or does not touch the chest or abdominal area , the Chief Referee ´ s command is
+“ R a c k ” .  
+9 ) The height of the safety racks can be adjusted by the jury for safety reasons .
+0 1 . 0 3 . 2 0 2 6
+Powerlifting and rules of performance
+
+2 3
+GOOD LIFT
+GOOD LIFT
+NO LIFT
+NO LIFT
+0 1 . 0 3 . 2 0 2 6
+Powerlifting and rules of performance
+
+2 4
+PICTURE A - PROPER STARTING POSITION & SETUP 
+4 . 2 . 1 . CAUSES FOR DISQUALIFICATION OF A BENCH PRESS
+1 ) Failure to observe the Chief Referee ’ s signals at the commencement , during or completion of
+the lift . 
+2 ) Any change in the elected lifting position during the lift proper i . e . any raising movement of
+the head , shoulders , or buttocks , from the bench , or lateral movement of hands on the bar . 
+3 ) Heaving or Sinking the bar into the chest or abdominal area after it is motionless in such a way
+as to make the lift easier . 
+4 ) Utilizing upper body thrust to initiate upward movement of the bar from the chest . 
+5 ) Any downward movement of the whole of the bar in the course of being pressed out . 
+6 ) Bar is not lowered to chest or abdominal area i . e . not reaching the chest or abdominal area , or
+the bar is touching the belt . 
+7 ) Failure to press the bar to straight arms ’ length elbows locked at the completion of the lift . 
+8 ) Contact with the bar or the lifter by the spotter / loaders between the Chief Referee ’ s signals , in
+order to make the lift easier . 
+9 ) Any contact of the lifter ’ s feet with the bench or its supports . Lifting of the feet is not allowed .
+Foot movement is permissible but must remain flat on the platform . 
+1 0 ) Deliberate contact between the bar and the bar rests support . 
+1 1 ) Failure to lower the underside of both elbow joints level with or below the top surface of each
+respective shoulder joint 
+1 2 ) Failure to comply with any of the items outlined under the Rules of Performance .
+4 . 2 . 2 . RULES FOR THE DISABLED ATHLETES COMPETING IN IPF
+SINGLE LIFT BENCH PRESS CHAMPIONSHIPS 
+Bench press championships shall be organized without a special division for disabled lifters e . g .
+blind , sight impaired , mobility impaired . They may be assisted to , and from , the bench . Assisted
+to mean “ with the help of the coach or / and with use of crutches , sticks / canes or wheelchair ” . The
+rules of competition apply equally to that of the able bodied . For lifters who have an amputated
+lower limb , a prosthetic device shall be considered the same as the natural limb . The lifter shall be
+weighed in without the device , with compensatory weight added according to the established
+fraction chart . Refer to WEIGHING IN item 5 . 
+For lifters with dysfunctional lower limbs that require leg braces or similar devices for walking , the
+device shall be considered as part of the natural limb and the lifter shall be weighed in wearing
+the device . 
+0 1 . 0 3 . 2 0 2 6
+Powerlifting and rules of performance
+
+2 5
+4 . 3 . DEADLIFT
+1 ) The lifter shall face the front of the platform with the bar laid horizontally in front of the lifter ’ s
+feet , gripped with an optional grip in both hands and lifted until the lifter is standing erect . 
+2 ) On completion of the lift the knees shall be locked in a straight position . The front bundle
+of the deltoid muscle should be placed behind the imaginary projection of the bar . ( See the
+picture ) 
+3 ) The Chief Referee ’ s signal shall consist of a downward movement of the arm and the audible
+command “ Down ” . The signal will not be given until the bar is held motionless and the lifter is in
+the apparent finished position . 
+4 ) Any rising of the bar or any deliberate attempt to do so will count as an attempt . Once the
+attempt has begun no downward movement is allowed until the lifter reaches the erect position
+with the knees locked . If the bar settles as the shoulders come back ( slightly downward on
+completion ) this should not be reason to disqualify the lift . 
+SCHEMATIC REPRESENTATION OF THE CORRECT 
+SHOULDER ’ S ABDUCTION IN THE FINAL POSITION OF
+THE DEADLIFT 
+A - THE FRONT BUNDLE OF THE
+DELTOID MUSCLE 
+B – THE BAR 
+RED STRAIGHT LINE – IMAGINARY
+PROJECTION OF THE BAR 
+α – the deflection angle 
+THE DIAGRAM BELOW SHOWS THE SUPPORTING OF
+THE BAR ON THE THIGHS
+4 . 3 . 1 . CAUSES FOR DISQUALIFICATION OF A DEADLIFT 
+1 ) Any downward movement of the bar before it reaches the final position . 
+2 ) Failure to stand erect with the shoulders back . 
+3 ) Failure to lock the knees straight at the completion of the lift . 
+4 ) Supporting the bar on the thighs during the performance of the lift . If the bar edges up the
+thigh but is not supported this is not a reason for disqualification . The lifter should benefit in all
+decisions of doubt made by the referee . 
+5 ) Stepping backward or forward or moving the feet laterally . Rocking the feet between the ball
+and heel is permitted . Foot movement after the command “ Down ” will not be cause for failure . 
+0 1 . 0 3 . 2 0 2 6
+Powerlifting and rules of performance
+
+1 ) Weighing in of the competitors must take place no earlier than two hours before the start of
+the competition for a particular category / category . All lifters in the category / categories must
+attend the weigh in , which will be carried out in the presence of two / three appointed referees .
+Weight categories may be combined in a single lifting session . 
+2 ) If not already done , lots will be drawn to establish the order of weigh in . The lots drawn also
+establish the order of lifting throughout the competition when lifters require the same weights
+for their attempts . 
+3 ) The weigh in period will last one and a half hours . 
+4 ) The weigh in for each competitor will be carried out in a room with the door closed , with only
+the competitor , his their coach or manager of the same gender and the two / three referees
+present . For reasons of hygiene the lifter should wear socks / paper towel on the scale ’ s platform .
+Lifters need to identify himself / herself themselves with an ID / Passport . 
+5 ) Lifters may be weighed nude or in underwear which complies with the specifications set out
+in the appropriate section of the IPF and which does not materially affect
+the lifters bodyweight . Minimal clothing , for purposes of weigh - in , shall be strictly limited
+to : ( a ) The approved lifting singlet . ( b ) One approved t - shirt ( if applicable to the division ) : ( c )
+Standard underwear compliant with IPF specifications ; and ( d ) No footwear . If a question
+exists regarding weight of undergarments the clothing , a re - weigh in the nude lifter ’ s singlet
+may be requested . “ In competitions in which both sexes are competitors , the weigh in procedure
+may must be altered to ensure that lifters are weighed by officials of their own sex . Additional
+officials ( not necessarily referees ) may be appointed for this purpose ” 
+Disabled / Amputee lifters who are competing in bench press championships will have the
+following additions to their bodyweight : 
+For each below the ankle amputation 1 / 5 4 of bodyweight 
+For each below the knee amputation 1 / 3 6 of bodyweight
+ For each above the knee amputation 1 / 1 8 of bodyweight 
+ For each hip disarticulation 1 / 9 of bodyweight
+2 6
+6 ) Lowering the bar before receiving the Chief Referee ’ s signal . 
+7 ) Allowing the bar to return to the platform without maintaining control with both hands , i . e . ,
+releasing the bar from the palms of the hand . 
+8 ) Failure to comply with any of the items outlined under Rules of Performance 
+5 . WEIGHING IN
+For lifters with dysfunctional lower limbs that require leg braces or similar devices for walking , the
+device shall be considered as part of the natural limb and the lifter shall be weighed in wearing
+the device . 
+0 1 . 0 3 . 2 0 2 6
+Weighing in
+
+2 7
+6 ) Each lifter may only be weighed once . Only those whose bodyweight is heavier or lighter than
+the category limits of the category entered are allowed to return to the scales . They must return
+to the scales and make weight within the limits of the hour and a half allowed for the weigh in ;
+otherwise , they will be eliminated from the competition . A lifter can only be re - weighed as often
+as time and orderly progression by lots allows . A lifter may only be weighed outside the time limit
+of one and a half hours if he presents himself within the time limit , but due to the number of
+lifters trying to make weight , he is denied the opportunity of mounting the scales . He may then
+be allowed one re - weigh at the discretion of the referees . The lifter ’ s agreed bodyweight must
+not be made public until all lifters competing in the particular category / categories have been
+weighed in . 
+7 ) A lifter may only weigh in the category in which he was nominated 2 1 days prior to the meet
+date . In the case where groups are formed in a particular weight class the B and C groups may lift
+at a separate and earlier time to the A group . Where groups lift at separate times in this way the
+A group must have a minimum of 8 ( eight ) and a maximum of 1 4 ( fourteen ) lifters . 
+8 ) Lifters should check squat and bench press rack heights and foot blocks prior to the start of
+the competition . The rack height sheet must be signed or initialed after the check by the lifter or
+coach . It is in their interest . A copy of this official document goes to the Jury , Speaker , and
+Platform Manager . 
+6 . ORDER OF COMPETITION 
+6 . 1 . THE ROUND SYSTEM
+( a ) At the weigh in , the lifter or his coach must declare a starting weight for all three lifts . These
+must be entered on the appropriate first attempt card , signed by the lifter or his coach and
+retained by the official conducting the weigh in . The speaker ’ s card is deemed to be the
+appropriate first attempt card . The lifter will then be given eleven blank attempt cards for use
+during the competition . Three for the squat , three for the bench press , and five for the deadlift .
+Each lift distinguished by using a different colored card . Having made his first attempt at a lift ,
+the lifter or his coach must decide upon the weight required for his second attempt . This weight
+must be filled in were indicated upon the card and submitted to the competition secretary or
+other appointed official before the one - minute time allowance has elapsed . The same procedure
+is to be used for the second and third attempts on all three lifts .
+( b ) Responsibility for submitting attempts within the time limit rests solely with the lifter or his
+coach . Under the round system , the need for numerous marshals is eliminated , the attempt card
+being handed directly to the designated official . Examples of attempt cards are illustrated .
+Remember that the box for first attempts on the cards in the lifter ’ s possession is only to be used
+for the permitted first attempt change if required . Similarly , the fourth and fifth boxes on the
+deadlift card are only to be used for the two permitted changes on the third attempt deadlift if
+required . In single bench press competitions , a card similar to that of the deadlift will be used . 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+SPEAKER ’ S CARD
+NAME , SURNAME : BIRTH DATE :
+NATION : BODYWEIGHTLOT NUMBERWEIGHT CLASS
+IPF FORMULA
+SIGNATURE : LIFTER / COACH
+DISCIPLINE 1 ST ATTEMPT 2 ND ATTEMPT 3 RD ATTEMPTBEST ATTEMPT
+SQUAT
+BENCH PRESS
+DEADLIFT
+SUBTOTALSUBTOTAL
+DEADLIFT
+GROUPING 1 , 2 , 3 IPF POINTS
+PLACINGTOTAL
+2 8
+ATTEMPT CARDS
+Insert the Surname , Name
+Insert the chosen discipline & lot number
+1 , 2 , 3 Insert your chosen weight here 
+3 – 1 First changing 3 rd attempt . 
+3 – 2 Second changing 3 rd attempt .
+ ( b ) Where 1 0 or more lifters are competing in a session , groups may be formed consisting of
+approximately equal numbers of lifters . However , groups must be formed when 1 5 or more lifters
+are competing in the same session . A session can be composed of a single bodyweight category
+or any combination of bodyweight categories at the discretion of the organizer for purpose of
+presentation . In single lift Bench Press Championships groups of up to twenty ( 2 0 ) may be
+formed . Grouping shall be determined by examining the lifters ’ best totals achieved at national or
+international level during the previous twelve months . The lifters with the lowest totals will form
+the first group to lift with progressively higher totals forming further groups as necessary . Where
+a lifter has not provided a total for the previous twelve months , then that lifter shall automatically
+be placed in the first group to lift . 
+( c ) Each lifter will take his first attempt in the first round , his second attempt in the second round
+and his third attempt in the third round . 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+2 9
+( d ) When a group consists of less than 6 lifters , compensatory time allowances shall be added at
+the end of each round as follows : For 5 lifters add 1 minute ; 4 lifters add 2 minutes ; 3 lifters add 3
+minutes . 3 minutes is the maximum allowance permitted at the end of a round . Should a lifter
+follow himself when the compensatory clock is in operation , 3 minutes is the maximum
+allowance permitted . For compensatory time where groups are involved , unloading of the bar
+will take place at the end of the compensatory time , reloaded , then the one minute to begin the
+attempt . 
+( e ) The bar must be loaded progressively during each round on the principle of a rising bar . At no
+time will the weight on the bar be lowered within a round except for errors as described in item
+( i ) , and then only at the end of a round . 
+( f ) Lifting order within each round will be determined by the lifter ’ s choice of weight for that
+round . In the event of two lifters choosing the same weight , the lifter with the lowest lot number
+drawn at the weigh in , will lift first . The same applies to third round deadlift attempts , whereby
+the weight may be changed twice , subject to the bar not having already been loaded to the
+lifters originally chosen weight and the lifter having been called to the bar by the speaker .
+Example : 
+Lifter A with lot number 5 puts in 2 5 0 . 0 kg . 
+Lifter B with lot number 2 puts in 2 5 2 . 5 kg .
+Lifter A fails with 2 5 0 . 0 kg . 
+Can Lifter B drop the weight to 2 5 0 . 0 kg to win ? 
+No , the order of lifting is still determined by the lot number .
+( g ) If unsuccessful with an attempt , the lifter does not follow himself , but must wait until the next
+round before he can attempt that weight again . 
+( h ) If in a round an attempt is unsuccessful due to a wrongly loaded bar , spotter error , equipment
+failure or any other fault and through no fault of his own , the lifter will be granted a further
+attempt at the correct weight . The lifter shall take his extra attempt at the end of the round
+except if the lift is a record attempt , the lifter shall always follow himself no matter what round it
+is . If the lifter also happens to be the last lifter in the round , he shall be granted a three - minute
+rest prior to making his attempt , last but one in the round two minutes , last but two in the round
+one minute . In these cases where lifters are following themselves and given compensatory rest
+time the bar will be loaded as soon as the new attempt is turned in . The compensatory time will
+then be added to the usual one minute to begin the attempt . The clock will be started and the
+lifter will have that time to begin his attempt . Lifters following themselves will have four minutes
+time placed on the clock , during which time the lifter can begin his attempt as soon as he is
+ready . Lifters last but one in the round will be given three minutes , last but two in the round will
+be given two minutes , all others will be given the usual one minute to begin the attempt . In the
+third round of deadlifting and single bench press , if a lifter of any reason gets a new extra attempt
+by the jury , ( wrongly loaded bar , spotter error or equipment failure ) the lifter will be granted a
+further attempt at the correct weight , the lifter must be following him / herself . 
+( i ) A lifter is permitted one change of weight on the first attempt of each lift . The change of
+weight may be higher or lower than that originally submitted and the order of lifting in the first
+round will change accordingly . If he is in the first group , this change may take place at any time
+up to within three minutes before the start of the first round of that lift . The following groups are
+accorded a similar privilege up to within three attempts from the end of the previous group ’ s last
+round of that lift . Prior notice of these deadlines shall be announced by the speaker . If proper
+notice of these deadlines is not given , then an announcement authorizing such changes shall be
+made and a lifter may make a change within one minute of such announcement . 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+3 0
+( j ) A lifter must submit his second and third attempts within one minute of completing his
+preceding attempt . The one minute will begin from the time that the lights are activated . If no
+weight is submitted within the one - minute time allowance , the lifter will be granted a 2 . 5 kg
+increase on his next attempt . Should the lifter have failed his previous attempt and not submitted
+a weight for a further attempt within the one - minute time allowance , then the bar will be loaded
+to the failed weight .
+( k ) Weights submitted for second round attempts on all three lifts cannot be changed . Similarly ,
+third round attempts on the squat and bench press cannot be changed . Under this rule once an
+attempt is turned in , it cannot be withdrawn . The bar shall be loaded to the turned in weight and
+the clock will be run . 
+( l ) In the third round of the deadlift , two changes are permitted . The change of the weight may
+be higher or lower than the lifters previously submitted third attempt . However , these are only
+permitted provided that the lifter has not been called to the bar already loaded to his previously
+submitted weight by the speaker . 
+( m ) In bench press single lift competition rules in general are the same as for three lift
+competitions . However , in the third round , two weight changes are permitted and the rules as
+stated in ( m ) above for the deadlift apply equally here . 
+( n ) If a lifting session consists of a single group , i . e . , up to a maximum of 1 4 lifters , an interval of 2 0
+minutes shall be allowed between the lifts . This is to ensure adequate time for warm up and
+platform organization . 
+( o ) When two or more groups take part in a session upon a single platform , lifting will be
+organized on a group repetition basis . After the end of each discipline consisting of more than
+one group ( squat , bench press ) a time interval of 1 0 minutes is to be given between the
+disciplines . For example , if there are two groups taking part in a session , the first group will
+complete all three rounds of the squat . They will be followed immediately by the second group
+who will complete their three rounds of squat . The platform will then be set up for the bench
+press and the first group will complete their three rounds of the bench press , immediately
+followed by the second group who will similarly complete their three rounds of the bench press .
+The platform will then be set up for the deadlift and the first group will complete their three
+rounds of the deadlift , immediately followed by the second group who will similarly complete
+their three rounds of the deadlift . This system thus eliminates any time waste other than that
+necessary for arranging the platform between the lifts . 
+( p ) In competitions where designated international broadcast partners are present , the
+interval between disciplines ( Squat , Bench Press , and Deadlift ) can be adjusted . 
+The Technical Committee with the co - operation and assistance of the organizer will appoint the
+following officials : 
+( a ) Speaker / Announcer , a National or International Referee who is able to converse in English and
+that of the host nation . 
+( b ) Technical Secretary , an International Referee preferably able to converse and write in English
+and that of the host nation . 
+( c ) Time Keeper ( a qualified referee ) . 
+( d ) Marshals / Expeditors . 
+( e ) Scorers . 
+( f ) Spotter / Loaders . Correct code of dress - Meet t - shirt or regular t - shirt uniform in color . Track
+suit trousers uniform in color . Trainers or sports shoes . Athletic shorts may be worn in hot
+weather on the ruling of the jury . 
+( g ) Technical Controller ( a qualified international referee ) . 
+( h ) Additional officials may be appointed as required , e . g . doctors , paramedics etc . 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+3 1
+6 . 2 . RESPONSIBILITIES OF THE OFFICIALS 
+( a ) The Speaker is responsible for the efficient running of the competition . He acts as Master of
+Ceremonies and arranges the attempts chosen by the lifters in an orderly fashion , dictated by
+weight and , if necessary , lot number . He announces the weight required for the next attempt and
+the name of the lifter . When the bar is loaded and the platform cleared for lifting , the Chief
+Referee will indicate the fact to the Speaker . When the Speaker announces that the bar is ready
+and calls the lifter to the platform , the clock will begin . To clarify , - when the Speaker announces
+that the bar is “ ready / loaded ” , then the lifter is committed to the attempt . Attempts announced
+by the Speaker must be displayed upon the scoreboard erected in a prominent position , with the
+lifter ’ s names in order of lot number . 
+( b ) The Technical Secretary is responsible for attending the technical meeting prior to the
+competition . In the absence of the Technical Committee or a member of that committee the
+Technical Secretary will compile the Jury and Referee schedules from the names of those
+referees declared available for duty throughout the competition . He will complete the necessary
+“ Duty Referees and Jury Members ” lists for the competition and inform referees of categories to
+which they have been allocated . After the technical meeting when final team nominations have
+been compiled , the technical secretary will initiate a score sheet , non - itemized equipment check
+sheet , rack height sheet and order of weigh in sheet for each category in the competition ,
+entering the names of all lifters nominated in that category . Lots may also be drawn at this stage
+to establish weigh in and lifting order . He will also make out speaker competition cards for every
+lifter in the category . The above paperwork together with an adequate supply of lifter ’ s attempt
+slips / cards will be placed in the appropriate envelope for each bodyweight category in the
+competition and handed to the Chief Referee for that category . The Technical Secretary will
+attend each weigh in and advise the duty .
+( c ) Referees upon procedure and any matters that require attention . He should be an
+International Referee preferably from the host nation and able to deal with any problem that
+may arise due to language difficulties at the venue . It is the responsibility of the meet director to
+provide all necessary blank forms and paperwork to enable the Technical Secretary to carry out
+his work . A complete dossier on the job description together with all relative paperwork can be
+obtained from the Technical Committee free of charge available to all Meet Directors . 
+( d ) The time keeper is responsible for accurately recording the lapse between the announcement
+that the bar is ready and the lifter starting his attempt . He is also responsible for recording time
+allowances whenever required , e . g . after an attempt the lifter shall leave the platform within 3 0
+seconds . Once the clock is running for a lifter , it can only be stopped by the completion of a time
+allowance , by the start of the lift , or at the discretion of the Chief Referee . Consequently , it is of
+great importance that the lifter or his coach check the height of the squat racks prior to being
+called , as once the bar is announced as being ready , the clock will be started . Any further
+adjustments to the racks must be made within the lifter ’ s one - minute allowance , unless the lifter
+has nominated his rack height and this has been incorrectly set by the spotter / loaders . It is
+therefore essential that the rack height sheet be signed or initialed by the lifter or coach . This is
+an official document , which should verify in any dispute . The lifter is allowed one minute in which
+to start his attempt after the Speaker calls the lifter to the bar . 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+3 2
+If he does not start his attempt within this time allowance , the time keeper will call time and the
+Chief Referee shall give the audible command “ rack ” together with a backward movement of the
+arm . The lift will be declared “ no lift ” and the attempt forfeited . When the lifter starts the lift
+within the prescribed time allowance , the clock will be stopped . The definition of the start of an
+attempt depends upon the particular lift being performed . In the squat and bench press , the
+start is to coincide with the Chief Referee ’ s commencement signal . Refer to “ Referees ” item 3 . In
+the deadlift , the start is when the lifter makes a determined attempt to raise the bar . 
+( e ) Marshals / Expeditors are responsible for collecting the weight of required attempts from the
+lifters or their coaches and passing the information without delay to the Speaker . The lifter is
+allowed one minute between completing his last attempt and informing the speaker , via the
+Marshal , of the weight required for his next attempt . 
+( f ) Scorers are responsible for accurately recording the progress of the competition , and on
+completion , ensuring that the three referees sign the official score sheets , record certificates or
+any other document requiring signatures . Speaker to make an announcement to this effect
+before the referees disappear . 
+( g ) Spotter / loaders are responsible for loading and unloading the bar , adjusting squat racks and
+benches as required , cleaning the bar or platform at the request of the Chief Referee , and
+generally ensuring that the platform is well maintained and presents a neat and tidy appearance
+at all times . At no time shall there be less than two or more than five spotter / loaders on the
+platform . When the lifter prepares for his attempt , the spotter / loaders may assist him in removing
+the bar from the racks . They may also assist in replacing the bar after the attempt . However , they
+shall not touch the lifter or the bar during the actual attempt , i . e . , during the period of time that
+elapses between the commencement and completion signals . The only exception to this rule
+being that if the lift is in jeopardy and likely to result in injury to the lifter , the spotter / loaders may ,
+either at the request of the Chief Referee or the lifter himself , step in and relieve the lifter of the
+bar . If the lifter himself is deprived of an otherwise successful attempt by the error of a
+spotter / loader and through no fault of his own , he shall be awarded another attempt at the
+discretion of the Referees and Jury at the end of the round . 
+( h ) The Technical Controller will ensure that the lifter is that as announced and properly attired
+before mounting the platform . He / she must also attend the equipment control . 
+6 . 3 . MISCELLANEOUS RULES ( LOADING ERRORS , MISCONDUCT , APPEALS ETC . ) 
+1 ) The number of coaches of each nation for each lifting group in the warm - up area 
+1 Athlete = 3 Coaches 
+2 Athletes in the same group = 3 Coaches 
+2 Athletes in two different groups ( e . g . : A & B group ) = 5 Coaches 
+3 Athletes = in the same group = 5 Coaches 
+3 Athletes = in two different groups ( e . g . : A & B group ) = 6 Coaches 
+4 Athletes = 6 Coaches which is the maximum number of allowed Coaches 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+3 3
+The number of Coaches for each lifting group in the preparation / wrapping area Equipped lifting
+1 Athlete = 2 Coaches 
+2 Athletes = 4 Coaches 
+3 Athletes = 5 Coaches 
+4 Athletes = 6 Coaches which is the maximum number of allowed Coaches 
+The number of Coaches for each lifting group in the preparation area Classic lifting 
+1 Athlete = max 2 Coaches in one group 
+2 Athletes = max 2 Coaches in one group 
+3 Athletes = max 2 Coaches in one group 
+3 Athletes = max 3 Coaches in two groups 
+4 Athletes = max 4 Coaches in two groups which is the maximum number of allowed Coaches
+During any competition taking place on a platform or stage , only the lifter and ONE ( 1 ) coach ,
+members of the Jury , officiating referees , spotter / loaders and the Technical Controller will be
+allowed around the platform or on the stage . During the execution of the lift , only the lifter ,
+spotter / loaders and the referees are permitted to be present on the platform . Coaches shall
+remain within the designated coaching area as defined by the Jury or Technical Officer in charge .
+The coaching area must be made in such a way that allows the coach to place himself with a
+good view to the lifter with the possibility to give instructions and signals to the lifter regarding
+technical details ( e . g . depth in squat ) . 
+The coach area should be on a distance of no longer than 5 meters from the stage and it should
+be longer than the lifting stage that permits a walking area for the coach to see the lift from any
+side back or side front angle . Dress code for coaches at international events shall be national
+team tracksuit plus team or IPF approved t - shirt , or sport shorts plus team or IPF approved t -
+shirt , NO HATS , TAKING PICTURES or MAKING VIDEOS . Coach must adhere to this code failing
+which on the ruling of the Technical Controller or Jury , it may result in the coach being excluded
+from the event warm up room and competition surrounds . See COACH RESPONSIBILITIES on
+p a g e  4 4 .  
+2 ) A lifter shall not wrap , adjust his costume or use ammonia within view of the public . The only
+exception to this rule being that he may adjust his belt . 
+3 ) In international matches between two lifters or two nations contested in different bodyweight
+categories , the lifters may alternate irrespective of weight required for the attempts . The lifter
+requiring the lightest weight in his initial lift shall lift first and thereby set the order for the
+alternate attempts throughout that particular lift . 
+4 ) In IPF recognized competitions , the weight of the barbell must always be a multiple of 2 . 5 kg .
+Unless attempts are made on records , in Squat , Bench Press and Deadlift , the progression must
+be at least 2 . 5 kg between all attempts
+( a ) In a record attempt the weight of the barbell must be at least 0 . 5 kg in excess of the current
+record . 
+( b ) During the course of competition , a lifter may request a record attempt that is not a multiple
+of 2 . 5 kg . If the attempt is successful , it will be added to both the individual lift and total . 
+( c ) Record attempts may be taken on any or all of the lifter ’ s prescribed attempts .
+( d ) A lifter may only take increments of less than 2 . 5 kg for record attempts in the championship
+in which he is competing , e . g . a Master lifting in an open competition cannot take less than 2 . 5 kg
+to achieve Master ’ s records . 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+3 4
+( e ) In the event of a weight posted for the following round , which is not a multiple of 2 . 5 kg to
+exceed a record , the weight will be reduced to the nearest multiple of 2 . 5 kg , should a fellow
+competitor have exceeded this weight in the previous round . 
+Example 1 : 
+The current record is 3 0 2 . 5 kg . 
+Lifter A squats 3 0 0 kg in the first round then posts 3 0 3 . 5 kg , Lifter B squats 3 0 5 kg in the first
+round . 
+Lifter A second attempt now is reduced to 3 0 2 . 5 kg . 
+Example 2 : 
+The current record is 3 0 0 kg . 
+Lifter A posts only a 1 kg increment ( 3 0 1 kg ) having achieved his first attempt of 3 0 0 kg in the
+above scenario , Lifter B squats 3 0 5 kg in the first round , Lifter A must now take the nearest 2 . 5 kg
+a b o v e  ( 3 0 2 . 5  k g ) .  
+5 ) The Chief Referee will be solely responsible for decisions taken in the case of loading errors or
+incorrect announcements by the speaker . His decisions will be given to the speaker who will
+make the appropriate announcement . Examples of errors in loading : 
+( a ) If the bar is loaded to a lighter weight than originally requested and the attempt is successful ,
+he lifter may accept the successful attempt or elect to take the attempt again at the originally
+requested weight . If the attempt is not successful , the lifter will be granted a further attempt at
+the originally requested weight . In both the above cases , further attempts may only be taken at
+the end of the round in which the error occurred . 
+( b ) If the bar is loaded to a heavier weight than originally requested and the attempt is successful ,
+the lifter will be granted the attempt . However , the weight may be reduced again if required for
+other lifters . If the attempt is not successful , the lifter will be granted a further attempt at the end
+of the round in which the error occurred . 
+( c ) If the loading is not the same on each end of the bar ; or any change occurs to the bar or discs
+during the execution of the lift ; or the platform is disarranged , if despite these factors , the lift is
+successful , the lifter may accept the attempt or elect to take the attempt again . If the successful
+attempt is not a multiple of 2 . 5 kg , then the lower closest , multiple of 2 . 5 kg will be recorded on
+the score sheet . If the attempt is unsuccessful , the lifter will be granted a further attempt . Further
+attempts may only be taken at the end of the round in which the error occurred . 
+( d ) If the speaker makes a mistake by announcing a weight lighter or heavier than that requested
+by the lifter . The Chief Referee will make the same decisions as for errors in loading . 
+( e ) If for any reason it is not possible for the lifter or his coach to remain in the vicinity of the
+platform in order to follow the progress of the competition and the lifter misses his attempt
+because the speaker omitted to announce him at the appropriate weight , then the weight will be
+reduced as necessary and the lifter allowed to take his attempt , but only at the end of the round . 
+( f ) If the lifter himself is deprived of an otherwise successful attempt by the error of a
+spotter / loader , wrongly loaded bar or any other fault and through no fault of his own , he shall be
+awarded another attempt at the discretion of the Referees and Jury at the end of the round . If
+any lift is a record attempt the lifter shall always follow himself no matter what round it is .
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+3 5
+6 ) Three unsuccessful attempts in any lift will automatically eliminate the lifter from the overall
+competition . He may still compete for awards on individual lifts if he makes bona fide attempts
+on each of the lifts i . e . , weights attempted must be within his reasonable capabilities . If this is
+questionable the Jury will decide . 
+7 ) Other than initial removal of the bar from the racks , the lifter will not receive any help from the
+spotter / loaders in positioning himself for an attempt . 
+8 ) On the completion of an attempt , a lifter shall leave the platform within 3 0 seconds ; failure to
+comply with this rule may result in disqualification of the attempt at the discretion of the
+referees . This rule was designed for lifters who may have received some injury during the course
+of the lift , or perhaps the less able bodied , e . g . the blind lifter . 
+9 ) Athlete ’ s hair should be fixed ( braided or tied back ) in such a way as to not interfere with
+the referees ’ ability to judge the lift . 
+1 0 ) Lifters are expected to enter and exit the lifting area or platform in a respectful manner ,
+refraining from discarding their belt on the floor or engaging in any conduct that may be
+harmful to the integrity of the sport . 
+1 1 ) If during warm up or competition , a lifter suffers injury or in any other way exhibits signs of a 1 1 .
+condition which may unduly or significantly jeopardize the competitor ’ s health and wellbeing ,
+the official doctor has the right to examination . If the doctor considers it inadvisable for the lifter
+to continue , he may , in consultation with the Jury , insist upon the lifter retiring from the
+competition . The team manager or coach must be officially informed of such a decision . To avoid
+contamination a solution of one - part household bleach to 1 0 parts water is recommended to
+clean blood or tissue from the bar or platform and that in the warmup area should “ accidents ”
+occur . 
+1 2 ) Any lifter or coach , who by reason of his misconduct upon or near the competition platform is
+likely to discredit the sport , shall be officially warned . If the misconduct continues , the Jury , or
+Referees in the absence of the Jury , may disqualify the lifter or coach and order the lifter or coach
+to leave the venue . The team manager must be officially informed of both warning and
+disqualification . 
+1 3 ) The Jury and Referees may by a majority decision immediately disqualify a lifter or official if
+they are of the opinion that any misconduct is serious enough to warrant immediate
+disqualification rather than an official warning . The team manager must be informed of the
+disqualification . 
+1 4 ) In international competition , all appeals against referee ’ s decisions , complaints regarding the
+progress of the competition or against the behavior of any person or persons taking part in the
+competition must be made to the Jury . The Jury may require the appeal to be made in writing .
+The appeal or complaint must be lodged with the Chairman of the Jury by the team manager ,
+coach or in his absence , by the lifter . This must be done immediately following the action upon
+which the appeal or complaint is based . It will not be considered unless these terms are met . 
+1 5 ) If deemed necessary , the Jury may temporarily suspend the progress of the competition and
+retire to consider its verdict . After due consideration and upon reaching a unanimous verdict , the
+Jury will return and the Chairman will inform the complainant of its decision . The Jury ’ s verdict
+will be considered final and there will be no right of appeal to any other body . Upon
+recommencement of the competition which has been suspended , the next lifter shall be given
+three minutes in which to commence his lift . In the event of a complaint being made against a
+lifting member or official of an opposing team , “ The Jury will not consider challenges relating to
+the referees ’ decision on lifts performed by an athlete from an opposing team ” the written
+complaint shall be accompanied by the cash sum of Euro 7 5 or its equivalent in any currency .
+Should the Jury in its verdict consider that the complaint is of a frivolous or mischievous nature ,
+then the whole or any portion of the sum may be retained and donated to the IPF at the
+discretion of the Jury . 
+0 1 . 0 3 . 2 0 2 6
+Order of competition
+
+LIFTCOMMENCEMENT COMPLETION 
+SQUATA visual signal consisting of a
+downward movement of the
+arm together with the audible
+command “ squat ” 
+A visual signal consisting of a backward
+movement of the arm together with
+the audible command “ rack ” 
+BENCH PRESSA visual signal consisting of a
+downward movement of the
+arm together with the audible
+command “ start ” . 
+DURING :
+The audible command “ Press ”
+after motionless at the chest
+and the visible signal of an
+upward movement of the arm . 
+A visual signal consisting of a backward
+movement of the arm together with
+the audible command “ rack ” 
+DEADLIFTNo signal required A visual signal consisting of a
+downward movement of the arm
+together with the audible command
+“ d o w n ”  
+When a lifter fails to complete a squat or a bench press , the command is “ rack ” . 
+3 6
+1 6 . The Jury may utilize instant replay technology as an official tool to review lifts during IPF -
+sanctioned competitions . Instant replay may be used to assist the Jury in determining the
+correctness of referees ’ decisions or to confirm the validity of a lift in cases where visual
+evidence may clarify a technical or procedural matter . When used , the following shall apply : 
+( a ) The instant replay system shall be operated only by the jury or a designated official under
+Jury supervision . 
+( b ) The Jury may initiate review upon its own discretion or upon protest lodged in
+accordance with the rules . 
+( c ) The decision of the Jury , after instant replay review , shall be final and binding . 
+( d ) The use of instant replay shall not unduly delay the competition and must be conducted
+in a manner that maintains the flow of the event . 
+( e ) Instant replay may only be employed at IPF Calendar events or other competitions where
+the necessary technical equipment and personnel are available . 
+7 . REFEREES
+1 ) The referees shall be three in number , the Chief Referee or Center Referee and two side
+referees . Their international referee cards should be in date , and that of the Technical Controller ,
+and placed on the Jury table . 
+2 ) The Chief Referee is responsible for giving the necessary signals for all three lifts . 
+3 ) Signals required for the three lifts are as follows : 
+0 1 . 0 3 . 2 0 2 6
+Referees
+
+3 7
+4 ) Once the bar has been replaced in the racks or on the platform at the completion of the lift ,
+the referees will announce their decisions by means of the lights . White for a “ good lift ” and red
+for “ no lift ” . The cards will then be raised to indicate the reason for the “ no lift ” . 
+5 ) The three referees may seat themselves in what they consider to be the best viewing positions
+around the platform in a range not farther than 4 meters for each of the three lifts . However , the
+Chief Referee must always bear in mind the need to be visible to the lifter performing the squat
+or deadlift , and the side referees should always bear in mind the need to be visible to the Chief
+Referee so that he can observe their raised arms 
+6 ) Before the contest , the three referees shall jointly ascertain that : 
+( a ) The platform and competition equipment comply in all respects with the rules . Bars and discs
+are checked for weight discrepancies and defective equipment discarded . A second bar and
+collars should be readied and put aside in case of damage to the original bar or collars . 
+( b ) The scales work correctly and are accurate ( currently certified ) . 
+( c ) The lifters weigh in within the limits of weight and time for their bodyweight category . 
+( d ) The lifter ’ s personal equipment has been inspected to comply with the rules in all respects . It
+is the duty of the lifter to ensure that all items he wishes to wear on the platform have passed the
+scrutiny of the examining referees . Lifters discovered wearing or using apparel that has not been
+checked in may be subject to penalty , e . g . disqualification of the last attempt . 
+7 ) During the contest the three referees must jointly ascertain that : 
+( a ) The weight of the loaded bar agrees with the weight announced by the speaker . Referees may
+be issued with loading charts for this purpose . It is their joint responsibility . 
+( b ) On the platform the lifter ’ s personal equipment complies with the rules . If any referee has
+reason to doubt a lifter ’ s integrity in this respect he must after completion of the lift , inform the
+Chief Referee of his suspicions . The president of the Jury may then examine the lifter ’ s personal
+equipment . If the lifter is found to be wearing or using any illegal item other than that which may
+have inadvertently been passed in error by the examining referees , the lifter shall be immediately
+disqualified from the competition . If wearing any illegal item passed in error by the examining
+referees , and the lift in which the discovery was made is successful , the lift will be rejected and
+then the lifter will be granted a new attempt ( having removed the illegal item ) at the end of the
+round . Should a Technical Controller be in evidence , the lifter ' s attire will be scrutinized before
+he / she is allowed onto the platform . 
+8 ) Prior to the commencement of the Squat and Bench press the side referees will raise their
+arms and keep them raised until the lifter is in the correct position to begin the lift . If there is a
+majority opinion among the referees that a fault exists , the Chief Referee will not give the signal
+to commence the lift . The lifter has the remainder of his unexpired time allowance in which to
+correct the position of the bar or his stance in order to receive the commencement signal . Once a
+lift has commenced , the side referees will not call attention to faults during the execution of the
+lift . 
+9 ) Referees shall abstain from commentary and not receive any document or verbal account
+concerning the progress of the competition . Therefore , it is essential that the lot number of each
+lifter accompanies his name on the scoreboard so that the referees can follow the order of lifting . 
+1 0 ) A referee shall not attempt to influence the decisions of the other referees . 
+1 1 ) The Chief Referee may consult with the side referees , the Jury or any other official as necessary
+in order to expedite the competition . 
+0 1 . 0 3 . 2 0 2 6
+Referees
+
+3 8
+1 2 ) At his discretion , the Chief Referee may order that the bar and / or platform be cleaned . If the
+lifter or coach request the bar and / or platform to be cleaned , the request must be made via the
+Chief Referee / Technical Controller not the spotter / loaders . In the final round of the deadlift the
+bar must be cleaned before every attempt , and in any of the other two rounds , should the coach
+or lifter desire . 
+1 3 ) After the competition , the three referees shall sign the official score sheets , record certificates
+or any other documents requiring a signature . 
+1 4 ) In International Competition , referees will be selected by the Technical Committee and must
+have proved their competence at International or National Championships . 
+1 5 ) In International Competitions two referees of the same nation can be selected to adjudicate in
+a contest where more than one nation competes , and the nation the referees represent has no
+lifters nominated for the Championship . If a category consists of more than one group , all groups
+should have the same referees . If a change of referees is necessary the change should be made
+between the disciplines , so that all lifters have the same referees in the same discipline . 
+1 6 ) The selection of a referee to act as Chief Referee in one category does not preclude his
+selection as side referee in another category .
+1 7 ) At World Championships , or any other championships where attempts may be made on
+world records , only IPF category 1 or category 2 referees adjudicate . Each nation may nominate a
+maximum of three four referees to serve at the World Championships , plus 2 extra category 1
+referees for Jury duty , if there is an insufficient number . All nominated referees attending a
+championship , must be available for at least two days . 
+1 8 ) Referees and members of the Jury will be uniformly dressed as follows : 
+Men , winter : Dark blue blazer with
+appropriate IPF badge on the left breast .
+Proper grey trousers ( not jeans ) with a
+white shirt and appropriate IPF tie . 
+Men , summer : Proper grey trousers ( not
+jeans ) with a white shirt and appropriate
+IPF tie .
+Women , winter : Dark blue blazer with
+appropriate IPF badge on the left breast .
+Proper grey skirt or trousers ( not jeans )
+and a white blouse or shirt , and
+appropriate scarf / tie . 
+Women , summer : Proper grey skirt or
+trousers ( no jeans ) and a white blouse or
+shirt , and appropriate scarf / tie . 
+IPF badges and scarf / ties are red for category 1 referees and blue for category 2 referees . The
+Jury shall determine whether winter or summer dress will be worn . Shoes known as “ trainers ”
+do not compliment blazer and trousers ! Dress / Day wear black shoes and black socks must be
+worn . Open shoes are not allowed . 
+0 1 . 0 3 . 2 0 2 6
+Referees
+
+3 9
+1 9 ) Qualifications for a Category 2 Referee are as follows : 
+( a ) A national referee of at least two years standing , having officiated in the position as a referee
+with a minimum of two National Powerlifting Championships within this period . 
+( b ) Must be recommended by his National Federation . 
+( c ) Must take the Category 2 written / computer examination in English and practical examination
+at a World Championship , Continental Championship or Regional Championship . 
+( d ) Must achieve a passing score of 8 5 percent or more on written examination and 8 5 percent or
+more on practical examination .
+2 0 ) Qualifications for a Category 1 Referee are as follows : 
+( a ) Must be a Category 2 referee in good standing for a period of at least 4 years , officiating at a
+minimum six ( 6 ) international ( World and / or Regional ) and six ( 6 ) national championships . 
+( b ) Must have adjudicated at least 4 International Championships , excluding the World
+Bench Press Championships . 
+( b ) Must take Category 1 practical and written / computer examination at any World Championship
+( excluding the World Bench Press Championship ) , Continental Championship , Regional Games
+or International Tournament 
+( c ) Must adjudicate at least 7 5 attempts , 3 5 of which must be squats , while serving as Chief
+Referee . First round attempts by lifters will count . 
+( d ) The candidate will also be credited with 2 5 points / marks , and observed for competence by the
+examiner ( s ) during gear check , weigh in and while seated on the platform . A deduction of 0 . 5
+( half a point / mark ) will be made for any error that may contravene the technical rules . The
+examiner will be a member of the IPF Technical Committee or an Official appointed by the IPF
+Technical Committee and Referee Registrar . 
+( e ) The candidate must score at least 9 0 percent on his total examination . This includes the 7 5
+points on his decisions made on the platform as compared with those of the Jury members and
+not those of his fellow platform referees . The other 2 5 points coming from his decisions and
+performance of the necessary duties i . e . gear check , weigh in and platform control . 
+( f ) Must be nominated by his National Federation to the Chairman of the Technical Committee
+and Referee Registrar three months prior to his examination . 
+Basis for Nomination should be as follows : 
+1 . Candidate ’ s competence as a referee . 
+2 . Priority ranking as a Category 
+3 . Availability to referee at future international events . 
+4 . Knowledge of English language . 
+( g ) A requirement of the Category I candidate is that he / she is able to converse in English to a
+standard that will allow complete comprehension in disputes , particularly when asked to partake
+in jury duty . In this respect , the examiners will decide the proficiency of the candidate . If a
+candidate passes his / her category 1 examination but speak no English , he / she will be a Regional
+Category 1 Referee and can only be in the Jury at Regional meets or National meets . 
+0 1 . 0 3 . 2 0 2 6
+Referees
+
+4 0
+2 1 ) The selection of a candidate for examination by the IPF will be subject to the following Criteria : 
+( a ) The number of nominations received . 
+( b ) The number of examination positions available . 
+( c ) The current requirements for Category 1 referees within the various nations .
+2 2 ) Testing Procedures are as follows : 
+( a ) Category 2 A written / computer examination in English Language will be given only after a
+complete and comprehensive rules clinic has been conducted under the direction of an
+approved Category 1 referee who has been appointed as Chief Examiner by the IPF Technical
+Committee and Referee Registrar . A practical examination will be given after the
+written / computer examination during the competition , the candidate will be side referee and will
+adjudicate a total of 1 0 0 attempts , 4 0 of which must be squats . The candidate must be
+scrutinized by the Jury and score at least 8 5 percent on all his decisions when compared with a
+majority of the scrutinizing referees . Adjudication will begin with the first - round attempts . The
+written / computer and practical Category 2 examinations will be held only in conjunction with
+international or regional powerlifting championships . 
+( b ) Category 1 A practical and a written / computer examination will be given to a candidate at any
+World Championship ( excluding the World Bench Press Championship ) , Continental
+Championship , Regional Championships . The candidate will be scrutinized by the Jury . The
+candidate must score at least 9 0 percent on all his decisions when compared with a majority of
+the scrutinizing Jury members , this includes the candidate ’ s observed competence in handling
+all other duties , such as equipment check examinations and weigh in procedures . Adjudication
+will begin with the first - round attempts . 
+2 3 ) The examination fee shall be paid to the IPF Treasurer before the examination . All
+examination score sheets shall be marked by the scrutinizing referee / s . When marking is
+complete , the candidate shall be informed of the results . Marked score sheets shall be sent to the
+Referee ’ s Registrar .
+2 4 ) After receiving the examination results , the Referee Registrar will inform the candidates
+Federation ’ s National Secretary of the results and forward the appropriate credentials to the
+candidate . 
+2 5 ) A candidate taking a practical examination will be scrutinized by the Jury ( for Category 1 ) or
+the appointed scrutinizing referee / s ( for Category 2 ) to determine his success or failure . 
+2 6 ) Upon passing the examination , a referee ’ s date of promotion shall be the date of the
+examination . 
+2 7 ) Candidates who fail the examination are allowed to re - write at the same Championships and
+need to pay for the examination again . 
+2 8 ) Registration : 
+( a ) All referees must re - register with the IPF in order to maintain their current qualifications and
+at an acceptable standard . 
+( b ) Re - registration shall take place on the first of January in each Olympic year . 
+( c ) Technical Secretary at an international competition shall send a list in the form of an Excel file
+to the IPF Referee Registrar of the participant referees immediately after a competition . 
+( d ) A referee ’ s national federation is responsible for sending the necessary 5 0 Euro registration fee
+to the IPF Treasurer and a resume of his international and national experience during the
+previous registration period to the IPF Referee Registrar . 
+( e ) A referee who has been inactive for a four - year period or who fails to re - register will forfeit his
+credentials . Then need to retake examinations . 
+( f ) A card which is issued within the twelve months prior to the first of January in each Olympic
+year need not be renewed until the first of January the following Olympic year .
+0 1 . 0 3 . 2 0 2 6
+Referees
+
+4 1
+2 9 ) The IPF Referee Registrar shall provide each national federation with : 
+( a ) A current list of accredited referees . Updated annually . 
+( b ) A list of referees who need to re - register in order to remain accredited . 
+3 0 ) International Referees , both Category 1 and 2 , must have refereed a minimum of two ( 2 )
+International Powerlifting or Bench Press Championships and two National Powerlifting
+Championships during the previous four - year period between Olympic years in order to be
+acceptable for re - registration 
+8 . JURY AND TECHNICAL COMMITTEE 
+8 . 1 .  J U R Y
+1 ) At World and Continental Championships , a Jury will be appointed to preside over each lifting
+session . 
+2 ) The Jury shall consist of three or five Category 1 referees . In the absence of a member of the
+Technical Committee , the most senior member of the three or five shall be designated President
+of the Jury . The five - man jury can be installed only at the World Games or Men ’ s and Women ’ s
+Open Championships in Powerlifting . 
+3 ) The members of the Jury shall all be from different nations with the exception of the IPF
+President and the Chairman of the Technical Committee . 
+4 ) The function of the Jury is to ensure that the technical rules are correctly applied . 
+5 ) During the competition the Jury may , by a majority vote , replace any referee whose decisions
+in its opinion , prove him to be incompetent . The referee concerned must have received a warning
+prior to any action of dismissal . 
+6 ) The impartiality of referees cannot be doubted , but a mistake in refereeing can be committed
+in good faith . In such a case , the referee shall be allowed to give his explanation for making the
+decision which is the subject of his warning . 
+7 ) If a protest is made to the Jury against a referee , then the referee may be informed of the
+protest . The Jury should not put unnecessary stress on platform referees . 
+8 ) If a serious mistake occurs in the refereeing which is contrary to the technical rules , the Jury
+may take appropriate action to correct the mistake . They may at their discretion , grant the lifter a
+further attempt . 
+9 ) Only in extreme circumstances when there has been an obvious or blatant mistake in the
+refereeing will the Jury in consultation verbally or electronically with the referees , by unanimous
+jury vote with ( 3 ) Member Jury or with Majority vote with ( 5 ) Member Jury may reverse the
+decision . Only 2 to 1 referees ’ decision can be considered by the Jury . 
+1 0 ) The selection of lifters for drug testing shall always be made by the CCES
+1 1 ) The members of the Jury will be positioned to ensure an unimpeded view of the competition .
+1 2 ) Before each competition , the President of the Jury must satisfy himself that the members of
+the Jury have a complete knowledge of their role and any new regulations that amend or
+supplement those contained in the current edition of the handbook 
+1 3 ) If music accompanies the lifting , the Jury will determine the volume . The music will terminate
+when the lifter takes the weight of the bar in the squat and bench press or begins the pull in the
+deadlift .
+1 4 ) The referees ’ cards will be signed at the completion of the weight class . 
+0 1 . 0 3 . 2 0 2 6
+Jury and technical committee
+
+4 2
+8 . 2 . IPF TECHNICAL COMMITTEE 
+1 ) Will consist of a Chairman , who shall be a Category 1 referee elected by the General Assembly ,
+and up to ten members from various nations appointed by the Executive Committee in
+consultation with the Chairman of the Technical Committee . And a coach / lifter representative . 
+2 ) Will be entrusted with the examination of all requirements and proposals of a technical nature
+submitted by the affiliated federations . 
+3 ) Appoints the Chief Referee , side referees and the jury for the World Championships . May also
+appoint Referees who are present and not nominated by their nation and available in case of
+insufficient Referees . National Referees may be appointed as Technical Controllers 
+4 ) Trains and instructs referees who have not yet reached the international level and re - examines
+those who have already reached that level . 
+5 ) Informs the IPF General Assembly , President and General Secretary via the Referee Registrar
+as to which referees are eligible to referee after examination or re - examination . 
+6 ) Organizes courses for referees before any major competition such as the World
+Championships . The expense involved in organizing such courses or clinics must be borne by the
+organizing federation . 
+7 ) Makes proposals to the IPF General Assembly for the withdrawal of an international referee ’ s
+card when it deems such action necessary . 
+8 ) Publishes via the Executive , material of a technical nature that deals with training methods
+and performance of competition lifts
+9 ) ( a ) Will be responsible for inspecting all competition and personal equipment as defined in the
+handbook . Also , equipment that has been submitted by various manufacturers for the sole
+purpose of being able to use the words “ IPF Approved ” in their commercial advertisements . If the
+item or items submitted meet all current IPF rules and regulations , and the IPF Executive
+Committee agree with the decision of the Technical Committee , a fee for each item shall be
+levied by the IPF Executive and a certificate of approval will be issued by the Technical
+Committee . 
+( b ) At the end of each year , a renewal fee for each item as levied by the IPF Executive must be
+submitted to the IPF for purposes of re - certification of approval . If the design has been changed ,
+the item must be submitted to the Technical Committee for inspection and re - certification . 
+( c ) If , at any time after the certificate of approval has been issued , the manufacturer changes the
+design of the competition or personal equipment that was previously submitted for approval and
+it no longer meets current IPF rules and regulations , the IPF shall withdraw approval . The IPF will
+not issue another certificate until changes in design have been corrected and the item or items
+submitted to the Technical Committee for inspection .
+0 1 . 0 3 . 2 0 2 6
+Jury and technical committee
+9 . WORLD AND INTERNATIONAL RECORDS 
+9 . 1 . INTERNATIONAL COMPETITIONS 
+ 1 ) World and International records may only be made at the above named . That is , Championships
+sanctioned and recognized by the IPF , World and International Records will be accepted without
+weighing the barbell or the lifter , provided that the lifter had weighed in correctly before the
+competition and that the referees or the Technical Committee had checked the weight of the
+barbell and the discs before the competition .
+
+4 3
+Men ’ s and women ’ s 4 0 - 4 9 records exceeding the open record will be included in the open categories if
+appropriate . 
+Men ’ s and Women ’ s 5 0 - 5 9 records exceeding those gained in the 4 0 - 4 9 age group will be included in the
+4 0 - 4 9 category and Open categories if appropriate . 
+Men ’ s and Women ’ s 6 0 - 6 9 records exceeding those gained in the 5 0 - 5 9 will be included in the 5 0 - 5 9
+category and in the 4 0 - 4 9 category , and Open categories if appropriate . 
+Men ’ s and Women ’ s 7 0 + records exceeding those gained in the 6 0 - 6 9 age group , will be included in the 6 0 -
+6 9 category , and in the 5 0 - 5 9 or 4 0 - 4 9 category and Open categories if appropriate . Likewise , Sub - Junior
+1 4 - 1 8 records exceeding those gained in the Junior 1 9 - 2 3 age group will be included in this group , and Open
+categories if appropriate . 
+Junior 1 9 - 2 3 records exceeding the open record will be included in the open if appropriate . 
+Note : From 2 0 2 1 start to register the World Games records . The records should be registered in
+that bodyweight category to which belongs the competitor according to his bodyweight . The
+starting record standards should be equal to the World records in powerlifting as for 1 4 / 0 7 / 2 0 2 1
+2 ) Requirements for recognition of a World and International records are as follows : 
+( a ) The International Competition must be held under the sanction of the IPF . 
+( b ) Each of the adjudicating referees must hold a current IPF International Referee ’ s Card and be
+a member of a national federation affiliated to the IPF . It must be referees from three different
+nations on the stage and there must be a three member Jury . 
+( c ) The good faith and competence of referees of all member nations is beyond dispute . 
+( d ) Only bars and discs and racks that are listed on the IPF Approved list of apparel and
+equipment for use at IPF sanctioned competition , as current at the time , maybe used in the
+setting of World and International records . 
+( e ) Records on individual lifts must be accompanied by a total of the three lifts . Single lift Bench
+Press records made at a three lift ( Powerlifting ) event do not need to be accompanied by a total
+but bona fide attempt must be made both on squat and deadlift . 
+( f ) In the event two ( 2 ) lifters request the same weight for a new record in an individual lift , and if
+the first lifter by lot number succeeds , 0 . 5 kg will be added by the computer secretary ( if it ’ s not a
+multiple of 2 . 5 kg ’ s ) to his / her attempt to claim the record . The record holder is the lifter who
+makes the record total first . 
+( g ) New Records are only valid if they exceed the previous record by at least 0 . 5 kg . 
+( h ) If a lifter is attempting to set a World record in the deadlift and is placed at the end of the
+round by virtue of a protest , the remaining lifters in the group attempting the World record will
+have to increase their attempt by 0 . 5 kg . If more than one lifter is attempting to set a World
+record in the same discipline and a lifter gets a new attempt by virtue of a protest the lifter must
+following him / herself . 
+( i ) All records broken under the same conditions as that listed above shall be recognized and
+registered . 
+0 1 . 0 3 . 2 0 2 6
+World and international records
+3 ) World single lift bench press records may be made at any of the forenamed Championships
+known as single lift or as in ( a ) below . The same criterion applies to that of all world powerlifting
+records . 
+( a ) Should a lifter exceed the single lift bench press record whilst lifting in a three - lift powerlifting
+contest , he / she may claim the single lift bench press record if bona fide attempts are made on
+both squat and deadlift . 
+( b ) Should a lifter in a single lift bench press contest exceed the three - lift powerlifting record he /
+she cannot claim the three - lift powerlifting record .
+
+4 4
+1 0 . COACH RESPONSIBILITIES 
+ 1 ) THE AIMS OF A COACH RESPONSIBILITY 
+Is to ensure the successful coaching of their lifters at international level , to encourage
+participation in the sport of Powerlifting , to help each lifter to achieve the best results that their
+potential indicates , 
+2 ) WHAT IS THE COACH RESPONSIBILITY ? 
+The Coach has many duties associated with the above aims , he / she needs to have a strong
+character and disciplined approach at all times , he / she must always be in charge . 
+3 ) BEING A COACH , YOU MUST ENSURE THE FOLLOWING 
+The number of coaches of each nation for each lifting group in the warm - up area 
+1 Athlete = 3 Coaches 
+2 Athletes in the same group = 3 Coaches 
+2 Athletes in two different groups ( e . g . : A & B group ) = 5 Coaches 
+3 Athletes = in the same group = 5 Coaches 
+3 Athletes = in two different groups ( e . g . : A & B group ) = 6 Coaches 
+4 Athletes = 6 Coaches which is the maximum number of allowed Coaches
+The number of Coaches for each lifting group in the preparation / wrapping area Equipped lifting 
+1 Athlete = 2 Coaches 
+2 Athletes = 4 Coaches 
+3 Athletes = 5 Coaches 
+4 Athletes = 6 Coaches which is the maximum number of allowed Coaches 
+The number of Coaches for each lifting group in the preparation area Classic lifting 
+1 Athlete = max 2 Coaches in one group 
+2 Athletes = max 2 Coaches in one group 
+3 Athletes = max 2 Coaches in one group 
+3 Athletes = max 3 Coaches in two groups 
+4 Athletes = max 4 Coaches in two groups which is the maximum number of allowed Coaches 
+4 ) Promoters to install a Coach Observation zone in the wrapping area with a TV monitor link to
+the Lifting platform for coaches to be able to follow the lifting , if this is not possible then an
+Observation Zone behind the speaker table for coaches to view the lifting 
+5 ) The Head Coach must ensure only one coach goes with the athletes to the coaching zone and
+must be properly dress 
+6 ) The behaviors of the coaches and lifters in the warm up and wrapping area is the
+responsibility of the Head Coach 
+7 ) The Head Coach must ensure each of his assistant coaches receive a badge with photo to gain
+access to the warm up , wrapping and lifting area 
+0 1 . 0 3 . 2 0 2 6
+Coach responsibilities
+
+4 5
+8 ) The Head Coach must arrange with the organizer a fix training time for his / her team 
+9 ) The Head Coach must ensure all equipment used during training is replace on racks and the
+platforms is left tidy and the trainings area leaves in clean conditions ( no garbage etc . ) same
+applies after the Competition . 
+1 0 ) The Head Coach must ensure at weigh - in his / her lifters must present the following to the
+Referees : Appendix 2 , Lifters profile and passport . 
+1 1 ) The Head Coach must ensure at the equipment check lifters equipment is in accordance with
+IPF Technical rules . 
+1 2 ) The Head Coach and assistant coaches in the warm - up , wrapping and lifting area must
+acknowledge their Requirement to adhere to all the IPF Anti - Doping rules . 
+1 3 ) The head coach is responsible that no family member or any children is present in the warm
+up area , preparation arena . 
+1 4 ) The Head Coach to ensure the lifters is prepared and ready to take the platform when his / her
+name is called for the victory ceremony . 
+1 5 ) Concerning warm - up and wrapping , any drinking of alcohol by Head Coach , assistant
+coaches , and your lifters in the mentioned areas above is strictly forbidden , under no
+circumstance can any person under the influence of alcohol be in the warmup room at any
+time and this shall be ensured by the Head Coach 
+1 6 ) Eligible Coaches / Lifters : The nominated coaches must be members of the National
+Powerlifting Federation / Association . Each national federation has the autonomy to establish its
+own rules and procedures for its coaches and national team lifters . 
+0 1 . 0 3 . 2 0 2 6
+Coach responsibilities
+1 7 ) Pictures and Filming : In the warm - up area , for some lifters , it ' s necessary to view their lifts in a
+video to fully understand the minor corrections needed in their movements . This facilitates c
+communication between a coach and a lifter , which can take place on various levels . 
+1 8 ) I acknowledge that I have read and understood the above . I understand that abuse of
+these expectations will render me liable for disciplinary action by the IPF Disciplinary
+Committee , or in case relating to item 1 0 . above , for the review and hearing processes
+specified in the relevant articles of the IPF Anti - Doping Rules .
+N A M E  o f  H e a d  C o a c h … … … … … … … … … … … … … … … … . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . … … . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .  
+Please state 
+N A M E  o f  C o a c h … … … … … … … … … … … … … … … … … … … . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . … … … … … … … … … … … .  
+Please state 
+N a t i o n a l  F e d e r a t i o n . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .  
+S I G N A T U R E  … … … … … … … … … … … … … … . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .  D A T E  … … … … … . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .


### PR DESCRIPTION
## Summary
- Adds `docs/ipf-technical-rules-2026.md` — full text of the IPF Technical Rule Book (effective 01 March 2026, v3), extracted from the official PDF
- Covers all 10 sections: general rules, equipment, personal equipment, lift rules, weighing in, order of competition, referees, jury/technical committee, world records, and coach responsibilities
- Useful reference for implementing correct record-setting logic (section 9), age category cascade rules, and other IPF-mandated behaviour

## Test plan
- [ ] Verify document renders correctly in GitHub