### PR TITLE
test(webapi): migrate athlete and team GET tests to IAsyncLifetime (step 3)

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
@@ -89,7 +89,7 @@ public sealed class GetAthleteDetailsTests(CollectionFixture fixture) : IAsyncLi
     public async Task ReturnsNotFound_WhenAthleteDoesNotExist()
     {
         // Arrange
-        string path = $"{BasePath}/{Guid.NewGuid}";
+        string path = $"{BasePath}/{Guid.NewGuid()}";
 
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.GetAsync(path, CancellationToken.None);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
@@ -1,7 +1,8 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
 using Shouldly;
@@ -9,22 +10,47 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Athletes;
 
 [Collection(nameof(AthletesCollection))]
-public sealed class GetAthleteDetailsTests
+public sealed class GetAthleteDetailsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string BasePath = "/athletes";
 
-    private readonly HttpClient _unauthorizedHttpClient;
+    private readonly HttpClient _authorizedClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private string _slug = string.Empty;
 
-    public GetAthleteDetailsTests(CollectionFixture fixture)
+    public async ValueTask InitializeAsync()
     {
-        _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder().Build();
+        await _authorizedClient.PostAsJsonAsync(BasePath, command, CancellationToken.None);
+
+        List<AthleteSummary>? athletes = await _authorizedClient.GetFromJsonAsync<List<AthleteSummary>>(BasePath, CancellationToken.None);
+        AthleteSummary athlete = athletes!.First(a => a.Name == $"{command.FirstName} {command.LastName}");
+        _slug = athlete.Slug!;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!string.IsNullOrEmpty(_slug))
+        {
+            try
+            {
+                await _authorizedClient.DeleteAsync($"/athletes/{_slug}", CancellationToken.None);
+            }
+            catch (HttpRequestException)
+            {
+                // Best-effort cleanup; do not mask test failures.
+            }
+        }
+
+        _authorizedClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
     }
 
     [Fact]
     public async Task ReturnsOk_WhenAthleteExists()
     {
         // Arrange
-        string path = $"{BasePath}/{Constants.TestAthleteSlug}";
+        string path = $"{BasePath}/{_slug}";
 
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.GetAsync(path, CancellationToken.None);
@@ -37,7 +63,7 @@ public sealed class GetAthleteDetailsTests
     public async Task Deserializes()
     {
         // Arrange
-        string path = $"{BasePath}/{Constants.TestAthleteSlug}";
+        string path = $"{BasePath}/{_slug}";
 
         // Act
         AthleteDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<AthleteDetails>(path, CancellationToken.None);
@@ -50,13 +76,13 @@ public sealed class GetAthleteDetailsTests
     public async Task ReturnsCorrectAthlete()
     {
         // Arrange
-        string path = $"{BasePath}/{Constants.TestAthleteSlug}";
+        string path = $"{BasePath}/{_slug}";
 
         // Act
         AthleteDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<AthleteDetails>(path, CancellationToken.None);
 
         // Assert
-        response!.Slug.ShouldBe(Constants.TestAthleteSlug);
+        response!.Slug.ShouldBe(_slug);
     }
 
     [Fact]

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthletesTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthletesTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Athletes;
@@ -10,12 +10,44 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Athletes;
 
 [Collection(nameof(AthletesCollection))]
-public sealed class GetAthletesTests(CollectionFixture fixture)
+public sealed class GetAthletesTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string Path = "/athletes";
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
     private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private string _slug = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
+            .WithFirstName("0")
+            .WithLastName("0")
+            .Build();
+        await _authorizedHttpClient.PostAsJsonAsync(Path, command, CancellationToken.None);
+
+        List<AthleteSummary>? athletes = await _authorizedHttpClient.GetFromJsonAsync<List<AthleteSummary>>(Path, CancellationToken.None);
+        AthleteSummary athlete = athletes!.First(a => a.Name == "0 0");
+        _slug = athlete.Slug!;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!string.IsNullOrEmpty(_slug))
+        {
+            try
+            {
+                await _authorizedHttpClient.DeleteAsync($"/athletes/{_slug}", CancellationToken.None);
+            }
+            catch (HttpRequestException)
+            {
+                // Best-effort cleanup; do not mask test failures.
+            }
+        }
+
+        _authorizedHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
+    }
 
     [Fact]
     public async Task ReturnsOk_WhenNotAuthenticated()
@@ -62,18 +94,13 @@ public sealed class GetAthletesTests(CollectionFixture fixture)
         IReadOnlyList<AthleteSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<AthleteSummary>>(Path, CancellationToken.None);
 
         // Assert
-        response!.ShouldContain(x => x.Slug == Constants.TestAthleteSlug);
+        response!.ShouldContain(x => x.Slug == _slug);
     }
 
     [Fact]
     public async Task ReturnsTestAthletesOrderedByFirstName()
     {
         // Arrange
-        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
-            .WithFirstName("0")
-            .WithLastName("0")
-            .Build();
-        await _authorizedHttpClient.PostAsJsonAsync(Path, command, CancellationToken.None);
 
         // Act
         IReadOnlyList<AthleteSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<AthleteSummary>>(Path, CancellationToken.None);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
@@ -1,7 +1,8 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
 using Shouldly;
@@ -9,22 +10,47 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Teams;
 
 [Collection(nameof(TeamsCollection))]
-public sealed class GetTeamDetailsTests
+public sealed class GetTeamDetailsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string BasePath = "/teams";
 
-    private readonly HttpClient _unauthorizedHttpClient;
+    private readonly HttpClient _authorizedClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private string _slug = string.Empty;
 
-    public GetTeamDetailsTests(CollectionFixture fixture)
+    public async ValueTask InitializeAsync()
     {
-        _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+        CreateTeamCommand command = new CreateTeamCommandBuilder().Build();
+        await _authorizedClient.PostAsJsonAsync(BasePath, command, CancellationToken.None);
+
+        List<TeamSummary>? teams = await _authorizedClient.GetFromJsonAsync<List<TeamSummary>>(BasePath, CancellationToken.None);
+        TeamSummary team = teams!.First(t => t.ShortTitle == command.TitleShort);
+        _slug = team.Slug;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!string.IsNullOrEmpty(_slug))
+        {
+            try
+            {
+                await _authorizedClient.DeleteAsync($"/teams/{_slug}", CancellationToken.None);
+            }
+            catch (HttpRequestException)
+            {
+                // Best-effort cleanup; do not mask test failures.
+            }
+        }
+
+        _authorizedClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
     }
 
     [Fact]
     public async Task ReturnsOk_WhenTeamExists()
     {
         // Arrange
-        string path = $"{BasePath}/{Constants.TestTeamSlug}";
+        string path = $"{BasePath}/{_slug}";
 
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.GetAsync(path, CancellationToken.None);
@@ -37,7 +63,7 @@ public sealed class GetTeamDetailsTests
     public async Task Deserializes()
     {
         // Arrange
-        string path = $"{BasePath}/{Constants.TestTeamSlug}";
+        string path = $"{BasePath}/{_slug}";
 
         // Act
         TeamDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<TeamDetails>(path, CancellationToken.None);
@@ -50,13 +76,13 @@ public sealed class GetTeamDetailsTests
     public async Task ReturnsCorrectTeam()
     {
         // Arrange
-        string path = $"{BasePath}/{Constants.TestTeamSlug}";
+        string path = $"{BasePath}/{_slug}";
 
         // Act
         TeamDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<TeamDetails>(path, CancellationToken.None);
 
         // Assert
-        response!.Slug.ShouldBe(Constants.TestTeamSlug);
+        response!.Slug.ShouldBe(_slug);
     }
 
     [Fact]

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
@@ -89,7 +89,7 @@ public sealed class GetTeamDetailsTests(CollectionFixture fixture) : IAsyncLifet
     public async Task ReturnsNotFound_WhenTeamDoesNotExist()
     {
         // Arrange
-        string path = $"{BasePath}/{Guid.NewGuid}";
+        string path = $"{BasePath}/{Guid.NewGuid()}";
 
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.GetAsync(path, CancellationToken.None);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Teams;
@@ -10,12 +10,43 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Teams;
 
 [Collection(nameof(TeamsCollection))]
-public sealed class GetTeamsTests(CollectionFixture fixture)
+public sealed class GetTeamsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string Path = "/teams";
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
     private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private string _slug = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        CreateTeamCommand command = new CreateTeamCommandBuilder()
+            .WithTitle("0")
+            .Build();
+        await _authorizedHttpClient.PostAsJsonAsync(Path, command, CancellationToken.None);
+
+        List<TeamSummary>? teams = await _authorizedHttpClient.GetFromJsonAsync<List<TeamSummary>>(Path, CancellationToken.None);
+        TeamSummary team = teams!.First(t => t.ShortTitle == command.TitleShort);
+        _slug = team.Slug;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!string.IsNullOrEmpty(_slug))
+        {
+            try
+            {
+                await _authorizedHttpClient.DeleteAsync($"/teams/{_slug}", CancellationToken.None);
+            }
+            catch (HttpRequestException)
+            {
+                // Best-effort cleanup; do not mask test failures.
+            }
+        }
+
+        _authorizedHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
+    }
 
     [Fact]
     public async Task ReturnsOk()
@@ -50,22 +81,18 @@ public sealed class GetTeamsTests(CollectionFixture fixture)
         IReadOnlyList<TeamSummary>? response = await _unauthorizedHttpClient.GetFromJsonAsync<IReadOnlyList<TeamSummary>>(Path, CancellationToken.None);
 
         // Assert
-        response!.ShouldContain(x => x.Slug == Constants.TestTeamSlug);
+        response!.ShouldContain(x => x.Slug == _slug);
     }
 
     [Fact]
     public async Task OrdersTeamsByTitle()
     {
         // Arrange
-        CreateTeamCommand command = new CreateTeamCommandBuilder()
-            .WithTitle("0")
-            .Build();
-        await _authorizedHttpClient.PostAsJsonAsync(Path, command, CancellationToken.None);
 
         // Act
         IReadOnlyList<TeamSummary>? response = await _unauthorizedHttpClient.GetFromJsonAsync<IReadOnlyList<TeamSummary>>(Path, CancellationToken.None);
 
         // Assert
-        response![0].Title.ShouldBe(command.Title);
+        response![0].Title.ShouldBe("0");
     }
 }


### PR DESCRIPTION
## Summary

- `GetAthleteDetailsTests`, `GetAthletesTests`: add `IAsyncLifetime`; create own athlete (firstName="0", lastName="0") in `InitializeAsync`, clean up in `DisposeAsync`; replace `Constants.TestAthleteSlug` with locally-owned `_slug`
- `GetTeamDetailsTests`, `GetTeamsTests`: same pattern for teams (title="0"); move inline entity creation from `OrdersTeamsByTitle` / `ReturnsTestAthletesOrderedByFirstName` into `InitializeAsync`
- Fix pre-existing bug: `Guid.NewGuid` → `Guid.NewGuid()` in both details test classes (was producing method-group string, not a GUID)

Part of #387 — step 3 of 9.

## Test plan

- [ ] All 402 integration tests pass
- [ ] `GetAthleteDetailsTests.ReturnsNotFound_WhenAthleteDoesNotExist` and `GetTeamDetailsTests.ReturnsNotFound_WhenTeamDoesNotExist` now test with a real random GUID slug
- [ ] `GetAthletesTests` and `GetTeamsTests` ordering assertions rely on `InitializeAsync`-created data, no inline creation