### PR TITLE
test(webapi): migrate Users GET tests to IAsyncLifetime (step 4)

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Users/GetUserEditDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Users/GetUserEditDetailsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Users;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
 using Shouldly;
@@ -9,7 +10,7 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Users;
 
 [Collection(nameof(UsersCollection))]
-public sealed class GetUserEditDetailsTests(CollectionFixture fixture)
+public sealed class GetUserEditDetailsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string BasePath = "/users";
 
@@ -17,21 +18,54 @@ public sealed class GetUserEditDetailsTests(CollectionFixture fixture)
     private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
     private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
 
+    private int _userId;
+    private string _email = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        CreateUserCommand createCommand = new CreateUserCommandBuilder().Build();
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync(BasePath, createCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+        _email = createCommand.Email;
+        List<UserSummary>? users = await _authorizedHttpClient.GetFromJsonAsync<List<UserSummary>>(BasePath, CancellationToken.None);
+        _userId = users!.First(u => u.Email == _email).UserId;
+        ChangeUserRoleCommand roleCommand = new(["Admin"]);
+        await _authorizedHttpClient.PatchAsJsonAsync($"{BasePath}/{_userId}/role", roleCommand, CancellationToken.None);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_userId != 0)
+        {
+            try
+            {
+                await _authorizedHttpClient.DeleteAsync($"{BasePath}/{_userId}", CancellationToken.None);
+            }
+            catch (HttpRequestException)
+            {
+                // Best-effort cleanup; do not mask test failures.
+            }
+        }
+
+        _authorizedHttpClient.Dispose();
+        _nonAdminHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
+    }
+
     [Fact]
     public async Task ReturnsOk_WithUserDetails_WhenUserExists()
     {
         // Arrange
-        int userId = await GetSeededUserIdAsync();
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.GetAsync(
-            $"{BasePath}/{userId}/edit", CancellationToken.None);
+            $"{BasePath}/{_userId}/edit", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         UserEditDetails? details = await response.Content.ReadFromJsonAsync<UserEditDetails>(CancellationToken.None);
         details.ShouldNotBeNull();
-        details.Email.ShouldBe(Constants.TestUser.Email);
+        details.Email.ShouldBe(_email);
         details.Roles.ShouldContain("Admin");
     }
 
@@ -50,11 +84,10 @@ public sealed class GetUserEditDetailsTests(CollectionFixture fixture)
     public async Task ReturnsForbidden_WhenUserIsNotAdmin()
     {
         // Arrange
-        int userId = await GetSeededUserIdAsync();
 
         // Act
         HttpResponseMessage response = await _nonAdminHttpClient.GetAsync(
-            $"{BasePath}/{userId}/edit", CancellationToken.None);
+            $"{BasePath}/{_userId}/edit", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
@@ -69,12 +102,5 @@ public sealed class GetUserEditDetailsTests(CollectionFixture fixture)
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
-    }
-
-    private async Task<int> GetSeededUserIdAsync()
-    {
-        List<UserSummary>? users = await _authorizedHttpClient.GetFromJsonAsync<List<UserSummary>>(BasePath, CancellationToken.None);
-        UserSummary user = users!.First(u => u.Email == Constants.TestUser.Email);
-        return user.UserId;
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Users/GetUsersTest.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Users/GetUsersTest.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Users;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
 using Shouldly;
@@ -9,19 +10,44 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Users;
 
 [Collection(nameof(UsersCollection))]
-public sealed class GetUsersTest
+public sealed class GetUsersTest(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string Path = "/users";
 
-    private readonly HttpClient _authorizedHttpClient;
-    private readonly HttpClient _nonAdminHttpClient;
-    private readonly HttpClient _unauthorizedHttpClient;
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
 
-    public GetUsersTest(CollectionFixture fixture)
+    private int _userId;
+    private string _email = string.Empty;
+
+    public async ValueTask InitializeAsync()
     {
-        _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
-        _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
-        _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+        CreateUserCommand createCommand = new CreateUserCommandBuilder().Build();
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync(Path, createCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+        _email = createCommand.Email;
+        List<UserSummary>? users = await _authorizedHttpClient.GetFromJsonAsync<List<UserSummary>>(Path, CancellationToken.None);
+        _userId = users!.First(u => u.Email == _email).UserId;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_userId != 0)
+        {
+            try
+            {
+                await _authorizedHttpClient.DeleteAsync($"{Path}/{_userId}", CancellationToken.None);
+            }
+            catch (HttpRequestException)
+            {
+                // Best-effort cleanup; do not mask test failures.
+            }
+        }
+
+        _authorizedHttpClient.Dispose();
+        _nonAdminHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
     }
 
     [Fact]
@@ -57,7 +83,7 @@ public sealed class GetUsersTest
         IReadOnlyList<UserSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<UserSummary>>(Path, CancellationToken.None);
 
         // Assert
-        response!.ShouldContain(x => x.Email == Constants.TestUser.Email);
+        response!.ShouldContain(x => x.Email == _email);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `GetUsersTest`: convert to primary constructor + `IAsyncLifetime`; creates own user in `InitializeAsync`, deletes in `DisposeAsync`; replaces `Constants.TestUser.Email` containment check with `_email`
- `GetUserEditDetailsTests`: add `IAsyncLifetime`; creates user and assigns Admin role via `PATCH /users/{id}/role` in `InitializeAsync`; replaces `GetSeededUserIdAsync()` calls with `_userId`; asserts `details.Email.ShouldBe(_email)` and keeps `details.Roles.ShouldContain("Admin")`

`ChangePasswordTests`, `DeleteUserTests`, `ChangeUserRoleTests`, and `LoginTests` are unchanged — their seeded-user dependencies are inherent to the auth identity mechanism.

Part of #387 — step 4 of 9.

## Test plan

- [ ] All 402 integration tests pass
- [ ] `GetUserEditDetailsTests.ReturnsOk_WithUserDetails_WhenUserExists` verifies the created user's email and Admin role
- [ ] `GetUsersTest.ReturnsTestUser` verifies the created user appears in the list