### PR TITLE
test(webapi): migrate ComputeRecordsTests to IAsyncLifetime

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/RecordTestAthleteBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/RecordTestAthleteBuilder.cs
@@ -75,6 +75,11 @@ internal sealed class RecordTestAthleteBuilder(ResultsDbContext dbContext, int b
         decimal total = _squat + _bench + _deadlift;
         string slug = $"rectest-{baseId}";
 
+        string squat = _squat.ToString(CultureInfo.InvariantCulture);
+        string bench = _bench.ToString(CultureInfo.InvariantCulture);
+        string deadlift = _deadlift.ToString(CultureInfo.InvariantCulture);
+        string totalStr = total.ToString(CultureInfo.InvariantCulture);
+
         string seedSql =
             $"""
             DELETE FROM Records WHERE AttemptId IN ({squatAttemptId}, {benchAttemptId}, {deadliftAttemptId});
@@ -89,16 +94,16 @@ internal sealed class RecordTestAthleteBuilder(ResultsDbContext dbContext, int b
 
             SET IDENTITY_INSERT Participations ON;
             INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-            VALUES ({participationId}, {athleteId}, {_meetId}, 90.0, {_weightCategoryId}, {_ageCategoryId}, 1, 0, {_squat}, {_bench}, {_deadlift}, {total}, 400.0, 90.0, 50);
+            VALUES ({participationId}, {athleteId}, {_meetId}, 90.0, {_weightCategoryId}, {_ageCategoryId}, 1, 0, {squat}, {bench}, {deadlift}, {totalStr}, 400.0, 90.0, 50);
             SET IDENTITY_INSERT Participations OFF;
 
             SET IDENTITY_INSERT Attempts ON;
             INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({squatAttemptId}, {participationId}, 1, 1, {_squat}, 1, 'test', 'test');
+            VALUES ({squatAttemptId}, {participationId}, 1, 1, {squat}, 1, 'test', 'test');
             INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({benchAttemptId}, {participationId}, 2, 1, {_bench}, 1, 'test', 'test');
+            VALUES ({benchAttemptId}, {participationId}, 2, 1, {bench}, 1, 'test', 'test');
             INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({deadliftAttemptId}, {participationId}, 3, 1, {_deadlift}, 1, 'test', 'test');
+            VALUES ({deadliftAttemptId}, {participationId}, 3, 1, {deadlift}, 1, 'test', 'test');
             SET IDENTITY_INSERT Attempts OFF;
             """;
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
@@ -27,7 +27,6 @@ namespace KRAFT.Results.WebApi.IntegrationTests.Features.Records;
 [Collection(nameof(RecordsCollection))]
 public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    private const int SeedMeetId = 1;
     private const int RecordTestParticipationId = 100;
     private const int RecordTestAttemptId = 100;
     private const string AttemptWeightSql = "300.0";
@@ -143,7 +142,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -226,7 +225,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -292,7 +291,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -408,7 +407,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -461,7 +460,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -546,7 +545,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -622,7 +621,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -691,7 +690,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -760,7 +759,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -890,7 +889,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -967,7 +966,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantAResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantACommand,
             CancellationToken.None);
 
@@ -981,7 +980,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantBResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantBCommand,
             CancellationToken.None);
 
@@ -1080,7 +1079,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantAResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantACommand,
             CancellationToken.None);
 
@@ -1094,7 +1093,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantBResponse = await client.PostAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants",
+            $"/meets/{_meetId}/participants",
             participantBCommand,
             CancellationToken.None);
 
@@ -2075,26 +2074,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         }
     }
 
-    private static async Task RecordAttempt(
-        HttpClient client,
-        int participationId,
-        Discipline discipline,
-        int round,
-        decimal weight)
-    {
-        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
-            .WithWeight(weight)
-            .WithGood(true)
-            .Build();
-
-        HttpResponseMessage response = await client.PutAsJsonAsync(
-            $"/meets/{SeedMeetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
-            command,
-            CancellationToken.None);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
-    }
-
     private static async Task RecordAttemptForMeet(
         HttpClient client,
         int meetId,
@@ -2131,44 +2110,26 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await dbContext.Database.ExecuteSqlRawAsync(sql);
     }
 
-    /// <summary>
-    /// Removes non-seed participations (and their attempts/records) from the 83kg slot
-    /// in the seed meet. This prevents leftover data from prior endpoint-based tests
-    /// from interfering with the FullRebuildSlotsAsync computation.
-    /// </summary>
-    private static async Task CleanupStaleTestDataFor83KgAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            DELETE FROM Records WHERE AttemptId IN (
-                SELECT a.AttemptId FROM Attempts a
-                INNER JOIN Participations p ON a.ParticipationId = p.ParticipationId
-                WHERE p.WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
-                AND p.MeetId = {TestSeedConstants.Meet.Id}
-                AND p.ParticipationId NOT IN (1, 2, 3));
-            DELETE FROM Attempts WHERE ParticipationId IN (
-                SELECT ParticipationId FROM Participations
-                WHERE WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
-                AND MeetId = {TestSeedConstants.Meet.Id}
-                AND ParticipationId NOT IN (1, 2, 3));
-            DELETE FROM Participations
-            WHERE WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
-            AND MeetId = {TestSeedConstants.Meet.Id}
-            AND ParticipationId NOT IN (1, 2, 3);
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
     private static async Task RestoreClassic83KgSeedRecordAsync(ResultsDbContext dbContext)
     {
         // Slot rebuilds create chain records for seed attempts (AttemptId=1,2,3) across all age categories.
         // Delete all classic records for those attempts first, then restore the canonical seed record.
+        // Also restore seed AttemptIds 4,5 (squats for ParticipationId=1) that ClearAllRecordCategoriesAsync deletes.
         string sql =
             $"""
             DELETE FROM Records WHERE AttemptId IN (1, 2, 3) AND IsRaw = 1;
             INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
             VALUES ({TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.OpenId}, {TestSeedConstants.WeightCategory.Id83Kg}, 1, 195.0, '2025-03-15', 0, 1, 1, 1, 'seed');
+
+            IF NOT EXISTS (SELECT 1 FROM Attempts WHERE AttemptId = 4)
+            BEGIN
+                SET IDENTITY_INSERT Attempts ON;
+                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
+                VALUES (4, 1, 1, 2, 210.0, 1, 'seed', 'seed');
+                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
+                VALUES (5, 1, 1, 1, 190.0, 1, 'seed', 'seed');
+                SET IDENTITY_INSERT Attempts OFF;
+            END
             """;
 
         await dbContext.Database.ExecuteSqlRawAsync(sql, TestContext.Current.CancellationToken);
@@ -2188,6 +2149,9 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             AND RecordCategoryId IN (1, 2, 3, 4, 5, 6)
             AND IsRaw = 1
             AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg};
+
+            DELETE FROM Records WHERE AttemptId IN (4, 5);
+            DELETE FROM Attempts WHERE AttemptId IN (4, 5);
             """;
 
         await dbContext.Database.ExecuteSqlRawAsync(sql);
@@ -2272,6 +2236,42 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
             VALUES ({RecordTestAttemptId}, {RecordTestParticipationId}, 1, 1, {AttemptWeightSql}, 1, 'test', 'test');
             SET IDENTITY_INSERT Attempts OFF;
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(sql);
+    }
+
+    private async Task RecordAttempt(
+        HttpClient client,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight)
+    {
+        await RecordAttemptForMeet(client, _meetId, participationId, discipline, round, weight);
+    }
+
+    /// <summary>
+    /// Removes non-seed participations (and their attempts/records) from the 83kg slot
+    /// in the seed meet. This prevents leftover data from prior endpoint-based tests
+    /// from interfering with the FullRebuildSlotsAsync computation.
+    /// </summary>
+    private async Task CleanupStaleTestDataFor83KgAsync(ResultsDbContext dbContext)
+    {
+        string sql =
+            $"""
+            DELETE FROM Records WHERE AttemptId IN (
+                SELECT a.AttemptId FROM Attempts a
+                INNER JOIN Participations p ON a.ParticipationId = p.ParticipationId
+                WHERE p.WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
+                AND p.MeetId = {_meetId});
+            DELETE FROM Attempts WHERE ParticipationId IN (
+                SELECT ParticipationId FROM Participations
+                WHERE WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
+                AND MeetId = {_meetId});
+            DELETE FROM Participations
+            WHERE WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
+            AND MeetId = {_meetId};
             """;
 
         await dbContext.Database.ExecuteSqlRawAsync(sql);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
@@ -25,13 +25,51 @@ using RecordEntity = KRAFT.Results.WebApi.Features.Records.Record;
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Records;
 
 [Collection(nameof(RecordsCollection))]
-public sealed class ComputeRecordsTests(CollectionFixture fixture)
+public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const int SeedMeetId = 1;
     private const int RecordTestParticipationId = 100;
     private const int RecordTestAttemptId = 100;
     private const string AttemptWeightSql = "300.0";
     private const decimal AttemptWeight = 300.0m;
+
+    private readonly HttpClient _setupHttpClient = fixture.CreateAuthorizedHttpClient();
+    private int _meetId;
+    private string _meetSlug = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        CreateMeetCommand meetCommand = new CreateMeetCommandBuilder()
+            .WithIsRaw(true)
+            .Build();
+
+        HttpResponseMessage createResponse = await _setupHttpClient.PostAsJsonAsync(
+            "/meets",
+            meetCommand,
+            CancellationToken.None);
+
+        createResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _setupHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}",
+            CancellationToken.None);
+
+        _meetId = details!.MeetId;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_meetId != 0)
+        {
+            await _setupHttpClient.DeleteAsync(
+                $"/meets/{_meetSlug}",
+                CancellationToken.None);
+        }
+
+        _setupHttpClient.Dispose();
+    }
 
     [Fact]
     public async Task WhenGoodAttemptBeatsCurrentRecord_CreatesRecordAndCascades()

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
@@ -207,8 +207,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await CleanupStaleTestDataFor83KgAsync(dbContext);
-
         DateOnly masters4DateOfBirth = new(1950, 1, 1);
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder()
             .WithDateOfBirth(masters4DateOfBirth)
@@ -526,8 +524,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await CleanupStaleTestDataFor83KgAsync(dbContext);
-
         DateOnly masters1DateOfBirth = new(1984, 1, 1);
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder()
             .WithDateOfBirth(masters1DateOfBirth)
@@ -603,8 +599,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await CleanupStaleTestDataFor83KgAsync(dbContext);
-
         DateOnly masters4DateOfBirth = new(1950, 1, 1);
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder()
             .WithDateOfBirth(masters4DateOfBirth)
@@ -672,8 +666,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await CleanupStaleTestDataFor83KgAsync(dbContext);
-
         DateOnly masters4DateOfBirth = new(1950, 1, 1);
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder()
             .WithDateOfBirth(masters4DateOfBirth)
@@ -740,8 +732,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        await CleanupStaleTestDataFor83KgAsync(dbContext);
 
         DateOnly masters4DateOfBirth = new(1950, 1, 1);
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder()
@@ -934,8 +924,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await CleanupStaleTestDataFor83KgAsync(dbContext);
-
         DateOnly masters4DateOfBirth = new(1950, 1, 1);
 
         CreateAthleteCommand athleteACommand = new CreateAthleteCommandBuilder()
@@ -1046,8 +1034,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        await CleanupStaleTestDataFor83KgAsync(dbContext);
 
         DateOnly masters4DateOfBirth = new(1950, 1, 1);
 
@@ -2168,31 +2154,5 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         decimal weight)
     {
         await RecordAttemptForMeet(client, _meetId, participationId, discipline, round, weight);
-    }
-
-    /// <summary>
-    /// Removes non-seed participations (and their attempts/records) from the 83kg slot
-    /// in the seed meet. This prevents leftover data from prior endpoint-based tests
-    /// from interfering with the FullRebuildSlotsAsync computation.
-    /// </summary>
-    private async Task CleanupStaleTestDataFor83KgAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            DELETE FROM Records WHERE AttemptId IN (
-                SELECT a.AttemptId FROM Attempts a
-                INNER JOIN Participations p ON a.ParticipationId = p.ParticipationId
-                WHERE p.WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
-                AND p.MeetId = {_meetId});
-            DELETE FROM Attempts WHERE ParticipationId IN (
-                SELECT ParticipationId FROM Participations
-                WHERE WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
-                AND MeetId = {_meetId});
-            DELETE FROM Participations
-            WHERE WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
-            AND MeetId = {_meetId};
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
@@ -27,9 +27,6 @@ namespace KRAFT.Results.WebApi.IntegrationTests.Features.Records;
 [Collection(nameof(RecordsCollection))]
 public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    private const int RecordTestParticipationId = 100;
-    private const int RecordTestAttemptId = 100;
-    private const string AttemptWeightSql = "300.0";
     private const decimal AttemptWeight = 300.0m;
 
     private readonly HttpClient _setupHttpClient = fixture.CreateAuthorizedHttpClient();
@@ -76,19 +73,25 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         // Arrange
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        await SeedRecordComputationTestDataAsync(dbContext);
-
         RecordComputationService service = scope.ServiceProvider.GetRequiredService<RecordComputationService>();
+
+        const int weightCategoryId = TestSeedConstants.WeightCategory.Id83Kg;
+
+        await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, TestContext.Current.CancellationToken);
+
+        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, 600)
+            .WithWeightCategoryId(weightCategoryId)
+            .WithSquat(AttemptWeight)
+            .BuildAsync(TestContext.Current.CancellationToken);
 
         try
         {
             // Act
-            await service.ComputeRecordsAsync(RecordTestAttemptId, CancellationToken.None);
+            await service.ComputeRecordsAsync(athlete.SquatAttemptId, CancellationToken.None);
 
-            // Assert â€" records should exist for full Masters4 cascade: masters4, masters3, masters2, masters1, open
+            // Assert — records should exist for full Masters4 cascade: masters4, masters3, masters2, masters1, open
             List<RecordEntity> createdRecords = await dbContext.Set<RecordEntity>()
-                .Where(r => r.AttemptId == RecordTestAttemptId)
+                .Where(r => r.AttemptId == athlete.SquatAttemptId)
                 .Where(r => r.IsCurrent)
                 .Where(r => r.IsRaw)
                 .Where(r => r.RecordCategoryId == RecordCategory.Squat)
@@ -109,11 +112,11 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
             createdRecords.ShouldAllBe(r => r.Weight == AttemptWeight);
             createdRecords.ShouldAllBe(r => r.EraId == TestSeedConstants.Era.CurrentId);
-            createdRecords.ShouldAllBe(r => r.WeightCategoryId == TestSeedConstants.WeightCategory.Id83Kg);
+            createdRecords.ShouldAllBe(r => r.WeightCategoryId == weightCategoryId);
         }
         finally
         {
-            await CleanupDirectSeedTestDataAsync(dbContext);
+            await athlete.DeleteAsync(dbContext, TestContext.Current.CancellationToken);
         }
     }
 
@@ -2152,90 +2155,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
             DELETE FROM Records WHERE AttemptId IN (4, 5);
             DELETE FROM Attempts WHERE AttemptId IN (4, 5);
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task CleanupDirectSeedTestDataAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            DELETE FROM Records WHERE AttemptId = {RecordTestAttemptId};
-            DELETE FROM Attempts WHERE AttemptId = {RecordTestAttemptId};
-            DELETE FROM Participations WHERE ParticipationId = {RecordTestParticipationId};
-
-            -- Restore athlete DoB changed by SeedRecordComputationTestDataAsync
-            UPDATE Athletes SET DateOfBirth = '{TestSeedConstants.Athlete.DateOfBirth:yyyy-MM-dd}' WHERE AthleteId = {TestSeedConstants.Athlete.Id};
-
-            -- Restore the open raw squat 83kg record that was deleted by SeedRecordComputationTestDataAsync
-            IF NOT EXISTS (
-                SELECT 1 FROM Records
-                WHERE EraId = {TestSeedConstants.Era.CurrentId}
-                AND AgeCategoryId = {TestSeedConstants.AgeCategory.OpenId}
-                AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
-                AND RecordCategoryId = 1
-                AND IsRaw = 1)
-            BEGIN
-                INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-                VALUES ({TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.OpenId}, {TestSeedConstants.WeightCategory.Id83Kg}, 1, 195.0, '2025-03-15', 0, 1, 1, 1, 'seed');
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task ClearMastersCascadeRecordsAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            DELETE FROM Records
-            WHERE AgeCategoryId IN (
-                {TestSeedConstants.AgeCategory.OpenId},
-                {TestSeedConstants.AgeCategory.Masters1Id},
-                {TestSeedConstants.AgeCategory.Masters2Id},
-                {TestSeedConstants.AgeCategory.Masters3Id},
-                {TestSeedConstants.AgeCategory.Masters4Id})
-            AND RecordCategoryId = 1
-            AND IsRaw = 1
-            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg};
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task SeedRecordComputationTestDataAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            -- Clear any existing records for masters age categories in raw squat 83kg to avoid interference
-            DELETE FROM Records
-            WHERE AgeCategoryId IN ({TestSeedConstants.AgeCategory.Masters1Id}, {TestSeedConstants.AgeCategory.Masters2Id}, {TestSeedConstants.AgeCategory.Masters3Id}, {TestSeedConstants.AgeCategory.Masters4Id})
-            AND RecordCategoryId = 1
-            AND IsRaw = 1
-            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg};
-
-            -- Also clear the open raw squat 83kg record to ensure our attempt beats it
-            DELETE FROM Records
-            WHERE AgeCategoryId = {TestSeedConstants.AgeCategory.OpenId}
-            AND RecordCategoryId = 1
-            AND IsRaw = 1
-            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg};
-
-            -- Set athlete DoB to Masters4 range so biological age cascades correctly
-            UPDATE Athletes SET DateOfBirth = '1950-01-01' WHERE AthleteId = {TestSeedConstants.Athlete.Id};
-
-            -- Participation in Masters4 age category for athlete 1 in test meet 1
-            SET IDENTITY_INSERT Participations ON;
-            INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-            VALUES ({RecordTestParticipationId}, {TestSeedConstants.Athlete.Id}, {TestSeedConstants.Meet.Id}, 80.5, {TestSeedConstants.WeightCategory.Id83Kg}, {TestSeedConstants.AgeCategory.Masters4Id}, 1, 0, {AttemptWeightSql}, 130.0, 250.0, 680.0, 450.0, 95.0, 50);
-            SET IDENTITY_INSERT Participations OFF;
-
-            -- Good squat attempt that beats any existing record
-            SET IDENTITY_INSERT Attempts ON;
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({RecordTestAttemptId}, {RecordTestParticipationId}, 1, 1, {AttemptWeightSql}, 1, 'test', 'test');
-            SET IDENTITY_INSERT Attempts OFF;
             """;
 
         await dbContext.Database.ExecuteSqlRawAsync(sql);


### PR DESCRIPTION
## Summary

- Migrates `ComputeRecordsTests` to implement `IAsyncLifetime`, creating a dedicated meet in `InitializeAsync` and deleting it in `DisposeAsync`
- Removes hardcoded `SeedMeetId = 1`, `RecordTestParticipationId = 100`, and `RecordTestAttemptId = 100`
- Migrates `WhenGoodAttemptBeatsCurrentRecord_CreatesRecordAndCascades` from inline SQL seeding to `RecordTestAthleteBuilder(dbContext, 200)`
- Removes dead/obsolete helpers: `SeedRecordComputationTestDataAsync`, `CleanupDirectSeedTestDataAsync`, `ClearMastersCascadeRecordsAsync`, `CleanupStaleTestDataFor83KgAsync`
- Fixes locale-sensitive decimal SQL formatting in `RecordTestAthleteBuilder` via `CultureInfo.InvariantCulture`

## Test plan

- [x] All 25 `ComputeRecordsTests` pass
- [x] Security review: no blocking findings
- [x] Performance review: no findings
- [x] Code review: blocking finding (no-op cleanup method) fixed and re-reviewed as passing

Closes #399. Part of #387.