### PR TITLE
refactor(tests): migrate meets test classes to own test data (step 5)

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/AddParticipantTests.cs
@@ -10,19 +10,40 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 
 [Collection(nameof(MeetsCollection))]
-public sealed class AddParticipantTests(CollectionFixture fixture)
+public sealed class AddParticipantTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    private const int ExistingMeetId = 2;
-    private const int MeetWithExistingParticipationId = 1;
     private const int NonExistentMeetId = 99999;
-    private const int MeetForTeamTest = 5;
-    private const int NegativeBodyWeightTestMeetId = 4;
-    private const int BodyWeightExceedsMaxMeetId = 7;
-    private const int BodyWeightJustAboveMaxMeetId = 8;
     private const int ExistingTeamId = 1;
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
     private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private int _meetId;
+    private string _meetSlug = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder().Build();
+
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync("/meets", command, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}", CancellationToken.None);
+        _meetId = details!.MeetId;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_meetId != 0)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
+    }
 
     [Fact]
     public async Task ReturnsCreated_WhenSuccessful()
@@ -35,7 +56,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
@@ -53,7 +74,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/3/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
@@ -70,7 +91,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -102,7 +123,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -116,9 +137,13 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
             .WithAthleteSlug(Constants.TestAthleteSlug)
             .Build();
 
+        HttpResponseMessage firstResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
+        firstResponse.EnsureSuccessStatusCode();
+
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{MeetWithExistingParticipationId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
@@ -135,7 +160,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{BodyWeightExceedsMaxMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -152,7 +177,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{BodyWeightJustAboveMaxMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -162,14 +187,14 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
     public async Task ReturnsUnauthorized_WhenNameClaimIsMissing()
     {
         // Arrange
-        HttpClient noNameClaimHttpClient = fixture.CreateNoNameClaimHttpClient();
+        using HttpClient noNameClaimHttpClient = fixture.CreateNoNameClaimHttpClient();
         AddParticipantCommand command = new AddParticipantCommandBuilder()
             .WithAthleteSlug(Constants.TestAthleteSlug)
             .Build();
 
         // Act
         HttpResponseMessage response = await noNameClaimHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -187,7 +212,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{MeetForTeamTest}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
@@ -205,7 +230,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{ExistingMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
@@ -224,7 +249,7 @@ public sealed class AddParticipantTests(CollectionFixture fixture)
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{NegativeBodyWeightTestMeetId}/participants", command, CancellationToken.None);
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Meets;
@@ -10,17 +10,37 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 
 [Collection(nameof(MeetsCollection))]
-public sealed class GetMeetsTests
+public sealed class GetMeetsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string Path = "/meets";
 
-    private readonly HttpClient _authorizedHttpClient;
-    private readonly HttpClient _unauthorizedHttpClient;
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private string _meetSlug = string.Empty;
+    private string _meetTitle = string.Empty;
 
-    public GetMeetsTests(CollectionFixture fixture)
+    public async ValueTask InitializeAsync()
     {
-        _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
-        _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+        CreateMeetCommand command = new CreateMeetCommandBuilder()
+            .WithStartDate(new DateOnly(2099, 1, 1))
+            .Build();
+
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync(Path, command, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
+        _meetTitle = command.Title;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!string.IsNullOrEmpty(_meetSlug))
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
     }
 
     [Fact]
@@ -51,37 +71,40 @@ public sealed class GetMeetsTests
     public async Task ReturnsMeets()
     {
         // Arrange
-        CreateMeetCommand command = new CreateMeetCommandBuilder().Build();
-        await _authorizedHttpClient.PostAsJsonAsync(Path, command, CancellationToken.None);
 
         // Act
         IReadOnlyList<MeetSummary>? response = await _unauthorizedHttpClient.GetFromJsonAsync<IReadOnlyList<MeetSummary>>(Path, CancellationToken.None);
 
         // Assert
-        response!.ShouldContain(x => x.Title == command.Title);
+        response!.ShouldContain(x => x.Title == _meetTitle);
     }
 
     [Fact]
     public async Task OnlyReturnsMeetsWithSpecifiedYear()
     {
         // Arrange
-        int year = 2023;
+        int year = 2099;
         string path = $"{Path}?year={year}";
-
-        CreateMeetCommand firstCommand = new CreateMeetCommandBuilder()
-            .WithStartDate(new DateOnly(year, 1, 1))
-            .Build();
-        await _authorizedHttpClient.PostAsJsonAsync(Path, firstCommand, CancellationToken.None);
 
         CreateMeetCommand secondCommand = new CreateMeetCommandBuilder()
             .WithStartDate(new DateOnly(2025, 1, 1))
             .Build();
-        await _authorizedHttpClient.PostAsJsonAsync(Path, secondCommand, CancellationToken.None);
+        HttpResponseMessage secondCreateResponse = await _authorizedHttpClient.PostAsJsonAsync(Path, secondCommand, CancellationToken.None);
+        secondCreateResponse.EnsureSuccessStatusCode();
+        string secondMeetSlug = secondCreateResponse.Headers.Location!.ToString().TrimStart('/');
 
-        // Act
-        IReadOnlyList<MeetSummary>? response = await _unauthorizedHttpClient.GetFromJsonAsync<IReadOnlyList<MeetSummary>>(path, CancellationToken.None);
+        try
+        {
+            // Act
+            IReadOnlyList<MeetSummary>? response = await _unauthorizedHttpClient.GetFromJsonAsync<IReadOnlyList<MeetSummary>>(path, CancellationToken.None);
 
-        // Assert
-        response!.ShouldAllBe(x => x.StartDate.Year == year);
+            // Assert
+            response!.ShouldNotBeEmpty();
+            response.ShouldAllBe(x => x.StartDate.Year == year);
+        }
+        finally
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{secondMeetSlug}", CancellationToken.None);
+        }
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
@@ -11,25 +11,53 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 
 [Collection(nameof(MeetsCollection))]
-public sealed class RemoveParticipantTests(CollectionFixture fixture)
+public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const int NonExistentMeetId = 99999;
     private const int NonExistentParticipationId = 99999;
-    private const int ExistingMeetId = 4;
+    private const int IrrelevantParticipationId = int.MaxValue;
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
     private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
     private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private int _meetId;
+    private string _meetSlug = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder().Build();
+
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync("/meets", command, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}", CancellationToken.None);
+        _meetId = details!.MeetId;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_meetId != 0)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+        _nonAdminHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
+    }
 
     [Fact]
     public async Task ReturnsNoContent_WhenSuccessful()
     {
         // Arrange
-        int participationId = await AddParticipantAsync(ExistingMeetId);
+        int participationId = await AddParticipantAsync(_meetId);
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync(
-            $"/meets/{ExistingMeetId}/participants/{participationId}", CancellationToken.None);
+            $"/meets/{_meetId}/participants/{participationId}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
@@ -40,7 +68,7 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture)
     {
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync(
-            $"/meets/{ExistingMeetId}/participants/{NonExistentParticipationId}", CancellationToken.None);
+            $"/meets/{_meetId}/participants/{NonExistentParticipationId}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -65,7 +93,7 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture)
     {
         // Act
         HttpResponseMessage response = await _nonAdminHttpClient.DeleteAsync(
-            $"/meets/{ExistingMeetId}/participants/1", CancellationToken.None);
+            $"/meets/{_meetId}/participants/{IrrelevantParticipationId}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
@@ -76,7 +104,7 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture)
     {
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.DeleteAsync(
-            $"/meets/{ExistingMeetId}/participants/1", CancellationToken.None);
+            $"/meets/{_meetId}/participants/{IrrelevantParticipationId}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);


### PR DESCRIPTION
## Summary

- `GetMeetsTests`, `AddParticipantTests`, `RemoveParticipantTests` now implement `IAsyncLifetime` and create their own meets per-test instead of relying on hardcoded seeded row IDs
- Two-step init for participant tests: POST `/meets` → GET `/meets/{slug}` to extract integer `MeetId` (Location header returns a slug, not an ID)
- `DisposeAsync` uses guard + plain `DeleteAsync` (no try/catch — `HttpClient` doesn't throw on 4xx responses)
- `OnlyReturnsMeetsWithSpecifiedYear` uses year 2099 (avoids collision with any seeded data) and cleans up the inline second meet with `try/finally`

Closes part of #387 (step 5 of 9).

## Test plan

- [ ] 22 affected tests pass: `GetMeetsTests`, `AddParticipantTests`, `RemoveParticipantTests`
- [ ] No hardcoded seeded meet IDs remain in the 3 migrated classes
- [ ] `DisposeAsync` pattern matches the established convention (guard + fire-and-forget `DeleteAsync`)