### PR TITLE
refactor(webapi): replace reflection-based test setup with builders

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Bans/Ban.cs
+++ b/src/KRAFT.Results.WebApi/Features/Bans/Ban.cs
@@ -1,9 +1,15 @@
-﻿using KRAFT.Results.WebApi.Features.Athletes;
+﻿using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Athletes;
 
 namespace KRAFT.Results.WebApi.Features.Bans;
 
 internal sealed class Ban
 {
+    // For EF Core
+    private Ban()
+    {
+    }
+
     public int BanId { get; private set; }
 
     public int AthleteId { get; private set; }
@@ -15,4 +21,22 @@ internal sealed class Ban
     public DateTime ToDate { get; private set; }
 
     public DateTime CreatedOn { get; private set; }
+
+    internal static Result<Ban> Create(int athleteId, DateTime fromDate, DateTime toDate)
+    {
+        if (fromDate > toDate)
+        {
+            return BanErrors.FromDateAfterToDate;
+        }
+
+        Ban ban = new()
+        {
+            AthleteId = athleteId,
+            FromDate = fromDate,
+            ToDate = toDate,
+            CreatedOn = DateTime.UtcNow,
+        };
+
+        return ban;
+    }
 }

--- a/src/KRAFT.Results.WebApi/Features/Bans/BanErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Bans/BanErrors.cs
@@ -1,0 +1,10 @@
+﻿using KRAFT.Results.WebApi.Abstractions;
+
+namespace KRAFT.Results.WebApi.Features.Bans;
+
+internal static class BanErrors
+{
+    internal static readonly Error FromDateAfterToDate = new(
+        "Bans.FromDateAfterToDate",
+        "From date cannot be after to date.");
+}

--- a/src/KRAFT.Results.WebApi/Features/Bans/BanErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Bans/BanErrors.cs
@@ -4,7 +4,7 @@ namespace KRAFT.Results.WebApi.Features.Bans;
 
 internal static class BanErrors
 {
-    internal static readonly Error FromDateAfterToDate = new(
+    internal static Error FromDateAfterToDate => new(
         "Bans.FromDateAfterToDate",
         "From date cannot be after to date.");
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Abstractions/AggregateRootTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Abstractions/AggregateRootTests.cs
@@ -1,9 +1,7 @@
-using System.Reflection;
-
-using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Athletes;
 using KRAFT.Results.WebApi.Features.Countries;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 
 using Shouldly;
 
@@ -15,7 +13,7 @@ public sealed class AggregateRootTests
     public void ClearDomainEvents_EmptiesEventList()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
         Country country = new();
         Athlete athlete = Athlete.Create(creator, "John", "Doe", "m", country, null, null).FromResult();
         athlete.DomainEvents.ShouldNotBeEmpty();
@@ -25,13 +23,5 @@ public sealed class AggregateRootTests
 
         // Assert
         athlete.DomainEvents.ShouldBeEmpty();
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Builders/BanBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Builders/BanBuilder.cs
@@ -1,0 +1,30 @@
+using KRAFT.Results.WebApi.Features.Bans;
+
+namespace KRAFT.Results.WebApi.UnitTests.Builders;
+
+internal sealed class BanBuilder
+{
+    private int _athleteId = 1;
+    private DateTime _fromDate = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private DateTime _toDate = new(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+
+    public BanBuilder WithAthleteId(int athleteId)
+    {
+        _athleteId = athleteId;
+        return this;
+    }
+
+    public BanBuilder WithFromDate(DateTime fromDate)
+    {
+        _fromDate = fromDate;
+        return this;
+    }
+
+    public BanBuilder WithToDate(DateTime toDate)
+    {
+        _toDate = toDate;
+        return this;
+    }
+
+    public Ban Build() => Ban.Create(_athleteId, _fromDate, _toDate).FromResult();
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Builders/UserBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Builders/UserBuilder.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+using KRAFT.Results.WebApi.Features.Users;
+
+namespace KRAFT.Results.WebApi.UnitTests.Builders;
+
+// User.Create() requires a User creator parameter, creating a chicken-and-egg problem.
+// Reflection is encapsulated here so that test files can create User instances without
+// duplicating reflection code.
+internal sealed class UserBuilder
+{
+    private string _username = "testuser";
+
+    public UserBuilder WithUsername(string username)
+    {
+        _username = username;
+        return this;
+    }
+
+    public User Build()
+    {
+        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
+        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
+        usernameProperty.SetValue(user, _username);
+        return user;
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/Create/RaisesAthleteCreatedEventTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/Create/RaisesAthleteCreatedEventTests.cs
@@ -1,9 +1,8 @@
-using System.Reflection;
-
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Athletes;
 using KRAFT.Results.WebApi.Features.Countries;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 
 using Shouldly;
 
@@ -15,7 +14,7 @@ public sealed class RaisesAthleteCreatedEventTests
     public void RaisesExactlyOneAthleteCreatedEvent()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
         Country country = new();
 
         // Act
@@ -27,13 +26,5 @@ public sealed class RaisesAthleteCreatedEventTests
         IDomainEvent domainEvent = athlete.DomainEvents.ShouldHaveSingleItem();
         AthleteCreatedEvent createdEvent = domainEvent.ShouldBeOfType<AthleteCreatedEvent>();
         createdEvent.Athlete.ShouldBeSameAs(athlete);
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/IsEligibleForRecord/IsEligibleForRecordTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/IsEligibleForRecord/IsEligibleForRecordTests.cs
@@ -1,9 +1,7 @@
-using System.Reflection;
-
-using KRAFT.Results.WebApi.Features.Athletes;
 using KRAFT.Results.WebApi.Features.Bans;
 using KRAFT.Results.WebApi.Features.Countries;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 
 using Shouldly;
 
@@ -29,7 +27,10 @@ public sealed class IsEligibleForRecordTests
     {
         // Arrange
         WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
-        Ban ban = CreateBan(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
         athlete.Bans.Add(ban);
 
         // Act
@@ -44,7 +45,10 @@ public sealed class IsEligibleForRecordTests
     {
         // Arrange
         WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
-        Ban ban = CreateBan(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2024, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2024, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
         athlete.Bans.Add(ban);
 
         // Act
@@ -59,7 +63,10 @@ public sealed class IsEligibleForRecordTests
     {
         // Arrange
         WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
-        Ban ban = CreateBan(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
         athlete.Bans.Add(ban);
 
         // Act
@@ -74,7 +81,10 @@ public sealed class IsEligibleForRecordTests
     {
         // Arrange
         WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
-        Ban ban = CreateBan(new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc), new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
         athlete.Bans.Add(ban);
 
         // Act
@@ -89,7 +99,10 @@ public sealed class IsEligibleForRecordTests
     {
         // Arrange
         WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
-        Ban ban = CreateBan(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc));
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
         athlete.Bans.Add(ban);
 
         // Act
@@ -101,25 +114,9 @@ public sealed class IsEligibleForRecordTests
 
     private static WebApi.Features.Athletes.Athlete CreateAthlete()
     {
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
         Country country = new();
         return WebApi.Features.Athletes.Athlete.Create(
             creator, "John", "Doe", "m", country, null, null).FromResult();
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
-    }
-
-    private static Ban CreateBan(DateTime fromDate, DateTime toDate)
-    {
-        Ban ban = (Ban)Activator.CreateInstance(typeof(Ban), nonPublic: true)!;
-        typeof(Ban).GetProperty(nameof(Ban.FromDate))!.SetValue(ban, fromDate);
-        typeof(Ban).GetProperty(nameof(Ban.ToDate))!.SetValue(ban, toDate);
-        return ban;
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Bans/BanTests/Create.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Bans/BanTests/Create.cs
@@ -1,0 +1,44 @@
+using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Bans;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Bans.BanTests;
+
+public sealed class Create
+{
+    [Fact]
+    public void WhenValidDates_ReturnsBan()
+    {
+        // Arrange
+        int athleteId = 1;
+        DateTime fromDate = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        DateTime toDate = new(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        Result<Ban> result = Ban.Create(athleteId, fromDate, toDate);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        Ban ban = result.FromResult();
+        ban.AthleteId.ShouldBe(athleteId);
+        ban.FromDate.ShouldBe(fromDate);
+        ban.ToDate.ShouldBe(toDate);
+    }
+
+    [Fact]
+    public void WhenFromDateAfterToDate_ReturnsFailure()
+    {
+        // Arrange
+        int athleteId = 1;
+        DateTime fromDate = new(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+        DateTime toDate = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        Result<Ban> result = Ban.Create(athleteId, fromDate, toDate);
+
+        // Assert
+        result.IsFailure.ShouldBeTrue();
+        result.Error.ShouldBe(BanErrors.FromDateAfterToDate);
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/Create/BodyWeightValidationTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/Create/BodyWeightValidationTests.cs
@@ -1,8 +1,6 @@
-using System.Reflection;
-
 using KRAFT.Results.WebApi.Abstractions;
-using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
@@ -15,7 +13,7 @@ public sealed class BodyWeightValidationTests
     public void ReturnsFailure_WhenBodyWeightIsZero()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
 
         // Act
         Result<WebApi.Features.Participations.Participation> result =
@@ -31,7 +29,7 @@ public sealed class BodyWeightValidationTests
     public void ReturnsFailure_WhenBodyWeightExceedsMaximum()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
 
         // Act
         Result<WebApi.Features.Participations.Participation> result =
@@ -47,7 +45,7 @@ public sealed class BodyWeightValidationTests
     public void StoresBodyWeightValueObject_WhenValid()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
 
         // Act
         Result<WebApi.Features.Participations.Participation> result =
@@ -59,13 +57,5 @@ public sealed class BodyWeightValidationTests
         WebApi.Features.Participations.Participation participation = result.FromResult();
         participation.Weight.ShouldBeOfType<BodyWeight>();
         participation.Weight.Value.ShouldBe(83.5m);
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/Create/RaisesParticipationAddedEventTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/Create/RaisesParticipationAddedEventTests.cs
@@ -1,8 +1,7 @@
-using System.Reflection;
-
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 
 using Shouldly;
 
@@ -14,7 +13,7 @@ public sealed class RaisesParticipationAddedEventTests
     public void RaisesExactlyOneParticipationAddedEvent()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
 
         // Act
         WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
@@ -25,13 +24,5 @@ public sealed class RaisesParticipationAddedEventTests
         IDomainEvent domainEvent = participation.DomainEvents.ShouldHaveSingleItem();
         ParticipationAddedEvent addedEvent = domainEvent.ShouldBeOfType<ParticipationAddedEvent>();
         addedEvent.Participation.ShouldBeSameAs(participation);
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecordAttempt/RaisesAttemptRecordedEventTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecordAttempt/RaisesAttemptRecordedEventTests.cs
@@ -1,9 +1,8 @@
-using System.Reflection;
-
 using KRAFT.Results.Contracts;
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 
 using Shouldly;
 
@@ -15,7 +14,7 @@ public sealed class RaisesAttemptRecordedEventTests
     public void RaisesAttemptRecordedEvent()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
         WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
             creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
 
@@ -31,13 +30,5 @@ public sealed class RaisesAttemptRecordedEventTests
         recordedEvent.Attempt.Discipline.ShouldBe(Discipline.Squat);
         recordedEvent.Attempt.Round.ShouldBe((short)1);
         recordedEvent.Attempt.Weight.ShouldBe(200m);
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateAttempt/RaisesAttemptRecordedEventTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateAttempt/RaisesAttemptRecordedEventTests.cs
@@ -1,10 +1,9 @@
-using System.Reflection;
-
 using KRAFT.Results.Contracts;
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Attempts;
 using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 
 using Shouldly;
 
@@ -16,7 +15,7 @@ public sealed class RaisesAttemptRecordedEventTests
     public void RaisesAttemptRecordedEvent()
     {
         // Arrange
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
         WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
             creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
 
@@ -34,13 +33,5 @@ public sealed class RaisesAttemptRecordedEventTests
         recordedEvent.Participation.ShouldBeSameAs(participation);
         recordedEvent.Attempt.ShouldBeSameAs(attempt);
         recordedEvent.Attempt.Weight.ShouldBe(210m);
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateBodyWeight/BodyWeightValidationTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateBodyWeight/BodyWeightValidationTests.cs
@@ -1,8 +1,6 @@
-using System.Reflection;
-
 using KRAFT.Results.WebApi.Abstractions;
-using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
 using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
@@ -55,16 +53,8 @@ public sealed class BodyWeightValidationTests
 
     private static WebApi.Features.Participations.Participation CreateParticipation()
     {
-        User creator = CreateUser("testuser");
+        User creator = new UserBuilder().Build();
         return WebApi.Features.Participations.Participation.Create(
             creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
-    }
-
-    private static User CreateUser(string username)
-    {
-        User user = (User)Activator.CreateInstance(typeof(User), nonPublic: true)!;
-        PropertyInfo usernameProperty = typeof(User).GetProperty(nameof(User.Username))!;
-        usernameProperty.SetValue(user, username);
-        return user;
     }
 }


### PR DESCRIPTION
## Summary

- Added `Ban.Create()` factory method with `fromDate <= toDate` validation, filling a gap in the domain model
- Created `UserBuilder` and `BanBuilder` in the unit test project for entity construction
- Replaced all `Activator.CreateInstance` + `PropertyInfo.SetValue` reflection across 8 unit test files with builder calls

Closes #381

## Test plan

- [ ] All 99 unit tests pass (verified locally)
- [ ] `Activator.CreateInstance` only remains in `UserBuilder.cs` (encapsulated) and out-of-scope `RecordTests/Demote.cs`
- [ ] `Ban.Create()` factory tested: valid dates return success, invalid dates return failure