### PR TITLE
test(webapi): migrate GetMeetParticipationsTests to IAsyncLifetime

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/CollectionFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/CollectionFixture.cs
@@ -69,11 +69,11 @@ public sealed class CollectionFixture : IAsyncLifetime
         return childFactory.CreateClient();
     }
 
-    public async Task ExecuteSqlAsync(string sql)
+    public async Task ExecuteSqlAsync(FormattableString sql)
     {
         await using AsyncServiceScope scope = Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
+        await dbContext.Database.ExecuteSqlAsync(sql);
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -2,23 +2,95 @@ using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
 using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
 
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 
 [Collection(nameof(MeetsCollection))]
-public sealed class GetMeetParticipationsTests
+public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    private const string Path = $"/meets/{Constants.OrderingMeet.Slug}/participations";
+    private readonly HttpClient _setupHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
+    private readonly string _suffix = UniqueShortCode.Next();
+    private readonly List<string> _athleteSlugs = [];
+    private int _meetId;
+    private string _meetSlug = string.Empty;
+    private string _charlieFullName = string.Empty;
+    private string _deltaFullName = string.Empty;
+    private string _bobFullName = string.Empty;
+    private string _annaFullName = string.Empty;
+    private int _charlieParticipationId;
+    private int _deltaParticipationId;
+    private int _bobParticipationId;
+    private int _annaParticipationId;
 
-    private readonly HttpClient _httpClient;
-
-    public GetMeetParticipationsTests(CollectionFixture fixture)
+    public async ValueTask InitializeAsync()
     {
-        _httpClient = fixture.Factory!.CreateClient();
+        CreateMeetCommand meetCommand = new CreateMeetCommandBuilder()
+            .WithIsRaw(true)
+            .Build();
+
+        HttpResponseMessage createResponse = await _setupHttpClient.PostAsJsonAsync(
+            "/meets", meetCommand, CancellationToken.None);
+        createResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _setupHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}", CancellationToken.None);
+        _meetId = details!.MeetId;
+
+        string charlieSlug = await CreateAthleteAsync("Charlie", $"Test{_suffix}");
+        string deltaSlug = await CreateAthleteAsync("Delta", $"Test{_suffix}");
+        string bobSlug = await CreateAthleteAsync("Bob", $"Test{_suffix}");
+        string annaSlug = await CreateAthleteAsync("Anna", $"Test{_suffix}");
+
+        _charlieFullName = $"Charlie Test{_suffix}";
+        _deltaFullName = $"Delta Test{_suffix}";
+        _bobFullName = $"Bob Test{_suffix}";
+        _annaFullName = $"Anna Test{_suffix}";
+
+        _charlieParticipationId = await AddParticipantAsync(charlieSlug);
+        _deltaParticipationId = await AddParticipantAsync(deltaSlug);
+        _bobParticipationId = await AddParticipantAsync(bobSlug);
+        _annaParticipationId = await AddParticipantAsync(annaSlug);
+
+        await RecordFullTotalAsync(_charlieParticipationId, 195.0m, 125.0m, 250.0m);
+        await RecordFullTotalAsync(_deltaParticipationId, 195.0m, 125.0m, 250.0m);
+        await RecordFullTotalAsync(_bobParticipationId, 170.0m, 110.0m, 220.0m);
+
+        await RecordAttempt(_annaParticipationId, Discipline.Squat, 1, 100.0m, false);
+        await RecordAttempt(_annaParticipationId, Discipline.Squat, 2, 100.0m, false);
+        await RecordAttempt(_annaParticipationId, Discipline.Squat, 3, 100.0m, false);
+
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Participations SET Place = 1 WHERE ParticipationId IN ({_charlieParticipationId}, {_deltaParticipationId})");
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Participations SET Place = 3 WHERE ParticipationId = {_bobParticipationId}");
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Participations SET Disqualified = 1 WHERE ParticipationId = {_annaParticipationId}");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_meetId != 0)
+        {
+            await _setupHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+        }
+
+        foreach (string slug in _athleteSlugs)
+        {
+            await _setupHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
+        }
+
+        _setupHttpClient.Dispose();
+        _httpClient.Dispose();
     }
 
     [Fact]
@@ -27,7 +99,8 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        HttpResponseMessage response = await _httpClient.GetAsync(Path, CancellationToken.None);
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -39,14 +112,19 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
         participations.Count.ShouldBe(4);
 
-        List<MeetParticipation> placed = participations.Where(p => p.Rank > 0).ToList();
-        List<MeetParticipation> unplaced = participations.Where(p => p.Rank <= 0).ToList();
+        List<MeetParticipation> placed = participations
+            .Where(p => p.Rank > 0)
+            .ToList();
+        List<MeetParticipation> unplaced = participations
+            .Where(p => p.Rank <= 0)
+            .ToList();
 
         int lastPlacedIndex = participations.IndexOf(placed[^1]);
         int firstUnplacedIndex = participations.IndexOf(unplaced[0]);
@@ -60,13 +138,14 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
         MeetParticipation last = participations[^1];
         last.Disqualified.ShouldBeTrue();
-        last.Athlete.ShouldBe("Anna Test");
+        last.Athlete.ShouldBe(_annaFullName);
     }
 
     [Fact]
@@ -75,14 +154,17 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
-        List<MeetParticipation> tiedAtFirst = participations.Where(p => p.Rank == 1).ToList();
+        List<MeetParticipation> tiedAtFirst = participations
+            .Where(p => p.Rank == 1)
+            .ToList();
         tiedAtFirst.Count.ShouldBe(2);
-        tiedAtFirst[0].Athlete.ShouldBe("Charlie Test");
-        tiedAtFirst[1].Athlete.ShouldBe("Delta Test");
+        tiedAtFirst[0].Athlete.ShouldBe(_charlieFullName);
+        tiedAtFirst[1].Athlete.ShouldBe(_deltaFullName);
     }
 
     [Fact]
@@ -91,12 +173,17 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
-        List<MeetParticipation> placed = participations.Where(p => p.Rank > 0).ToList();
-        List<int> ranks = placed.Select(p => p.Rank).ToList();
+        List<MeetParticipation> placed = participations
+            .Where(p => p.Rank > 0)
+            .ToList();
+        List<int> ranks = placed
+            .Select(p => p.Rank)
+            .ToList();
         ranks.ShouldBe(ranks.OrderBy(r => r).ToList());
     }
 
@@ -106,11 +193,12 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
-        MeetParticipation disqualified = participations.Single(p => p.Athlete == "Anna Test");
+        MeetParticipation disqualified = participations.Single(p => p.Athlete == _annaFullName);
         disqualified.Disqualified.ShouldBeTrue();
     }
 
@@ -120,11 +208,12 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
-        MeetParticipation participation = participations.First(p => p.Athlete == "Charlie Test");
+        MeetParticipation participation = participations.First(p => p.Athlete == _charlieFullName);
         participation.AgeCategory.ShouldBe("Opinn flokkur");
         participation.AgeCategorySlug.ShouldBe("open");
     }
@@ -135,11 +224,12 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
-        MeetParticipation placed = participations.First(p => p.Athlete == "Bob Test");
+        MeetParticipation placed = participations.First(p => p.Athlete == _bobFullName);
         placed.Disqualified.ShouldBeFalse();
     }
 
@@ -149,11 +239,12 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
-        MeetParticipation participation = participations.First(p => p.Athlete == "Delta Test");
+        MeetParticipation participation = participations.First(p => p.Athlete == _deltaFullName);
         participation.IpfPoints.ShouldBeGreaterThan(78m);
         participation.IpfPoints.ShouldBeLessThan(83m);
     }
@@ -164,11 +255,74 @@ public sealed class GetMeetParticipationsTests
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(Path, CancellationToken.None);
+        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
         participations.ShouldNotBeNull();
-        MeetParticipation participation = participations.Single(p => p.Athlete == "Anna Test");
+        MeetParticipation participation = participations.Single(p => p.Athlete == _annaFullName);
         participation.IpfPoints.ShouldBe(0m);
+    }
+
+    private async Task<string> CreateAthleteAsync(string firstName, string lastName)
+    {
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
+            .WithFirstName(firstName)
+            .WithLastName(lastName)
+            .WithDateOfBirth(new DateOnly(1990, 1, 1))
+            .Build();
+
+        HttpResponseMessage response = await _setupHttpClient.PostAsJsonAsync(
+            "/athletes", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = Slug.Create($"{firstName} {lastName}");
+        _athleteSlugs.Add(slug);
+        return slug;
+    }
+
+    private async Task<int> AddParticipantAsync(string athleteSlug)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(82.0m)
+            .WithAgeCategorySlug("open")
+            .Build();
+
+        HttpResponseMessage response = await _setupHttpClient.PostAsJsonAsync(
+            $"/meets/{_meetId}/participants", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        return result!.ParticipationId;
+    }
+
+    private async Task RecordFullTotalAsync(int participationId, decimal squat, decimal bench, decimal deadlift)
+    {
+        await RecordAttempt(participationId, Discipline.Squat, 1, squat, true);
+        await RecordAttempt(participationId, Discipline.Bench, 1, bench, true);
+        await RecordAttempt(participationId, Discipline.Deadlift, 1, deadlift, true);
+    }
+
+    private async Task RecordAttempt(
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight,
+        bool good)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .WithGood(good)
+            .Build();
+
+        HttpResponseMessage response = await _setupHttpClient.PutAsJsonAsync(
+            $"/meets/{_meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -275,9 +275,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
             "/athletes", command, CancellationToken.None);
         response.EnsureSuccessStatusCode();
 
-        List<AthleteSummary>? athletes = await _authorizedHttpClient.GetFromJsonAsync<List<AthleteSummary>>(
-            $"/athletes?search={firstName}+{lastName}", CancellationToken.None);
-        string slug = athletes!.Single(a => a.Name == $"{firstName} {lastName}").Slug!;
+        string slug = $"{firstName} {lastName}".ToLowerInvariant().Replace(' ', '-');
         _athleteSlugs.Add(slug);
         return slug;
     }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -6,7 +6,6 @@ using KRAFT.Results.Contracts.Athletes;
 using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
-using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
 
@@ -15,8 +14,8 @@ namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 [Collection(nameof(MeetsCollection))]
 public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    private readonly HttpClient _setupHttpClient = fixture.CreateAuthorizedHttpClient();
-    private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly HttpClient _unauthorizedHttpClient = fixture.Factory!.CreateClient();
     private readonly string _suffix = UniqueShortCode.Next();
     private readonly List<string> _athleteSlugs = [];
     private int _meetId;
@@ -36,13 +35,13 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
             .WithIsRaw(true)
             .Build();
 
-        HttpResponseMessage createResponse = await _setupHttpClient.PostAsJsonAsync(
+        HttpResponseMessage createResponse = await _authorizedHttpClient.PostAsJsonAsync(
             "/meets", meetCommand, CancellationToken.None);
         createResponse.EnsureSuccessStatusCode();
 
         _meetSlug = createResponse.Headers.Location!.ToString().TrimStart('/');
 
-        MeetDetails? details = await _setupHttpClient.GetFromJsonAsync<MeetDetails>(
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
             $"/meets/{_meetSlug}", CancellationToken.None);
         _meetId = details!.MeetId;
 
@@ -81,16 +80,16 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
     {
         if (_meetId != 0)
         {
-            await _setupHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+            await _authorizedHttpClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
         }
 
         foreach (string slug in _athleteSlugs)
         {
-            await _setupHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
+            await _authorizedHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
         }
 
-        _setupHttpClient.Dispose();
-        _httpClient.Dispose();
+        _authorizedHttpClient.Dispose();
+        _unauthorizedHttpClient.Dispose();
     }
 
     [Fact]
@@ -99,7 +98,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        HttpResponseMessage response = await _httpClient.GetAsync(
+        HttpResponseMessage response = await _unauthorizedHttpClient.GetAsync(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -112,7 +111,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -138,7 +137,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -154,7 +153,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -173,7 +172,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -193,7 +192,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -208,7 +207,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -224,7 +223,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -239,7 +238,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -255,7 +254,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         // Arrange
 
         // Act
-        List<MeetParticipation>? participations = await _httpClient.GetFromJsonAsync<List<MeetParticipation>>(
+        List<MeetParticipation>? participations = await _unauthorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
             $"/meets/{_meetSlug}/participations", CancellationToken.None);
 
         // Assert
@@ -272,11 +271,13 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
             .WithDateOfBirth(new DateOnly(1990, 1, 1))
             .Build();
 
-        HttpResponseMessage response = await _setupHttpClient.PostAsJsonAsync(
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
             "/athletes", command, CancellationToken.None);
         response.EnsureSuccessStatusCode();
 
-        string slug = Slug.Create($"{firstName} {lastName}");
+        List<AthleteSummary>? athletes = await _authorizedHttpClient.GetFromJsonAsync<List<AthleteSummary>>(
+            $"/athletes?search={firstName}+{lastName}", CancellationToken.None);
+        string slug = athletes!.Single(a => a.Name == $"{firstName} {lastName}").Slug!;
         _athleteSlugs.Add(slug);
         return slug;
     }
@@ -289,7 +290,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
             .WithAgeCategorySlug("open")
             .Build();
 
-        HttpResponseMessage response = await _setupHttpClient.PostAsJsonAsync(
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
             $"/meets/{_meetId}/participants", command, CancellationToken.None);
         response.EnsureSuccessStatusCode();
 
@@ -318,7 +319,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
             .WithGood(good)
             .Build();
 
-        HttpResponseMessage response = await _setupHttpClient.PutAsJsonAsync(
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
             $"/meets/{_meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
             command,
             CancellationToken.None);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -6,6 +6,7 @@ using KRAFT.Results.Contracts.Athletes;
 using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
 
@@ -275,7 +276,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
             "/athletes", command, CancellationToken.None);
         response.EnsureSuccessStatusCode();
 
-        string slug = $"{firstName} {lastName}".ToLowerInvariant().Replace(' ', '-');
+        string slug = Slug.Create($"{firstName} {lastName}");
         _athleteSlugs.Add(slug);
         return slug;
     }


### PR DESCRIPTION
## Summary

- Migrates `GetMeetParticipationsTests` to `IAsyncLifetime`, creating its own meet, 4 athletes, and participations via API in `InitializeAsync` and cleaning up in `DisposeAsync`
- Removes dependency on `Constants.OrderingMeet.Slug` and its raw-SQL seeded data
- Sets `Place` and `Disqualified` via `ExecuteSqlAsync` (tracked for removal in #403/#404 once those fields become computed side effects)
- Hardens `CollectionFixture.ExecuteSqlAsync` to accept `FormattableString` and route through EF Core's parameterised overload instead of `ExecuteSqlRawAsync`

## Test plan

- [ ] All 10 `GetMeetParticipationsTests` pass locally
- [ ] `dotnet test` full suite green

Closes #395
Part of #387