### PR TITLE
refactor(tests): migrate UpdateBodyWeightTests and RecordAttemptTests to own test data (step 6)

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
@@ -15,34 +15,53 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 
 [Collection(nameof(RecordAttemptsCollection))]
-public sealed class RecordAttemptTests
+public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    private const int SeedMeetId = 1;
-    private const int SeedParticipationId = 2;
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+    private int _meetId;
+    private string _meetSlug = string.Empty;
+    private int _participationId;
 
-    private readonly CollectionFixture _fixture;
-    private readonly HttpClient _authorizedHttpClient;
-    private readonly HttpClient _unauthorizedHttpClient;
-    private readonly HttpClient _nonAdminHttpClient;
-
-    public RecordAttemptTests(CollectionFixture fixture)
+    public async ValueTask InitializeAsync()
     {
-        _fixture = fixture;
-        _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
-        _unauthorizedHttpClient = fixture.Factory!.CreateClient();
-        _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+        CreateMeetCommand meetCommand = new CreateMeetCommandBuilder().Build();
+
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync("/meets", meetCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}", CancellationToken.None);
+        _meetId = details!.MeetId;
+
+        _participationId = await AddParticipantAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_meetId != 0)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
+        _nonAdminHttpClient.Dispose();
     }
 
     [Fact]
     public async Task ReturnsNoContent_WhenCreatingNewAttempt()
     {
         // Arrange
-        int participationId = await AddParticipantToSeedMeet();
+        int participationId = await AddParticipantAsync();
         RecordAttemptCommand command = new RecordAttemptCommandBuilder().Build();
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, participationId, Discipline.Squat, 1),
+            Path(_meetId, participationId, Discipline.Squat, 1),
             command,
             CancellationToken.None);
 
@@ -54,15 +73,8 @@ public sealed class RecordAttemptTests
     public async Task ReturnsNoContent_WhenUpdatingExistingAttempt()
     {
         // Arrange
-        int participationId = await AddParticipantToSeedMeet();
-        RecordAttemptCommand createCommand = new RecordAttemptCommandBuilder()
-            .WithWeight(100.0m)
-            .Build();
-
-        await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, participationId, Discipline.Squat, 1),
-            createCommand,
-            CancellationToken.None);
+        int participationId = await AddParticipantAsync();
+        await RecordAttempt(participationId, Discipline.Squat, 1, 100.0m, true);
 
         RecordAttemptCommand updateCommand = new RecordAttemptCommandBuilder()
             .WithWeight(110.0m)
@@ -70,7 +82,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, participationId, Discipline.Squat, 1),
+            Path(_meetId, participationId, Discipline.Squat, 1),
             updateCommand,
             CancellationToken.None);
 
@@ -82,7 +94,7 @@ public sealed class RecordAttemptTests
     public async Task TotalsRecalculated_AfterAttemptRecorded()
     {
         // Arrange
-        int participationId = await AddParticipantToSeedMeet();
+        int participationId = await AddParticipantAsync();
 
         await RecordAttempt(participationId, Discipline.Squat, 1, 100.0m, true);
         await RecordAttempt(participationId, Discipline.Squat, 2, 110.0m, true);
@@ -96,7 +108,7 @@ public sealed class RecordAttemptTests
         // Assert - best good lifts: Squat=110, Bench=70, Deadlift=160, Total=340
         IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
             .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
-                $"/meets/{Constants.TestMeetSlug}/participations",
+                $"/meets/{_meetSlug}/participations",
                 CancellationToken.None);
 
         participations.ShouldNotBeNull();
@@ -111,7 +123,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, 99999, Discipline.Squat, 1),
+            Path(_meetId, 99999, Discipline.Squat, 1),
             command,
             CancellationToken.None);
 
@@ -127,7 +139,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(99999, SeedParticipationId, Discipline.Squat, 1),
+            Path(99999, _participationId, Discipline.Squat, 1),
             command,
             CancellationToken.None);
 
@@ -143,7 +155,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, SeedParticipationId, Discipline.Squat, 1),
+            Path(_meetId, _participationId, Discipline.Squat, 1),
             command,
             CancellationToken.None);
 
@@ -159,7 +171,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _nonAdminHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, SeedParticipationId, Discipline.Squat, 1),
+            Path(_meetId, _participationId, Discipline.Squat, 1),
             command,
             CancellationToken.None);
 
@@ -175,7 +187,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, SeedParticipationId, (Discipline)99, 1),
+            Path(_meetId, _participationId, (Discipline)99, 1),
             command,
             CancellationToken.None);
 
@@ -191,7 +203,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, SeedParticipationId, Discipline.Squat, 4),
+            Path(_meetId, _participationId, Discipline.Squat, 4),
             command,
             CancellationToken.None);
 
@@ -209,7 +221,7 @@ public sealed class RecordAttemptTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, SeedParticipationId, Discipline.Squat, 1),
+            Path(_meetId, _participationId, Discipline.Squat, 1),
             command,
             CancellationToken.None);
 
@@ -221,7 +233,7 @@ public sealed class RecordAttemptTests
     public async Task BombedOut_WhenNoBenchGoodLifts()
     {
         // Arrange - all bench attempts are no-good
-        int participationId = await AddParticipantToSeedMeet();
+        int participationId = await AddParticipantAsync();
 
         await RecordAttempt(participationId, Discipline.Squat, 1, 100.0m, true);
         await RecordAttempt(participationId, Discipline.Bench, 1, 60.0m, false);
@@ -232,22 +244,23 @@ public sealed class RecordAttemptTests
         // Act
         IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
             .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
-                $"/meets/{Constants.TestMeetSlug}/participations",
+                $"/meets/{_meetSlug}/participations",
                 CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
         MeetParticipation? bombedOut = participations
-            .LastOrDefault(p => p.Total == 0m && p.Attempts.Any());
+            .FirstOrDefault(p => p.ParticipationId == participationId);
 
         bombedOut.ShouldNotBeNull();
+        bombedOut.Total.ShouldBe(0m);
     }
 
     [Fact]
     public async Task AttemptPersistedThroughAggregate_WhenRecordedViaParticipation()
     {
         // Arrange
-        int participationId = await AddParticipantToSeedMeet();
+        int participationId = await AddParticipantAsync();
 
         // Act
         await RecordAttempt(participationId, Discipline.Squat, 1, 120.0m, true);
@@ -255,7 +268,7 @@ public sealed class RecordAttemptTests
         // Assert — retrieve participation and verify attempt is persisted and retrievable
         IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
             .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
-                $"/meets/{Constants.TestMeetSlug}/participations",
+                $"/meets/{_meetSlug}/participations",
                 CancellationToken.None);
 
         participations.ShouldNotBeNull();
@@ -276,13 +289,13 @@ public sealed class RecordAttemptTests
     {
         // Arrange — create participant, record rounds 1 and 2, then inject a legacy round 4 attempt
         // (weight 0, good = true) as the old system stored as a placeholder
-        int participationId = await AddParticipantToSeedMeet();
+        int participationId = await AddParticipantAsync();
 
         await RecordAttempt(participationId, Discipline.Squat, 1, 100.0m, true);
         await RecordAttempt(participationId, Discipline.Squat, 2, 110.0m, true);
 
         DbContextOptions<ResultsDbContext> dbOptions = new DbContextOptionsBuilder<ResultsDbContext>()
-            .UseSqlServer(_fixture.Database!.ConnectionString)
+            .UseSqlServer(fixture.Database!.ConnectionString)
             .Options;
 
         await using (ResultsDbContext dbContext = new(dbOptions))
@@ -298,7 +311,7 @@ public sealed class RecordAttemptTests
 
         // Act — editing round 3 must not be blocked by the legacy round 4 entry
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, participationId, Discipline.Squat, 3),
+            Path(_meetId, participationId, Discipline.Squat, 3),
             command,
             CancellationToken.None);
 
@@ -317,14 +330,14 @@ public sealed class RecordAttemptTests
             .Build();
 
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
-            Path(SeedMeetId, participationId, discipline, round),
+            Path(_meetId, participationId, discipline, round),
             command,
             CancellationToken.None);
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
     }
 
-    private async Task<int> AddParticipantToSeedMeet()
+    private async Task<int> AddParticipantAsync()
     {
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
         HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
@@ -341,9 +354,11 @@ public sealed class RecordAttemptTests
             .Build();
 
         HttpResponseMessage participantResponse = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
+
+        participantResponse.EnsureSuccessStatusCode();
 
         AddParticipantResponse? result = await participantResponse.Content
             .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateBodyWeightTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateBodyWeightTests.cs
@@ -12,31 +12,76 @@ using Shouldly;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 
 [Collection(nameof(MeetsCollection))]
-public sealed class UpdateBodyWeightTests
+public sealed class UpdateBodyWeightTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    private const int SeedMeetId = 1;
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
+    private readonly HttpClient _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+    private int _meetId;
+    private string _meetSlug = string.Empty;
+    private int _participationId;
 
-    private readonly HttpClient _authorizedHttpClient;
-    private readonly HttpClient _unauthorizedHttpClient;
-    private readonly HttpClient _nonAdminHttpClient;
-
-    public UpdateBodyWeightTests(CollectionFixture fixture)
+    public async ValueTask InitializeAsync()
     {
-        _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
-        _unauthorizedHttpClient = fixture.Factory!.CreateClient();
-        _nonAdminHttpClient = fixture.CreateNonAdminAuthorizedHttpClient();
+        CreateMeetCommand meetCommand = new CreateMeetCommandBuilder().Build();
+
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync("/meets", meetCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}", CancellationToken.None);
+        _meetId = details!.MeetId;
+
+        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
+        HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes",
+            athleteCommand,
+            CancellationToken.None);
+
+        athleteResponse.EnsureSuccessStatusCode();
+
+        string athleteSlug = Slug.Create($"{athleteCommand.FirstName} {athleteCommand.LastName}");
+
+        AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .Build();
+
+        HttpResponseMessage participantResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{_meetId}/participants",
+            participantCommand,
+            CancellationToken.None);
+
+        participantResponse.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await participantResponse.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        _participationId = result!.ParticipationId;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_meetId != 0)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
+        _nonAdminHttpClient.Dispose();
     }
 
     [Fact]
     public async Task ReturnsNoContent_WhenSuccessful()
     {
         // Arrange
-        int participationId = await AddParticipantToSeedMeet();
         UpdateBodyWeightCommand command = new(85.50m);
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, participationId),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
@@ -48,24 +93,23 @@ public sealed class UpdateBodyWeightTests
     public async Task UpdatesBodyWeight_WhenSuccessful()
     {
         // Arrange
-        int participationId = await AddParticipantToSeedMeet();
         decimal newWeight = 92.75m;
         UpdateBodyWeightCommand command = new(newWeight);
 
         // Act
         await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, participationId),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
         // Assert
         List<MeetParticipation>? participations = await _authorizedHttpClient
             .GetFromJsonAsync<List<MeetParticipation>>(
-                $"/meets/{Constants.TestMeetSlug}/participations",
+                $"/meets/{_meetSlug}/participations",
                 CancellationToken.None);
 
         participations.ShouldNotBeNull();
-        participations.ShouldContain(p => p.ParticipationId == participationId && p.BodyWeight == newWeight);
+        participations.ShouldContain(p => p.ParticipationId == _participationId && p.BodyWeight == newWeight);
     }
 
     [Fact]
@@ -76,7 +120,7 @@ public sealed class UpdateBodyWeightTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, 99999),
+            Path(_meetId, 99999),
             command,
             CancellationToken.None);
 
@@ -92,7 +136,7 @@ public sealed class UpdateBodyWeightTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(99999, 1),
+            Path(99999, _participationId),
             command,
             CancellationToken.None);
 
@@ -108,7 +152,7 @@ public sealed class UpdateBodyWeightTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, 1),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
@@ -124,7 +168,7 @@ public sealed class UpdateBodyWeightTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, 1),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
@@ -140,7 +184,7 @@ public sealed class UpdateBodyWeightTests
 
         // Act
         HttpResponseMessage response = await _unauthorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, 1),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
@@ -156,7 +200,7 @@ public sealed class UpdateBodyWeightTests
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, 1),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
@@ -168,12 +212,11 @@ public sealed class UpdateBodyWeightTests
     public async Task ReturnsNoContent_WhenBodyWeightIsAtMaximum()
     {
         // Arrange
-        int participationId = await AddParticipantToSeedMeet();
         UpdateBodyWeightCommand command = new(400.0m);
 
         // Act
         HttpResponseMessage response = await _authorizedHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, participationId),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
@@ -189,7 +232,7 @@ public sealed class UpdateBodyWeightTests
 
         // Act
         HttpResponseMessage response = await _nonAdminHttpClient.PatchAsJsonAsync(
-            Path(SeedMeetId, 1),
+            Path(_meetId, _participationId),
             command,
             CancellationToken.None);
 
@@ -199,31 +242,4 @@ public sealed class UpdateBodyWeightTests
 
     private static string Path(int meetId, int participationId) =>
         $"/meets/{meetId}/participations/{participationId}";
-
-    private async Task<int> AddParticipantToSeedMeet()
-    {
-        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
-        HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
-            "/athletes",
-            athleteCommand,
-            CancellationToken.None);
-
-        athleteResponse.EnsureSuccessStatusCode();
-
-        string athleteSlug = ValueObjects.Slug.Create($"{athleteCommand.FirstName} {athleteCommand.LastName}");
-
-        AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
-            .WithAthleteSlug(athleteSlug)
-            .Build();
-
-        HttpResponseMessage participantResponse = await _authorizedHttpClient.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
-            participantCommand,
-            CancellationToken.None);
-
-        AddParticipantResponse? result = await participantResponse.Content
-            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
-
-        return result!.ParticipationId;
-    }
 }


### PR DESCRIPTION
## Summary

- `UpdateBodyWeightTests` and `RecordAttemptTests` now implement `IAsyncLifetime`
- `InitializeAsync` creates a fresh meet + athlete + participant per test; no hardcoded seeded row IDs remain
- `DisposeAsync` uses guard + fire-and-forget `DeleteAsync` on the meet (meets with participants return 409 — intentionally ignored, container is ephemeral)
- `BombedOut_WhenNoBenchGoodLifts` assertion tightened: now scoped to the specific `participationId` created in Arrange rather than searching all participations
- `ReturnsNoContent_WhenUpdatingExistingAttempt` Arrange now uses the `RecordAttempt` helper (which asserts success) instead of unchecked inline `PutAsJsonAsync`

Closes #393 and #394. Part of #387 (step 6 of 9).

## Test plan

- [ ] 23 affected tests pass: `UpdateBodyWeightTests` (10), `RecordAttemptTests` (13)
- [ ] No hardcoded seeded row IDs remain in either class
- [ ] `DisposeAsync` pattern matches the established convention