### PR TITLE
docs(webapi): trim IPF technical rules to project-relevant content

### DIFF
--- a/docs/ipf-technical-rules-2026.md
+++ b/docs/ipf-technical-rules-2026.md
@@ -14,67 +14,26 @@ The official text shall be maintained by the IPF and published in English. In th
 1. General Rules of Powerlifting
    - 1.1 Age Categories
    - 1.2 Bodyweight Categories
-
 2. Equipment and Specifications
-
-3. Personal Equipment
-
-4. Powerlifting and Rules of Performance
+3. Causes for Disqualification
    - 4.1 Squat
    - 4.2 Bench Press
    - 4.3 Deadlift
+4. Weighing In
+5. Order of Competition
+6. Miscellaneous Rules
+7. World and International Records
+8. Jury Override
 
-5. Weighing In
-
-6. Order of Competition
-
-7. Referees
-
-8. Jury and Technical Committee
-
-9. World and International Records
-
-10. Coach Responsibilities
-
-   ---
+---
 
 ## 1. General Rules of Powerlifting
 
-1. Throughout this rulebook, for reasons of brevity, wherever the words "he" or "his" occur, such reference is deemed to apply to either sex. All references to gender shall ensure equal rights for both sexes and shall not present women as requiring separate rules unless explicitly necessary.
+1. Each competitor is allowed three attempts on each lift. The lifter's best valid attempt on each lift counts toward his competition total. If two or more lifters achieve the same total, the lighter lifter ranks above the heavier lifter.
 
-   In competitions in which both sexes are competing:
+   If two lifters register the same body weight at the weigh in and eventually achieve the same total at the end of the competition, the lifter making the total first will take precedence over the other lifter. Where awards are presented for best squat, bench press and deadlift or if a world record is broken, the same procedure will apply.
 
-   **(a)** The International Powerlifting Federation recognizes the following lifts which must be taken in the same sequence in all competitions conducted under IPF rules:
-   A. Squat
-   B. Bench Press
-   C. Deadlift
-   D. Total
-
-   **(b)** Competition takes place between lifters in categories defined by sex, body weight and age.
-   The Men's and Women's Open Championships permit lifters from 1 January in the calendar year he/she reaches 19 years and upwards.
-
-   **(c)** In the event of a Powerlifting or Bench Press Championships being combined e.g. with a Sub- Junior, Junior Open & Master's Championships having both Classic (1 category) and Equipped (1 category), a lifter has the option of competing in both Championships. The athlete shall be required to pay the entry fee for both championships and will be required to compete twice. No lifter is allowed to compete 2 times in Classic or 2 times in Equipped. Masters 3 and 4 are not permitted to compete in the Open Class. Once the athlete is entered on the Preliminary Nomination, he/she may not change their age division. The lifter may only change the weight class on the Final Nomination.
-
-   **(d)** The rules apply to all levels of competition.
-
-   **(e)** Each competitor is allowed three attempts on each lift. The lifter's best valid attempt on each lift counts toward his competition total. If two or more lifters achieve the same total, the lighter lifter ranks above the heavier lifter.
-
-   **(f)** If two lifters register the same body weight at the weigh in and eventually achieve the same total at the end of the competition, the lifter making the total first will take precedence over the other lifter. Where awards are presented for best squat, bench press and deadlift or if a world record is broken, the same procedure will apply.
-
-2. The IPF, through its member federations, conducts and sanctions the following World Championships. The major events on the IPF calendar are as follows:
-
-   - Equipped World Open Powerlifting Championship
-   - Equipped World Sub-Junior and Junior Powerlifting Championship
-   - Equipped World Masters Powerlifting Championship
-   - Equipped World Bench Press Championship (Open, Sub-Junior/Junior and Master)
-   - Classic World Open Powerlifting Championship
-   - Classic World Sub-Junior and Junior Powerlifting Championship
-   - Classic World Masters Powerlifting Championship
-   - Classic World Bench Press Championship (Open, Sub-Junior/Junior and Master)
-   - University World Cup
-   - Other international events as approved by the EC.
-
-   The Championship Secretary, in consult with the Executive Committee, shall ensure that major international events do not clash. If necessary, sanction (s) may be refused to achieve an orderly Calendar. If necessary, the events on the Calendar may be combined into one championship.
+2. In the event of a Powerlifting or Bench Press Championships being combined e.g. with a Sub-Junior, Junior Open & Master's Championships having both Classic (1 category) and Equipped (1 category), a lifter has the option of competing in both Championships. No lifter is allowed to compete 2 times in Classic or 2 times in Equipped. Masters 3 and 4 are not permitted to compete in the Open Class. Once the athlete is entered on the Preliminary Nomination, he/she may not change their age division. The lifter may only change the weight class on the Final Nomination.
 
 3. The IPF also recognizes and registers world records for the same lifts within the categories described hereunder:
 
@@ -127,27 +86,15 @@ Competitive lifting for lifters below the age of 14 is only allowed at National 
 
 2. Each nation is allowed a maximum of eight (8) competitors spread throughout the range of the eight (8) bodyweight categories for men and eight (8) competitors throughout the range of eight (8) bodyweight categories for women. In the Junior and Sub-Junior age categories nine (9) for men and nine (9) for women. There must not be more than two competitors from any one nation in any particular bodyweight category.
 
-3. Each nation is allowed a maximum of five alternates or reserves. To take part in the competition they must have been nominated 60 days before the date of the championships on the preliminary nomination with the bodyweight categories and best totals achieved at National or international championships during the last 12 months.
+3. Point scoring for all World, Continental and Regional Championships shall be: 12, 9, 8, 7, 6, 5, 4, 3, and 2 points for the first nine places in any bodyweight category. Thereafter, each lifter who makes a total in the competition shall be awarded one point. Point scoring for all national competitions shall be at the discretion of the national federation.
 
-4. Each Nation must submit a team roster giving the name of each lifter and his/her body weight category. Best totals from National or International Championships during the previous 12 months shall be stated. This may include his/her result achieved at last year's International Championships in the same bodyweight category. The date and title of the competition in which the total was achieved must also be stated. These details must be submitted to the Championship Secretary of the IPF or of the Region and also to the Meet Director at least 60 days before the date of the Championships on the preliminary nomination. Final selection, submitted not later than 21 days before the date of the Championship, must be made from those nominated 60 days before the date of the Championships. This includes reserve or alternate lifters. At this point in time each lifter must nominate the bodyweight category in which they wish to lift in these Championships. After the final selection (final nomination) no changes in the weight category in which the lifter is nominated will be allowed. Nominated lifters without results from any of the above Championships will be ranked in the first lifting group if his/her bodyweight category is divided into multiple groups. Failure to comply with any of these requirements may result in disqualification of the offending team. A lifter cannot produce a qualifying total via his national federation for entry to World, International or Regional Championships while he is under suspension by the IPF or Region.
+4. Only the point scores of the five best placed lifters of each nation will be counted for the team competition at all international championships. In case of a tie in points scored, final team placing shall be decided for team awards as in item 6. If a member of a team is found to have committed a violation of the IPF Anti-Doping Rules during an Event where a team ranking is based on the addition of individual results (points), the points of the Athlete committing the violation will be subtracted from the team result and may not be repeated by the resulting points of another team member.
 
-5. Point scoring for all World, Continental and Regional Championships shall be: 12, 9, 8, 7, 6, 5, 4, 3, and 2 points for the first nine places in any bodyweight category. Thereafter, each lifter who makes a total in the competition shall be awarded one point. Point scoring for all national competitions shall be at the discretion of the national federation.
+5. Team awards shall be given for the first three places with Medals, 5 Gold to the Best Team, 5 Silver to the 2nd Best Team and 5 Bronze to the 3rd Best Team. In the case of a tie for the classification of a team or a nation, the team having the largest number of first places will be ranked first. In the case of a tie between two nations having the same number of first places, the one having the most second places will be classified first, and so on through the placing of the maximum of five scoring lifters. Should teams or Nations finish equally after this procedure has been applied, then the team or Nation with the greater total number of IPF points will be declared the higher placed. Teams with less than 3 lifters will not receive medals.
 
-6. Only the point scores of the five best placed lifters of each nation will be counted for the team competition at all international championships. In case of a tie in points scored, final team placing shall be decided for team awards as in item 8. If a member of a team is found to have committed a violation of the IPF Anti-Doping Rules during an Event where a team ranking is based on the addition of individual results (points), the points of the Athlete committing the violation will be subtracted from the team result and may not be repeated by the resulting points of another team member.
+6. At all IPF Championships a "Best lifter" award shall be given to the lifter who produces the best performance based upon the IPF formula. Awards will also be presented to second and third places. Categories with less than 3 Lifters will not receive any "Best Lifter" awards.
 
-7. Any nation having been a member of the IPF for more than three years should include at least one international referee among its team officials at World Championships. If a referee from that nation is not present or, if present, makes himself unavailable to act in the capacity of either referee or member for jury during the championships, then only the four best placed lifters from that nation will be counted for the team competition.
-
-8. Team awards shall be given for the first three places with Medals, 5 Gold to the Best Team, 5 Silver to the 2nd Best Team and 5 Bronze to the 3rd Best Team. In the case of a tie for the classification of a team or a nation, the team having the largest number of first places will be ranked first. In the case of a tie between two nations having the same number of first places, the one having the most second places will be classified first, and so on through the placing of the maximum of five scoring lifters. Should teams or Nations finish equally after this procedure has been applied, then the team or Nation with the greater total number of IPF points will be declared the higher placed. Teams with less than 3 lifters will not receive medals.
-
-9. At all IPF Championships a "Best lifter" award shall be given to the lifter who produces the best performance based upon the IPF formula. Awards will also be presented to second and third places. Categories with less than 3 Lifters will not receive any "Best Lifter" awards.
-
-10. At International Championships, medals will be presented for first, second and third places for each category based upon totals. In addition, medals or merit award certificates shall be presented for first, second and third places in the individual lifts of squat, bench press and deadlift in each category. Each lifter must receive a Participation medal/memento from the Meet Organizer (By-Laws 13.3). Should a lifter fail to succeed in either or both of the squat or bench press disciplines he/she may continue to compete for the remainder of the contest, and the lifter will be eligible for awards in any discipline in which he/she records a successful lift or lifts. To receive this award the lifter must make a bona fide attempt on each of the three disciplines.
-   Dress code for athletes at World Championships medal ceremonies is - full team track suit, t-shirt, athletic footwear. Compliance will be monitored by the Technical Controller for the session.
-   Failure to adhere to these requirements shall disqualify the lifter from receiving the medal(s) on the platform, although their place in contest results will stand.
-
-11. It is forbidden to whip and smash the lifter in front of the audience and media.
-
-12. At all IPF events, the organizer must provide for the safety of athletes and officials a qualified medical person on duty throughout the championships.
+7. Should a lifter fail to succeed in either or both of the squat or bench press disciplines he/she may continue to compete for the remainder of the contest, and the lifter will be eligible for awards in any discipline in which he/she records a successful lift or lifts. To receive this award the lifter must make a bona fide attempt on each of the three disciplines.
 
 ## 2. Equipment and Specifications
 
@@ -298,242 +245,9 @@ A clearly visible and detailed scoreboard must be provided for spectators, offic
 | --- | ---- | --- | ----- | --------- | --------- | --------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ----- | ----- |
 | ... |      |     |       |           |           |           |        |        |        |        |        |        |        |       |       |
 
-## 3. Personal Equipment
-
-### 3.1. Suits
-
-#### Supportive
-A supportive lifting suit may be worn only in competitions which are designated as Equipped. A supportive lifting suit may be worn for all lifts in competitions which are designated as an Equipped (in which a non-supportive lifting suit may instead be worn).
-The suit-straps must be worn over the lifter's shoulders at all times in all lifts in all competitions.
-Only supportive lifting suits from manufacturers accepted onto the "Approved List of Apparel and Equipment for Use at IPF Competitions" shall be permitted for use in competitions. In addition, any such supportive suits from Approved manufacturers must meet all the specifications of the IPF Technical Rules; supportive suits from Approved manufacturers which breach any IPF Technical Rule shall not be permitted for use in competitions.
-The supportive lifting suit must conform to the following specifications:
-
-**(a)** The suit's material shall be of a single thickness.
-
-**(b)** There must be legs to the suit, extending a minimum of 3 cm and a maximum of 15 cm, from the top of the crutch down the inside of the leg, as measured when worn by the lifter in a standing position.
-
-**(c)** Any alteration to the costume which exceeds the established widths, lengths or thickness previously stated shall make the suit illegal for competition.
-
-**(d)** Alterations in the form of pleats made to tighten suits or supportive shirts are permitted, provided they are made only along the manufacturer's original seams. Non-factory alterations to tighten suits and shirts are not illegal when done in the form of pleats. However, the pleats must be made only on the manufacturer's original seams. These pleats must be made on the inside of the suit or shirt. Any alterations made on areas other than the manufacturer's seams are illegal.
-Pleats may not be sewn back onto the body of the garment.
-
-**(e)** Where a tightening has been made in the shoulder straps and the excess material is longer than 3 cm's, this must then be turned inside the suit and not sewn back onto the straps. No more than 3 cm length may protrude outside the suit.
-
-**(f)** The suit may bear the logos or emblems of the approved manufacturer of the suit of the lifter's nation of the lifter's name as per the rule "Sponsor's Logos"
-In national and lower-level contests only, of the lifter's club or individual sponsor, where that logo or emblem has not otherwise been approved by the IPF.
-
-#### Singlet (Non-Supportive)
-A singlet (non-supportive lifting suit) shall be worn in competitions which are designated as Classic/Raw and may be worn in competitions which are designated as Equipped (in which a supportive lifting suit may instead be worn).
-The singlet straps must be worn over the lifter's shoulders at all times in all lifts in all competitions. Only singlets (non-supportive) from manufacturers accepted onto the "Approved List of Apparel and Equipment for Use at IPF Competitions" shall be permitted for use in competitions. In addition, any such singlets (non-supportive) from approved manufacturers must meet all the specifications of the IPF Technical Rules; any singlets from an approved manufacturer that breaches an IPF Technical Rule and shall not be permitted for use in competitions.
-The singlet (non-supportive) must conform to the following specifications:
-
-**(a)** The singlet shall be one-piece and form fitting without any looseness when worn. Lifters can wear approved long-legged singlets.
-Whichever type of singlet a lifter wears for squat, they must wear the same singlet throughout all disciplines.
-
-**(b)** It is permitted to wear knee sleeves over a long-legged singlet; however, knee sleeves may not be worn under the singlet. The Technical Controller must verify that no knee sleeves are worn beneath the singlet. Deadlift socks may be worn over a long-legged singlet but are not mandatory.
-
-**(c)** The singlet must be constructed entirely of fabric or a synthetic textile material, such that no support is given to the lifter by the singlet in the execution of any lift.
-
-**(d)** The singlet's material shall be of a single thickness, other than a second thickness of material of up to 12 cm x 24 cm allowed in the area of crotch.
-
-**(e)** There must be legs to the singlet, extending a minimum of 3 cm and a maximum of 25 cm, from the top of the crotch down the inside of the leg, as measured when worn by the lifter in a standing position.
-
-**(f)** The singlet may bear the logos or emblems: of the approved manufacturer of the singlet of the lifter's nation of the lifter's name as per rule "Sponsor's Logos" in national and lower-level contests only, of the lifter's club or individual sponsor, where that logo or emblem has not otherwise been approved by the IPF.
-
-### 3.2. T-Shirt
-
-A t-shirt must be worn under the lifting singlet by all lifters in the Squat, Bench Press and Deadlift. The only exception to those requirements is that a Supportive shirt is permitted to be worn instead of a t-shirt as per rule "Supportive Shirts" below; a combination of t-shirt and supportive shirt is not allowed.
-The t-shirt must conform to the following specifications:
-
-**(a)** the shirt must be constructed entirely of fabric or a synthetic textile and shall not consist, in whole or part, of any rubberized or similar stretch material, nor have any reinforced seams or pockets, buttons, zippers or other than a round neck collar.
-
-**(b)** the t-shirt must have tight fit "Form Fitting" sleeves. Those sleeves must terminate below the lifter's deltoid and must not extend onto or below the lifter's elbow. The sleeves may not be pushed or rolled up onto the deltoid when the lifter is competing. See pictures below.
-
-### 3.3. Supportive Shirts
-
-A supportive shirt which has been accepted onto the "Approved List of Apparel and Equipment for Use at IPF Competitions" may be worn only at competitions designated as Equipped.
-The supportive shirt must be conformed to the following specifications:
-
-**(a)** the shirt must be constructed entirely of fabric or a synthetic textile and shall not consist, in whole or part, of any rubberized on similar stretch material, nor have any reinforced seams or pockets, buttons, zippers or other than a round neck collar
-
-**(b)** the shirt must have sleeves. Those sleeves must terminate below the lifter's deltoid and must not extend onto or below the lifter's elbow. The sleeves may not be pushed or rolled up onto the deltoid when the lifter is competing.
-
-**(c)** the shirt may be plain i.e. of a single color and with no logos or emblems, or may bear the logo or emblem: of the lifter's nation of the lifter's name of the event in which the lifter is competing in national and lower-level contests only, the lifter's club or individual sponsor, where that logo or emblem has not otherwise been approved by the IPF.
-
-**(d)** any manipulation or doctoring of the supportive shirt from the original design as supplied by the manufacturer and approved by The Technical Committee will render the shirt illegal for use in competition. The material must cover the whole of the deltoid area as arrowed 2.
-
-### 3.4. Briefs
-
-A standard commercial "athletic supporter" or standard commercial briefs of any mixture of cotton, nylon or polyester shall be worn under the lifting suit. Women may also wear a commercial or sports bra.
-Swimming trunks or any garment consisting of rubberized or similar stretch material except in the waistband, shall not be worn under the lifting costume.
-Any supportive undergarment is not legal for use in IPF competition.
-
-### 3.5. Socks
-
-Socks may be worn.
-
-**(a)** They may be of any color or colors and may have manufacturer's logos.
-
-**(b)** They shall not be of such length on the leg that they come into contact with the knee wraps or knee cap supporter.
-
-**(c)** Full length leg stockings, tights or hose are strictly forbidden.
-Shin length socks must be worn to cover and protect the shins while performing the deadlift.
-
-### 3.6. Belt
-
-Competitors may wear a belt. If worn, it shall be on the outside of the lifting suit. Only belts from manufacturers accepted onto the "Approved List of Apparel and Equipment for Use at IPF Competitions" shall be permitted for use in competitions.
-Materials and Construction:
-
-**(a)** The main body shall be made of leather, vinyl or other similar non-stretch material in one or more laminations which may be glued and/or stitched together.
-
-**(b)** It shall not have additional padding, bracing or supports of any material either on the surface or concealed within the laminations of the belt.
-
-**(c)** The buckle shall be attached at one end of the belt by means of studs and/or stitching.
-
-**(d)** The belt may have a buckle with one or two prongs or "quick release" type ("quick release" referring to lever.)
-
-**(e)** A tongue loop shall be attached close to the buckle by means of studs/or stitching.
-
-**(f)** The belt may be plain i.e. of a single or two or more colors and with no logos, or may bear the logo or emblem of the lifter's name as per the rule "Sponsor's Logos" in national and lower-level contests only, the lifter's club or individual sponsor, where the logo or emblem has not otherwise been approved by the IPF.
-Dimensions:
-
-| Dimension | Maximum |
-|-----------|---------|
-| Width of belt | 10 cm |
-| Thickness of belt (main length) | 13 mm |
-| Inside width of buckle | 11 cm |
-| Outside width of buckle | 13 cm |
-| Tongue loop width | 5 cm |
-| End of belt to far end of tongue loop | 25 cm |
-
-### 3.7. Shoes or Boots
-
-Shoes or boots shall be worn.
-
-**(a)** Shoes shall be taken to include only indoor sports shoes/sports boots; Weightlifting/Powerlifting boots or Deadlift slippers. The above is referring to indoor sports e.g. wrestling/basketball. Hiking boots do not fall into this category
-
-**(b)** The sole thickness shall not exceed 5 cm at any point.
-
-**(c)** The underside must be flat i.e. no projections, irregularities, or modification of the standard design
-
-**(d)** Loose inner soles that are not part of the manufactured shoe shall be limited to one - centimeter thickness.
-
-**(e)** Socks with a rubber outside sole lining are not allowed in disciplines - Squat/Bench Press/Deadlift.
-
-**(f)** Shoes must be properly fastened (laces tied or velcro straps secured) when the lifter is on the platform.
-
-### 3.8. Knee Sleeves
-
-Sleeves, being cylinders of neoprene, may be worn only on the knees by the lifter in the performance of any lift in competition; sleeves cannot be worn or used on any part of the body other than the knees. Knee sleeves cannot be worn where the lifter also wears knee wraps, as per the rule "Wraps" below. Only knee sleeves from manufacturers accepted onto the "Approved List of Apparel and Equipment for Use at IPF Competitions" shall be permitted for use in competitions. In addition, any such sleeves from approved manufacturers must meet all the specifications of the IPF Technical Rules; knee sleeves which breach any IPF Technical Rule shall not be permitted for use in competitions.
-Knee sleeves must conform to the following specifications:
-
-**(a)** The sleeves must be constructed entirely of a single ply of neoprene, or predominantly of a single ply of neoprene plus a non-supportive single layer of fabric over the neoprene. There may be stitched seams of the fabric and/or of the fabric onto the neoprene. The entire construction of the sleeves may not be such as to provide any appreciable support or rebound to the lifter's knees;
-
-**(b)** Knee sleeves shall be of a maximum thickness of 7 mm and a maximum length of 30 cm.
-
-**(c)** Knee sleeves shall not have any additional strapping, Velcro, drawstrings, padding or similar supportive devices in or on them. Knee sleeves must be continuous cylinders, without holes in the neoprene or in any covering material;
-
-**(d)** When worn by the lifter in competition, knee sleeves must not be in contact with the lifter's suit (other than long-legged) or socks and must be centered over the knee joint.
-
-**(e)** Athletes are permitted to receive personal assistance in the application of their knee sleeves.
-
-**(f)** It is permitted to wear knee sleeves over a long sleeve singlet, but not under the singlet.
-
-### 3.9. Wraps
-
-Only wraps of one ply commercially woven elastic that is covered with polyester, cotton or a combination of both of those materials or medical crepe are permitted. Supportive wraps: Only wraps from commercial manufacturers officially registered and approved by the Technical Committee shall be permitted for use in powerlifting competitions.
-Non-supportive wraps: Wraps made of medical crepe or bandage do not require Technical Committee approval.
-
-#### Wrist
-Wrists wraps shall not exceed 1 m in length and 8 cm in width. Any sleeves and Velcro patches/tabs for securing must be incorporated within the one-meter length. A loop may be attached as an aid to securing. The loop shall not remain over the thumb or fingers during the actual lift. A combination of wrist wraps and sweat bands is not allowed. A wrist covering shall not extend beyond 10 cm above and 2 cm below the center of the wrist joint and shall not exceed a covering width of 12 cm.
-
-#### Knee
-Wraps not exceeding 2 m in length and 8 cm in width may be worn only in competitions which are designated as Equipped. A knee wrap shall not extend beyond 15 cm above and 15 cm below the center of the knee joint and shall not exceed a total covering width of 30 cm.
-IPF approved knee sleeves are allowed. A combination of the two is strictly forbidden.
-Neoprene may be "synthetic rubber", but is only acceptable in the knee sleeve.
-Wraps shall not be in contact with socks or lifting suit.
-Wraps shall not be used elsewhere on the body.
-
-### 3.10. Head Wear
-
-Hats are strictly forbidden to be worn on the platform during lifting.
-Lifters may wear Hijab (head scarf) while lifting. In Bench Press the Jury or Referees may require the lifter to affix her hair accordingly to the performance of the Bench Press.
-Standard commercial sweat bands one color (Black or White) may be worn, not exceeding 12 cm in width. A combination of wrist wraps and sweat bands is not allowed.
-
-### 3.11. Medical Tape
-
-Two layers of medical tape may be worn around the thumbs. Medical tape or its like may not be worn anywhere else on the body without official permission of the Jury, or Chief Referee.
-Medical tape may not be used as aids to the lifter in holding the bar.
-Contingent upon prior approval by the Jury, Official Doctor, Paramedic or Paramedical personnel on duty medical tape may be applied to bodily injuries in a fashion that would not grant the lifter an undue advantage.
-At all competitions where a jury may not be present and no medical personnel are on duty.
-The Chief Referee shall have jurisdiction over the use of medical tape.
-
-### 3.12. Inspection of Personal Equipment
-
-**(a)** The inspection of personal equipment for each and every lifter in the competition may take place at any time (times may be announced at the Technical Meeting) throughout the meet prior to within thirty minutes of the start for their particular bodyweight category.
-
-**(b)** A minimum of two referees shall be appointed to fulfill this duty. All items shall be examined and approved before being officially stamped or marked.
-
-**(c)** Wraps over permitted length shall be rejected but may be cut to the correct length and resubmitted.
-
-**(d)** Any item considered unclean or torn shall be rejected.
-
-**(e)** The signed inspection sheet shall be handed to the president of the Jury at the end of the inspection period.
-
-**(f)** If after the inspection a lifter appears on the platform wearing or using any illegal item, other than that which may have inadvertently been passed by the referees, the lifter shall immediately be disqualified from the competition.
-
-**(g)** Referees shall also reject any knee sleeves that have been put on the lifter with the assistance of any other person or method, such as the use of plastic sliding devices, the use of lubricants etc. Socks are however permitted to put knee sleeves on.
-Athletes are permitted to receive personal assistance in the application of their knee sleeves.
-
-**(h)** All items mentioned previously under personal equipment shall be inspected.
-
-**(i)** Items such as watches, costume jewelry, mouthpieces, eye wear and feminine hygiene articles need not be inspected.
-
-**(j)** Before attempting a world record the lifter will be inspected by the Technical Controller. If the lifter is found to be wearing or using any illegal item, other than that which may have inadvertently been passed by the referees, the lifter shall be disqualified from the competition.
-
-**(k)** Referees and the Technical Controller for their particular bodyweight category must assemble five minutes prior to the start of the inspection of personal equipment.
-
-### 3.13. Sponsor's Logos
-
-**(a)** Over and above manufacturers logos and emblems listed on the "Approved List of Apparel and Equipment for Use at IPF Competitions", a nation or lifter may apply to the IPF Secretary General for permission for an additional logo or emblem to be listed as approved for display on items or personal equipment, for that applicant nation or lifter only. Such logo or emblem applications must be accompanied by a fee of an amount determined by the IPF Executive. The IPF, via the Executive, may approve the logo or emblem, but shall have the right to decline approval should, in the Executive's opinion, the logo or emblem compromise any commercial interest of the IPF or to fail to meet standards of good taste. The Executive shall also have the right, in its approval, to limit the size. or position on any item of personal equipment, or a logo or emblem.
-Any approval given shall remain in place from the date of that approval through the remainder of that calendar year and for the whole of the following calendar year, after which time a further application and fee payment must be made if the logo or emblem to remain approved.
-Logos or emblems approved under this rule shall be listed in an addendum to the "Approved List of Apparel and Equipment for Use at IPF Competitions"; also, the IPF Secretary General shall issue a letter of approval to successful applicants, that letter illustrating the approved logo or emblem and stating the date of approval and any limitations on the approval, such letter being acceptable proof for Referees at competitions of a valid approval. The logos or emblems of manufacturers not on the "Approved List of Apparel and Equipment for Use at IPF Competitions" nor on the addendum of approved logos or emblems established by this rule "Sponsor's Logos", may be worn only on t-shirts, shoes or socks, where the logo or emblem is printed or embroidered and is no more than 5 cm x 2 cm in size.
-
-### 3.14. General
-
-**(a)** The use of oil, grease or other lubricants on the body, or personal equipment is strictly forbidden.
-
-**(b)** Baby powder, resin, talc or magnesium carbonates are the only substances that may be added to the body and attire, but not to the wraps.
-
-**(c)** The use of any form of adhesive on the underside of footwear is strictly forbidden. This applies to any built-in adhesive, e.g. glass paper, emery cloth, etc. and to include resin and magnesium carbonate. A spray of water is acceptable.
-
-**(d)** No foreign substances may be applied to the powerlifting equipment. This takes into account all substances other than that which may be used periodically as a sterile agent in the cleaning of the bar, bench, or platform.
-
-**(e)** Light protective guards between sock and shin may be worn.
-
-**(f)** Athletes are allowed to wear necklaces and similar accessories. No part of the necklace or accessory shall be placed in the mouth while on the platform. A pendant or charm may be worn either over or under the T-shirt; however, if deemed to create a safety concern or interfere with the lift, the Referee may require it to be secured under the T-shirt or removed.
-
-## 4. Powerlifting and Rules of Performance
+## 4. Causes for Disqualification
 
 ### 4.1. Squat
-
-1. The lifter shall face the front of the platform, with the barbell placed horizontally across the shoulders, at a height no lower than the posterior deltoid level. hands and fingers gripping the bar The lifter's hands, thumbs, and fingers must be in complete contact with the bar while it is positioned in the rack stands and starting and lift completion position. The thumbs are not required to wrap around the bar. However, the hands, thumb, and fingers must remain in complete contact with the bar or the duration of the lift. The hands may be positioned anywhere on the bar inside and or in contact with the inner collars.
-
-2. After removing the bar from the racks, (the lifter may be aided in removal of the bar from the racks by the spotter/loaders) the lifter must move backwards to establish the starting position.
-   When the lifter is motionless, erect (slight deviation is allowable) with knees locked the Chief Referee will give the signal to begin the lift. The signal shall consist of a downward movement of the arm and the audible command "Squat". Before receiving the signal to "squat" the lifter may make any position adjustments within the rules, without penalty. For reasons of safety the lifter will be requested to "Replace" the bar, together with a backward movement of the arm, if after a period of five seconds he is not in the correct position to begin the lift. The Chief Referee will then convey the reason why the signal was not given.
-
-3. Upon receiving the Chief Referee's signal, the lifter must bend the knees and lower the body until the top surface of the legs at the hip joint is lower than the top of the knees. Only one descent attempt is allowed. The attempt is deemed to have commenced when the lifters knees have unlocked.
-
-4. The lifter must recover at will to an upright position with the knees locked. Double bouncing at the bottom of the squat attempt or any downward movement is not permitted. When the lifter is motionless (in the apparent final position) the Chief Referee will give the signal to rack the bar.
-
-5. The signal to rack the bar will consist of a backward motion of the arm and the audible command "Rack". The lifter must then return the bar to the racks. Foot movement after the rack signal will not be cause for failure. For reasons of safety the lifter may request the aid of the spotter/loaders in returning the bar to, and replacing it in the racks. The lifter must stay with the bar during this process. The lifter is not allowed to walk out through the front of the rack after completion of the lift.
-
-6. Not more than five and not less than two spotter/loaders shall be on the platform at any time.
-   The Referees may decide the number of spotter/loaders required on the platform at any time 2, 3, 4, or 5.
-
-#### 4.1.1. Causes for Disqualification of a Squat
-
-The diagrams below indicate the typical bar position but not obligatory and required depth in the squat:
 
 1. Failure to observe the Chief Referee's signals at the commencement or completion of a lift.
 
@@ -554,29 +268,6 @@ The diagrams below indicate the typical bar position but not obligatory and requ
 9. Failure to comply with any of the items outlined under Rules of Performance for the squat.
 
 ### 4.2. Bench Press
-
-1. The bench shall be placed on the platform with the head facing the front or angled up to 45 degrees. The Chief Referee shall position himself on the head side of the bench press rack. The lifter is not allowed to enter the rack from the head side of the bench press rack.
-
-2. The lifter must lie on their back with the head, shoulders, and buttocks (the picture PROPER STARTING POSITION & SETUP show the minimum acceptable) in contact with the bench surface.
-   The feet must be flat on the floor (as flat as the shape of the shoe will allow). Hands, thumbs and fingers must completely grip the bar positioned in the rack stands with a thumb around grip. This position shall be maintained throughout the lift. Foot movement is permissible but must remain flat on the platform. During the set-up on the bench, the athlete is not allowed to place his/her feet on the bench. The hair must not hide the back of the head when lying down on the bench. The Jury or Referees may require the lifter to affix his/her hair accordingly.
-
-3. To achieve firm footing the lifter may use flat surfaced plates, or blocks not exceeding 30 cm in total height and a minimum dimension of 60 cm x 40 cm, to build up the surface of the platform.
-   Blocks in the range of 5 cm, 10 cm, 20 cm, and 30 cm, should be made available for foot placement at all international competitions.
-
-4. Not more than five and not less than two spotter/loaders shall be on the platform at any time.
-   After correctly positioning himself, the lifter may enlist the help of the spotter/loaders in removing the bar from the racks. If assisted, the lift-off by the spotter/loaders must bring the bar to arm's length.
-
-5. The spacing of the hands shall not exceed 81 cm measured between the forefingers (both forefingers must be within the 81 cm marks and the whole of the forefingers must be in contact with the 81 cm marks if maximum grip is used). The use of the reverse grip is forbidden.
-
-6. After removing the bar from the racks, with or without the help of the spotter/loaders, the lifter shall wait with straight arms elbows locked for the Chief Referee's signal. The signal shall be given as soon as the lifter is motionless and the bar properly positioned. For reasons of safety the lifter will be requested to "Replace" the bar, together with a backward movement of the arm, if after a period of five seconds he is not in the correct position to begin the lift. The Chief Referee will then convey the reason why the signal was not given.
-
-7. The signal to begin the attempt shall consist of a downward movement of the arm together with the audible command "Start".
-
-8. After receiving the signal, the lifter must lower the bar to the chest or abdominal area whereby the underside of both elbow joints is lowered level with or below the top surface of each respective shoulder joint (the bar shall not touch the belt), hold it motionless, after which the Chief Referee will signal the audible command "Press". The lifter must then return the bar to straight arms' length elbows locked. When held motionless in this position the audible command "Rack" shall be given together with a backward motion of the arm. If the bar is lowered to the belt or does not touch the chest or abdominal area, the Chief Referee's command is "Rack".
-
-9. The height of the safety racks can be adjusted by the jury for safety reasons.
-
-#### 4.2.1. Causes for Disqualification of a Bench Press
 
 1. Failure to observe the Chief Referee's signals at the commencement, during or completion of the lift.
 
@@ -603,23 +294,7 @@ The diagrams below indicate the typical bar position but not obligatory and requ
 
 12. Failure to comply with any of the items outlined under the Rules of Performance.
 
-#### 4.2.2. Rules for the Disabled Athletes Competing in IPF
-
-#### Single Lift Bench Press Championships
-Bench press championships shall be organized without a special division for disabled lifters e.g. blind, sight impaired, mobility impaired. They may be assisted to, and from, the bench. Assisted to mean "with the help of the coach or/and with use of crutches, sticks/canes or wheelchair". The rules of competition apply equally to that of the able bodied. For lifters who have an amputated lower limb, a prosthetic device shall be considered the same as the natural limb. The lifter shall be weighed in without the device, with compensatory weight added according to the established fraction chart. Refer to WEIGHING IN item 5.
-For lifters with dysfunctional lower limbs that require leg braces or similar devices for walking, the device shall be considered as part of the natural limb and the lifter shall be weighed in wearing the device.
-
 ### 4.3. Deadlift
-
-1. The lifter shall face the front of the platform with the bar laid horizontally in front of the lifter's feet, gripped with an optional grip in both hands and lifted until the lifter is standing erect.
-
-2. On completion of the lift the knees shall be locked in a straight position. The front bundle of the deltoid muscle should be placed behind the imaginary projection of the bar. (See the picture)
-
-3. The Chief Referee's signal shall consist of a downward movement of the arm and the audible command "Down". The signal will not be given until the bar is held motionless and the lifter is in the apparent finished position.
-
-4. Any rising of the bar or any deliberate attempt to do so will count as an attempt. Once the attempt has begun no downward movement is allowed until the lifter reaches the erect position with the knees locked. If the bar settles as the shoulders come back (slightly downward on completion) this should not be reason to disqualify the lift.
-
-#### 4.3.1. Causes for Disqualification of a Deadlift
 
 1. Any downward movement of the bar before it reaches the final position.
 
@@ -639,16 +314,15 @@ For lifters with dysfunctional lower limbs that require leg braces or similar de
 
 ## 5. Weighing In
 
-1. Weighing in of the competitors must take place no earlier than two hours before the start of the competition for a particular category/category. All lifters in the category/categories must attend the weigh in, which will be carried out in the presence of two/three appointed referees. Weight categories may be combined in a single lifting session.
+1. Weighing in of the competitors must take place no earlier than two hours before the start of the competition for a particular category/category. All lifters in the category/categories must attend the weigh in. Weight categories may be combined in a single lifting session.
 
-2. If not already done, lots will be drawn to establish the order of weigh in. The lots drawn also establish the order of lifting throughout the competition when lifters require the same weights for their attempts.
+2. Lots will be drawn to establish the order of weigh in. The lots drawn also establish the order of lifting throughout the competition when lifters require the same weights for their attempts.
 
 3. The weigh in period will last one and a half hours.
 
-4. The weigh in for each competitor will be carried out in a room with the door closed, with only the competitor, his/their coach or manager of the same gender and the two/three referees present. For reasons of hygiene the lifter should wear socks/paper towel on the scale's platform. Lifters need to identify himself/herself/themselves with an ID/Passport.
+4. Each lifter may only be weighed once. Only those whose bodyweight is heavier or lighter than the category limits of the category entered are allowed to return to the scales. They must return to the scales and make weight within the limits of the hour and a half allowed for the weigh in; otherwise, they will be eliminated from the competition. A lifter can only be re-weighed as often as time and orderly progression by lots allows. A lifter may only be weighed outside the time limit of one and a half hours if he presents himself within the time limit, but due to the number of lifters trying to make weight, he is denied the opportunity of mounting the scales. He may then be allowed one re-weigh at the discretion of the referees. The lifter's agreed bodyweight must not be made public until all lifters competing in the particular category/categories have been weighed in.
 
-5. Lifters may be weighed nude or in underwear which complies with the specifications set out in the appropriate section of the IPF Technical Rulebook and which does not materially affect the lifters bodyweight. Minimal clothing, for purposes of weigh-in, shall be strictly limited to: (a) The approved lifting singlet. (b) One approved t-shirt (if applicable to the division): (c) Standard underwear compliant with IPF specifications; and (d) No footwear. If a question exists regarding weight of undergarments the clothing, a re-weigh in the nude lifter's singlet may be requested. "In competitions in which both sexes are competitors, the weigh in procedure may/must be altered to ensure that lifters are weighed by officials of their own sex. Additional officials (not necessarily referees) may be appointed for this purpose"
-   Disabled/Amputee lifters who are competing in bench press championships will have the following additions to their bodyweight:
+5. Disabled/Amputee lifters who are competing in bench press championships will have the following additions to their bodyweight:
 
    | Amputation                      | Addition           |
    | ------------------------------- | ------------------ |
@@ -659,11 +333,7 @@ For lifters with dysfunctional lower limbs that require leg braces or similar de
 
    For lifters with dysfunctional lower limbs that require leg braces or similar devices for walking, the device shall be considered as part of the natural limb and the lifter shall be weighed in wearing the device.
 
-6. Each lifter may only be weighed once. Only those whose bodyweight is heavier or lighter than the category limits of the category entered are allowed to return to the scales. They must return to the scales and make weight within the limits of the hour and a half allowed for the weigh in; otherwise, they will be eliminated from the competition. A lifter can only be re-weighed as often as time and orderly progression by lots allows. A lifter may only be weighed outside the time limit of one and a half hours if he presents himself within the time limit, but due to the number of lifters trying to make weight, he is denied the opportunity of mounting the scales. He may then be allowed one re-weigh at the discretion of the referees. The lifter's agreed bodyweight must not be made public until all lifters competing in the particular category/categories have been weighed in.
-
-7. A lifter may only weigh in the category in which he was nominated 21 days prior to the meet date. In the case where groups are formed in a particular weight class the B and C groups may lift at a separate and earlier time to the A group. Where groups lift at separate times in this way the A group must have a minimum of 8 (eight) and a maximum of 14 (fourteen) lifters.
-
-8. Lifters should check squat and bench press rack heights and foot blocks prior to the start of the competition. The rack height sheet must be signed or initialed after the check by the lifter or coach. It is in their interest. A copy of this official document goes to the Jury, Speaker, and Platform Manager.
+6. A lifter may only weigh in the category in which he was nominated 21 days prior to the meet date. In the case where groups are formed in a particular weight class the B and C groups may lift at a separate and earlier time to the A group. Where groups lift at separate times in this way the A group must have a minimum of 8 (eight) and a maximum of 14 (fourteen) lifters.
 
 ## 6. Order of Competition
 
@@ -743,87 +413,15 @@ No, the order of lifting is still determined by the lot number.
 **(p)** When two or more groups take part in a session upon a single platform, lifting will be organized on a group repetition basis. After the end of each discipline consisting of more than one group (squat, bench press) a time interval of 10 minutes is to be given between the disciplines. For example, if there are two groups taking part in a session, the first group will complete all three rounds of the squat. They will be followed immediately by the second group who will complete their three rounds of squat. The platform will then be set up for the bench press and the first group will complete their three rounds of the bench press, immediately followed by the second group who will similarly complete their three rounds of the bench press.
 The platform will then be set up for the deadlift and the first group will complete their three rounds of the deadlift, immediately followed by the second group who will similarly complete their three rounds of the deadlift. This system thus eliminates any time waste other than that necessary for arranging the platform between the lifts.
 
-**(q)** In competitions where designated international broadcast partners are present, the interval between disciplines (Squat, Bench Press, and Deadlift) can be adjusted.
-The Technical Committee with the co-operation and assistance of the organizer will appoint the following officials:
+**(q)** The lifter is allowed one minute in which to start his attempt after the Speaker calls the lifter to the bar. When the Speaker announces that the bar is "ready/loaded", the lifter is committed to the attempt. The clock starts when the bar is announced as ready. The clock stops when the lift starts: in the squat and bench press, the start coincides with the Chief Referee's commencement signal; in the deadlift, the start is when the lifter makes a determined attempt to raise the bar. If the lifter does not start his attempt within the one-minute allowance, the lift will be declared "no lift" and the attempt forfeited.
 
-   **(a)** Speaker/Announcer, a National or International Referee who is able to converse in English and that of the host nation.
+**(r)** On the completion of an attempt, a lifter shall leave the platform within 30 seconds; failure to comply with this rule may result in disqualification of the attempt at the discretion of the referees.
 
-   **(b)** Technical Secretary, an International Referee preferably able to converse and write in English and that of the host nation.
+### 6.2. Miscellaneous Rules
 
-   **(c)** Time Keeper (a qualified referee).
+1. In international matches between two lifters or two nations contested in different bodyweight categories, the lifters may alternate irrespective of weight required for the attempts. The lifter requiring the lightest weight in his initial lift shall lift first and thereby set the order for the alternate attempts throughout that particular lift.
 
-   **(d)** Marshals/Expeditors.
-
-   **(e)** Scorers.
-
-   **(f)** Spotter/Loaders. Correct code of dress-Meet t-shirt or regular t-shirt uniform in color. Track suit trousers uniform in color. Trainers or sports shoes. Athletic shorts may be worn in hot weather on the ruling of the jury.
-
-   **(g)** Technical Controller (a qualified international referee).
-
-   **(h)** Additional officials may be appointed as required, e.g. doctors, paramedics etc.
-
-### 6.2. Responsibilities of the Officials
-
-**(a)** The Speaker is responsible for the efficient running of the competition. He acts as Master of Ceremonies and arranges the attempts chosen by the lifters in an orderly fashion, dictated by weight and, if necessary, lot number. He announces the weight required for the next attempt and the name of the lifter. When the bar is loaded and the platform cleared for lifting, the Chief Referee will indicate the fact to the Speaker. When the Speaker announces that the bar is ready and calls the lifter to the platform, the clock will begin. To clarify, - when the Speaker announces that the bar is "ready/loaded", then the lifter is committed to the attempt. Attempts announced by the Speaker must be displayed upon the scoreboard erected in a prominent position, with the lifter's names in order of lot number.
-
-**(b)** The Technical Secretary is responsible for attending the technical meeting prior to the competition. In the absence of the Technical Committee or a member of that committee the Technical Secretary will compile the Jury and Referee schedules from the names of those referees declared available for duty throughout the competition. He will complete the necessary "Duty Referees and Jury Members" lists for the competition and inform referees of categories to which they have been allocated. After the technical meeting when final team nominations have been compiled, the technical secretary will initiate a score sheet, non-itemized equipment check sheet, rack height sheet and order of weigh in sheet for each category in the competition, entering the names of all lifters nominated in that category. Lots may also be drawn at this stage to establish weigh in and lifting order. He will also make out speaker competition cards for every lifter in the category. The above paperwork together with an adequate supply of lifter's attempt slips/cards will be placed in the appropriate envelope for each bodyweight category in the competition and handed to the Chief Referee for that category. The Technical Secretary will attend each weigh in and advise the duty.
-
-**(c)** Referees upon procedure and any matters that require attention. He should be an International Referee preferably from the host nation and able to deal with any problem that may arise due to language difficulties at the venue. It is the responsibility of the meet director to provide all necessary blank forms and paperwork to enable the Technical Secretary to carry out his work. A complete dossier on the job description together with all relative paperwork can be obtained from the Technical Committee free of charge available to all Meet Directors.
-
-**(d)** The time keeper is responsible for accurately recording the lapse between the announcement that the bar is ready and the lifter starting his attempt. He is also responsible for recording time allowances whenever required, e.g. after an attempt the lifter shall leave the platform within 30 seconds. Once the clock is running for a lifter, it can only be stopped by the completion of a time allowance, by the start of the lift, or at the discretion of the Chief Referee. Consequently, it is of great importance that the lifter or his coach check the height of the squat racks prior to being called, as once the bar is announced as being ready, the clock will be started. Any further adjustments to the racks must be made within the lifter's one-minute allowance, unless the lifter has nominated his rack height and this has been incorrectly set by the spotter/loaders. It is therefore essential that the rack height sheet be signed or initialed by the lifter or coach. This is an official document, which should verify in any dispute. The lifter is allowed one minute in which to start his attempt after the Speaker calls the lifter to the bar.
-If he does not start his attempt within this time allowance, the time keeper will call time and the Chief Referee shall give the audible command "rack" together with a backward movement of the arm. The lift will be declared "no lift" and the attempt forfeited. When the lifter starts the lift within the prescribed time allowance, the clock will be stopped. The definition of the start of an attempt depends upon the particular lift being performed. In the squat and bench press, the start is to coincide with the Chief Referee's commencement signal. Refer to "Referees" item 3. In the deadlift, the start is when the lifter makes a determined attempt to raise the bar.
-
-**(e)** Marshals/Expeditors are responsible for collecting the weight of required attempts from the lifters or their coaches and passing the information without delay to the Speaker. The lifter is allowed one minute between completing his last attempt and informing the speaker, via the Marshal, of the weight required for his next attempt.
-
-**(f)** Scorers are responsible for accurately recording the progress of the competition, and on completion, ensuring that the three referees sign the official score sheets, record certificates or any other document requiring signatures. Speaker to make an announcement to this effect before the referees disappear.
-
-**(g)** Spotter/loaders are responsible for loading and unloading the bar, adjusting squat racks and benches as required, cleaning the bar or platform at the request of the Chief Referee, and generally ensuring that the platform is well maintained and presents a neat and tidy appearance at all times. At no time shall there be less than two or more than five spotter/loaders on the platform. When the lifter prepares for his attempt, the spotter/loaders may assist him in removing the bar from the racks. They may also assist in replacing the bar after the attempt. However, they shall not touch the lifter or the bar during the actual attempt, i.e., during the period of time that elapses between the commencement and completion signals. The only exception to this rule being that if the lift is in jeopardy and likely to result in injury to the lifter, the spotter/loaders may, either at the request of the Chief Referee or the lifter himself, step in and relieve the lifter of the bar. If the lifter himself is deprived of an otherwise successful attempt by the error of a spotter/loader and through no fault of his own, he shall be awarded another attempt at the discretion of the Referees and Jury at the end of the round.
-
-**(h)** The Technical Controller will ensure that the lifter is that as announced and properly attired before mounting the platform. He/she must also attend the equipment control.
-
-### 6.3. Miscellaneous Rules (Loading Errors, Misconduct, Appeals etc.)
-
-1. The number of coaches of each nation for each lifting group:
-
-   **Warm-up area:**
-
-   | Athletes | Coaches |
-   |----------|---------|
-   | 1 | 3 |
-   | 2 (same group) | 3 |
-   | 2 (different groups) | 5 |
-   | 3 (same group) | 5 |
-   | 3 (different groups) | 6 |
-   | 4 | 6 (maximum) |
-
-   **Preparation/wrapping area (Equipped):**
-
-   | Athletes | Coaches |
-   |----------|---------|
-   | 1 | 2 |
-   | 2 | 4 |
-   | 3 | 5 |
-   | 4 | 6 (maximum) |
-
-   **Preparation area (Classic):**
-
-   | Athletes | Coaches |
-   |----------|---------|
-   | 1 (one group) | max 2 |
-   | 2 (one group) | max 2 |
-   | 3 (one group) | max 2 |
-   | 3 (two groups) | max 3 |
-   | 4 (two groups) | max 4 (maximum) |
-
-   During any competition taking place on a platform or stage, only the lifter and ONE (1) coach, members of the Jury, officiating referees, spotter/loaders and the Technical Controller will be allowed around the platform or on the stage. During the execution of the lift, only the lifter, spotter/loaders and the referees are permitted to be present on the platform. Coaches shall remain within the designated coaching area as defined by the Jury or Technical Officer in charge.
-   The coaching area must be made in such a way that allows the coach to place himself with a good view to the lifter with the possibility to give instructions and signals to the lifter regarding technical details (e.g. depth in squat).
-   The coach area should be on a distance of no longer than 5 meters from the stage and it should be longer than the lifting stage that permits a walking area for the coach to see the lift from any side back or side front angle. Dress code for coaches at international events shall be national team tracksuit plus team or IPF approved t-shirt, or sport shorts plus team or IPF approved t-shirt, NO HATS, TAKING PICTURES or MAKING VIDEOS. Coach must adhere to this code failing which on the ruling of the Technical Controller or Jury, it may result in the coach being excluded from the event warm up room and competition surrounds. See COACH RESPONSIBILITIES on page 44.
-
-2. A lifter shall not wrap, adjust his costume or use ammonia within view of the public. The only exception to this rule being that he may adjust his belt.
-
-3. In international matches between two lifters or two nations contested in different bodyweight categories, the lifters may alternate irrespective of weight required for the attempts. The lifter requiring the lightest weight in his initial lift shall lift first and thereby set the order for the alternate attempts throughout that particular lift.
-
-4. In IPF recognized competitions, the weight of the barbell must always be a multiple of 2.5 kg. Unless attempts are made on records, in Squat, Bench Press and Deadlift, the progression must be at least 2.5 kg between all attempts.
+2. In IPF recognized competitions, the weight of the barbell must always be a multiple of 2.5 kg. Unless attempts are made on records, in Squat, Bench Press and Deadlift, the progression must be at least 2.5 kg between all attempts.
 
    **(a)** In a record attempt the weight of the barbell must be at least 0.5 kg in excess of the current record.
 
@@ -842,7 +440,7 @@ If he does not start his attempt within this time allowance, the time keeper wil
    The current record is 300 kg.
    Lifter A posts only a 1 kg increment (301 kg) having achieved his first attempt of 300 kg in the above scenario, Lifter B squats 305 kg in the first round, Lifter A must now take the nearest 2.5 kg above (302.5 kg).
 
-5. The Chief Referee will be solely responsible for decisions taken in the case of loading errors or incorrect announcements by the speaker. His decisions will be given to the speaker who will make the appropriate announcement. Examples of errors in loading:
+3. The Chief Referee will be solely responsible for decisions taken in the case of loading errors or incorrect announcements by the speaker. His decisions will be given to the speaker who will make the appropriate announcement. Examples of errors in loading:
 
    **(a)** If the bar is loaded to a lighter weight than originally requested and the attempt is successful, he lifter may accept the successful attempt or elect to take the attempt again at the originally requested weight. If the attempt is not successful, the lifter will be granted a further attempt at the originally requested weight. In both the above cases, further attempts may only be taken at the end of the round in which the error occurred.
 
@@ -856,346 +454,27 @@ If he does not start his attempt within this time allowance, the time keeper wil
 
    **(f)** If the lifter himself is deprived of an otherwise successful attempt by the error of a spotter/loader, wrongly loaded bar or any other fault and through no fault of his own, he shall be awarded another attempt at the discretion of the Referees and Jury at the end of the round. If any lift is a record attempt the lifter shall always follow himself no matter what round it is.
 
-6. Three unsuccessful attempts in any lift will automatically eliminate the lifter from the overall competition. He may still compete for awards on individual lifts if he makes bona fide attempts on each of the lifts i.e., weights attempted must be within his reasonable capabilities. If this is questionable the Jury will decide.
+4. Three unsuccessful attempts in any lift will automatically eliminate the lifter from the overall competition. He may still compete for awards on individual lifts if he makes bona fide attempts on each of the lifts i.e., weights attempted must be within his reasonable capabilities. If this is questionable the Jury will decide.
 
-7. Other than initial removal of the bar from the racks, the lifter will not receive any help from the spotter/loaders in positioning himself for an attempt.
+## 7. World and International Records
 
-8. On the completion of an attempt, a lifter shall leave the platform within 30 seconds; failure to comply with this rule may result in disqualification of the attempt at the discretion of the referees. This rule was designed for lifters who may have received some injury during the course of the lift, or perhaps the less able bodied, e.g. the blind lifter.
-
-9. Athlete's hair should be fixed (braided or tied back) in such a way as to not interfere with the referees' ability to judge the lift.
-
-10. Lifters are expected to enter and exit the lifting area or platform in a respectful manner, refraining from discarding their belt on the floor or engaging in any conduct that may be harmful to the integrity of the sport.
-
-11. If during warm up or competition, a lifter suffers injury or in any other way exhibits signs of a condition which may unduly or significantly jeopardize the competitor's health and wellbeing, the official doctor has the right to examination. If the doctor considers it inadvisable for the lifter to continue, he may, in consultation with the Jury, insist upon the lifter retiring from the competition. The team manager or coach must be officially informed of such a decision. To avoid contamination a solution of one-part household bleach to 10 parts water is recommended to clean blood or tissue from the bar or platform and that in the warmup area should "accidents" occur.
-
-12. Any lifter or coach, who by reason of his misconduct upon or near the competition platform is likely to discredit the sport, shall be officially warned. If the misconduct continues, the Jury, or Referees in the absence of the Jury, may disqualify the lifter or coach and order the lifter or coach to leave the venue. The team manager must be officially informed of both warning and disqualification.
-
-13. The Jury and Referees may by a majority decision immediately disqualify a lifter or official if they are of the opinion that any misconduct is serious enough to warrant immediate disqualification rather than an official warning. The team manager must be informed of the disqualification.
-
-14. In international competition, all appeals against referee's decisions, complaints regarding the progress of the competition or against the behavior of any person or persons taking part in the competition must be made to the Jury. The Jury may require the appeal to be made in writing. The appeal or complaint must be lodged with the Chairman of the Jury by the team manager, coach or in his absence, by the lifter. This must be done immediately following the action upon which the appeal or complaint is based. It will not be considered unless these terms are met.
-
-15. If deemed necessary, the Jury may temporarily suspend the progress of the competition and retire to consider its verdict. After due consideration and upon reaching a unanimous verdict, the Jury will return and the Chairman will inform the complainant of its decision. The Jury's verdict will be considered final and there will be no right of appeal to any other body. Upon recommencement of the competition which has been suspended, the next lifter shall be given three minutes in which to commence his lift. In the event of a complaint being made against a lifting member or official of an opposing team, "The Jury will not consider challenges relating to the referees' decision on lifts performed by an athlete from an opposing team" the written complaint shall be accompanied by the cash sum of Euro 75 or its equivalent in any currency.
-   Should the Jury in its verdict consider that the complaint is of a frivolous or mischievous nature, then the whole or any portion of the sum may be retained and donated to the IPF at the discretion of the Jury.
-
-   | Lift | Commencement | Completion |
-   |------|-------------|------------|
-   | SQUAT | A visual signal consisting of a downward movement of the arm together with the audible command "squat" | A visual signal consisting of a backward movement of the arm together with the audible command "rack" |
-   | BENCH PRESS | A visual signal consisting of a downward movement of the arm together with the audible command "start". DURING: The audible command "Press" after motionless at the chest and the visible signal of an upward movement of the arm. | A visual signal consisting of a backward movement of the arm together with the audible command "rack" |
-   | DEADLIFT | No signal required | A visual signal consisting of a downward movement of the arm together with the audible command "down" |
-   When a lifter fails to complete a squat or a bench press, the command is "rack".
-
-16. The Jury may utilize instant replay technology as an official tool to review lifts during IPF-sanctioned competitions. Instant replay may be used to assist the Jury in determining the correctness of referees' decisions or to confirm the validity of a lift in cases where visual evidence may clarify a technical or procedural matter. When used, the following shall apply:
-
-   **(a)** The instant replay system shall be operated only by the jury or a designated official under Jury supervision.
-
-   **(b)** The Jury may initiate review upon its own discretion or upon protest lodged in accordance with the rules.
-
-   **(c)** The decision of the Jury, after instant replay review, shall be final and binding.
-
-   **(d)** The use of instant replay shall not unduly delay the competition and must be conducted in a manner that maintains the flow of the event.
-
-   **(e)** Instant replay may only be employed at IPF Calendar events or other competitions where the necessary technical equipment and personnel are available.
-
-## 7. Referees
-
-1. The referees shall be three in number, the Chief Referee or Center Referee and two side referees. Their international referee cards should be in date, and that of the Technical Controller, and placed on the Jury table.
-
-2. The Chief Referee is responsible for giving the necessary signals for all three lifts.
-
-3. Signals required for the three lifts are as follows:
-
-4. Once the bar has been replaced in the racks or on the platform at the completion of the lift, the referees will announce their decisions by means of the lights. White for a "good lift" and red for "no lift". The cards will then be raised to indicate the reason for the "no lift".
-
-5. The three referees may seat themselves in what they consider to be the best viewing positions around the platform in a range not farther than 4 meters for each of the three lifts. However, the Chief Referee must always bear in mind the need to be visible to the lifter performing the squat or deadlift, and the side referees should always bear in mind the need to be visible to the Chief Referee so that he can observe their raised arms.
-
-6. Before the contest, the three referees shall jointly ascertain that:
-
-   **(a)** The platform and competition equipment comply in all respects with the rules. Bars and discs are checked for weight discrepancies and defective equipment discarded. A second bar and collars should be readied and put aside in case of damage to the original bar or collars.
-
-   **(b)** The scales work correctly and are accurate (currently certified).
-
-   **(c)** The lifters weigh in within the limits of weight and time for their bodyweight category.
-
-   **(d)** The lifter's personal equipment has been inspected to comply with the rules in all respects. It is the duty of the lifter to ensure that all items he wishes to wear on the platform have passed the scrutiny of the examining referees. Lifters discovered wearing or using apparel that has not been checked in may be subject to penalty, e.g. disqualification of the last attempt.
-
-7. During the contest the three referees must jointly ascertain that:
-
-   **(a)** The weight of the loaded bar agrees with the weight announced by the speaker. Referees may be issued with loading charts for this purpose. It is their joint responsibility.
-
-   **(b)** On the platform the lifter's personal equipment complies with the rules. If any referee has reason to doubt a lifter's integrity in this respect he must after completion of the lift, inform the Chief Referee of his suspicions. The president of the Jury may then examine the lifter's personal equipment. If the lifter is found to be wearing or using any illegal item other than that which may have inadvertently been passed in error by the examining referees, the lifter shall be immediately disqualified from the competition. If wearing any illegal item passed in error by the examining referees, and the lift in which the discovery was made is successful, the lift will be rejected and then the lifter will be granted a new attempt (having removed the illegal item) at the end of the round. Should a Technical Controller be in evidence, the lifter's attire will be scrutinized before he/she is allowed onto the platform.
-
-8. Prior to the commencement of the Squat and Bench press the side referees will raise their arms and keep them raised until the lifter is in the correct position to begin the lift. If there is a majority opinion among the referees that a fault exists, the Chief Referee will not give the signal to commence the lift. The lifter has the remainder of his unexpired time allowance in which to correct the position of the bar or his stance in order to receive the commencement signal. Once a lift has commenced, the side referees will not call attention to faults during the execution of the lift.
-
-9. Referees shall abstain from commentary and not receive any document or verbal account concerning the progress of the competition. Therefore, it is essential that the lot number of each lifter accompanies his name on the scoreboard so that the referees can follow the order of lifting.
-
-10. A referee shall not attempt to influence the decisions of the other referees.
-
-11. The Chief Referee may consult with the side referees, the Jury or any other official as necessary in order to expedite the competition.
-
-12. At his discretion, the Chief Referee may order that the bar and/or platform be cleaned. If the lifter or coach request the bar and/or platform to be cleaned, the request must be made via the Chief Referee/Technical Controller not the spotter/loaders. In the final round of the deadlift the bar must be cleaned before every attempt, and in any of the other two rounds, should the coach or lifter desire.
-
-13. After the competition, the three referees shall sign the official score sheets, record certificates or any other documents requiring a signature.
-
-14. In International Competition, referees will be selected by the Technical Committee and must have proved their competence at International or National Championships.
-
-15. In International Competitions two referees of the same nation can be selected to adjudicate in a contest where more than one nation competes, and the nation the referees represent has no lifters nominated for the Championship. If a category consists of more than one group, all groups should have the same referees. If a change of referees is necessary the change should be made between the disciplines, so that all lifters have the same referees in the same discipline.
-
-16. The selection of a referee to act as Chief Referee in one category does not preclude his selection as side referee in another category.
-
-17. At World Championships, or any other championships where attempts may be made on world records, only IPF category 1 or category 2 referees adjudicate. Each nation may nominate a maximum of three four referees to serve at the World Championships, plus 2 extra category 1 referees for Jury duty, if there is an insufficient number. All nominated referees attending a championship, must be available for at least two days.
-
-18. Referees and members of the Jury will be uniformly dressed as follows:
-
-   | Season | Men | Women |
-   |--------|-----|-------|
-   | Winter | Dark blue blazer with IPF badge on left breast. Grey trousers (not jeans), white shirt, IPF tie. | Dark blue blazer with IPF badge on left breast. Grey skirt or trousers (not jeans), white blouse or shirt, IPF scarf/tie. |
-   | Summer | Grey trousers (not jeans), white shirt, IPF tie. | Grey skirt or trousers (not jeans), white blouse or shirt, IPF scarf/tie. |
-
-   IPF badges and scarf/ties are red for category 1 referees and blue for category 2 referees. The Jury shall determine whether winter or summer dress will be worn. Shoes known as "trainers" do not compliment blazer and trousers! Dress/Day wear black shoes and black socks must be worn. Open shoes are not allowed.
-
-19. Qualifications for a Category 2 Referee are as follows:
-
-   **(a)** A national referee of at least two years standing, having officiated in the position as a referee with a minimum of two National Powerlifting Championships within this period.
-
-   **(b)** Must be recommended by his National Federation.
-
-   **(c)** Must take the Category 2 written/computer examination in English and practical examination at a World Championship, Continental Championship or Regional Championship.
-
-   **(d)** Must achieve a passing score of 85 percent or more on written examination and 85 percent or more on practical examination.
-
-20. Qualifications for a Category 1 Referee are as follows:
-
-   **(a)** Must be a Category 2 referee in good standing for a period of at least 4 years, officiating at a minimum six (6) international (World and/or Regional) and six (6) national championships.
-
-   **(b)** Must have adjudicated at least 4 International Championships, excluding the World Bench Press Championships.
-
-   **(c)** Must take Category 1 practical and written/computer examination at any World Championship (excluding the World Bench Press Championship), Continental Championship, Regional Games or International Tournament
-
-   **(d)** Must adjudicate at least 75 attempts, 35 of which must be squats, while serving as Chief Referee. First round attempts by lifters will count.
-
-   **(e)** The candidate will also be credited with 25 points/marks, and observed for competence by the examiner (s) during gear check, weigh in and while seated on the platform. A deduction of 0.5 (half a point/mark) will be made for any error that may contravene the technical rules. The examiner will be a member of the IPF Technical Committee or an Official appointed by the IPF Technical Committee and Referee Registrar.
-
-   **(f)** The candidate must score at least 90 percent on his total examination. This includes the 75 points on his decisions made on the platform as compared with those of the Jury members and not those of his fellow platform referees. The other 25 points coming from his decisions and performance of the necessary duties i.e. gear check, weigh in and platform control.
-
-   **(g)** Must be nominated by his National Federation to the Chairman of the Technical Committee and Referee Registrar three months prior to his examination.
-   Basis for Nomination should be as follows:
-      - Candidate's competence as a referee.
-      - Priority ranking as a Category 2 referee.
-      - Availability to referee at future international events.
-      - Knowledge of English language.
-
-   **(h)** A requirement of the Category I candidate is that he/she is able to converse in English to a standard that will allow complete comprehension in disputes, particularly when asked to partake in jury duty. In this respect, the examiners will decide the proficiency of the candidate. If a candidate passes his/her category 1 examination but speak no English, he/she will be a Regional Category 1 Referee and can only be in the Jury at Regional meets or National meets.
-
-21. The selection of a candidate for examination by the IPF will be subject to the following Criteria:
-
-   **(a)** The number of nominations received.
-
-   **(b)** The number of examination positions available.
-
-   **(c)** The current requirements for Category 1 referees within the various nations.
-
-22. Testing Procedures are as follows:
-
-   **(a)** Category 2 A written/computer examination in English Language will be given only after a complete and comprehensive rules clinic has been conducted under the direction of an approved Category 1 referee who has been appointed as Chief Examiner by the IPF Technical Committee and Referee Registrar. A practical examination will be given after the written/computer examination during the competition, the candidate will be side referee and will adjudicate a total of 100 attempts, 40 of which must be squats. The candidate must be scrutinized by the Jury and score at least 85 percent on all his decisions when compared with a majority of the scrutinizing referees. Adjudication will begin with the first-round attempts. The written/computer and practical Category 2 examinations will be held only in conjunction with international or regional powerlifting championships.
-
-   **(b)** Category 1 A practical and a written/computer examination will be given to a candidate at any World Championship (excluding the World Bench Press Championship), Continental Championship, Regional Championships. The candidate will be scrutinized by the Jury. The candidate must score at least 90 percent on all his decisions when compared with a majority of the scrutinizing Jury members, this includes the candidate's observed competence in handling all other duties, such as equipment check examinations and weigh in procedures. Adjudication will begin with the first-round attempts.
-
-23. The examination fee shall be paid to the IPF Treasurer before the examination. All examination score sheets shall be marked by the scrutinizing referee/s. When marking is complete, the candidate shall be informed of the results. Marked score sheets shall be sent to the Referee's Registrar.
-
-24. After receiving the examination results, the Referee Registrar will inform the candidates Federation's National Secretary of the results and forward the appropriate credentials to the candidate.
-
-25. A candidate taking a practical examination will be scrutinized by the Jury (for Category 1) or the appointed scrutinizing referee/s (for Category 2) to determine his success or failure.
-
-26. Upon passing the examination, a referee's date of promotion shall be the date of the examination.
-
-27. Candidates who fail the examination are allowed to re-write at the same Championships and need to pay for the examination again.
-
-28. Registration:
-
-   **(a)** All referees must re-register with the IPF in order to maintain their current qualifications and at an acceptable standard.
-
-   **(b)** Re-registration shall take place on the first of January in each Olympic year.
-
-   **(c)** Technical Secretary at an international competition shall send a list in the form of an Excel file to the IPF Referee Registrar of the participant referees immediately after a competition.
-
-   **(d)** A referee's national federation is responsible for sending the necessary 50 Euro registration fee to the IPF Treasurer and a resume of his international and national experience during the previous registration period to the IPF Referee Registrar.
-
-   **(e)** A referee who has been inactive for a four-year period or who fails to re-register will forfeit his credentials. Then need to retake examinations.
-
-   **(f)** A card which is issued within the twelve months prior to the first of January in each Olympic year need not be renewed until the first of January the following Olympic year.
-
-29. The IPF Referee Registrar shall provide each national federation with:
-
-   **(a)** A current list of accredited referees. Updated annually.
-
-   **(b)** A list of referees who need to re-register in order to remain accredited.
-
-30. International Referees, both Category 1 and 2, must have refereed a minimum of two (2) International Powerlifting or Bench Press Championships and two National Powerlifting Championships during the previous four-year period between Olympic years in order to be acceptable for re-registration.
-
-## 8. Jury and Technical Committee
-
-### 8.1. Jury
-
-1. At World and Continental Championships, a Jury will be appointed to preside over each lifting session.
-
-2. The Jury shall consist of three or five Category 1 referees. In the absence of a member of the Technical Committee, the most senior member of the three or five shall be designated President of the Jury. The five-man jury can be installed only at the World Games or Men's and Women's Open Championships in Powerlifting.
-
-3. The members of the Jury shall all be from different nations with the exception of the IPF President and the Chairman of the Technical Committee.
-
-4. The function of the Jury is to ensure that the technical rules are correctly applied.
-
-5. During the competition the Jury may, by a majority vote, replace any referee whose decisions in its opinion, prove him to be incompetent. The referee concerned must have received a warning prior to any action of dismissal.
-
-6. The impartiality of referees cannot be doubted, but a mistake in refereeing can be committed in good faith. In such a case, the referee shall be allowed to give his explanation for making the decision which is the subject of his warning.
-
-7. If a protest is made to the Jury against a referee, then the referee may be informed of the protest. The Jury should not put unnecessary stress on platform referees.
-
-8. If a serious mistake occurs in the refereeing which is contrary to the technical rules, the Jury may take appropriate action to correct the mistake. They may at their discretion, grant the lifter a further attempt.
-
-9. Only in extreme circumstances when there has been an obvious or blatant mistake in the refereeing will the Jury in consultation verbally or electronically with the referees, by unanimous jury vote with (3) Member Jury or with Majority vote with (5) Member Jury may reverse the decision. Only 2 to 1 referees' decision can be considered by the Jury.
-
-10. The selection of lifters for drug testing shall always be made by the CCES.
-
-11. The members of the Jury will be positioned to ensure an unimpeded view of the competition.
-
-12. Before each competition, the President of the Jury must satisfy himself that the members of the Jury have a complete knowledge of their role and any new regulations that amend or supplement those contained in the current edition of the handbook.
-
-13. If music accompanies the lifting, the Jury will determine the volume. The music will terminate when the lifter takes the weight of the bar in the squat and bench press or begins the pull in the deadlift.
-
-14. The referees' cards will be signed at the completion of the weight class.
-
-### 8.2. IPF Technical Committee
-
-1. Will consist of a Chairman, who shall be a Category 1 referee elected by the General Assembly, and up to ten members from various nations appointed by the Executive Committee in consultation with the Chairman of the Technical Committee. And a coach/lifter representative.
-
-2. Will be entrusted with the examination of all requirements and proposals of a technical nature submitted by the affiliated federations.
-
-3. Appoints the Chief Referee, side referees and the jury for the World Championships. May also appoint Referees who are present and not nominated by their nation and available in case of insufficient Referees. National Referees may be appointed as Technical Controllers.
-
-4. Trains and instructs referees who have not yet reached the international level and re-examines those who have already reached that level.
-
-5. Informs the IPF General Assembly, President and General Secretary via the Referee Registrar as to which referees are eligible to referee after examination or re-examination.
-
-6. Organizes courses for referees before any major competition such as the World Championships. The expense involved in organizing such courses or clinics must be borne by the organizing federation.
-
-7. Makes proposals to the IPF General Assembly for the withdrawal of an international referee's card when it deems such action necessary.
-
-8. Publishes via the Executive, material of a technical nature that deals with training methods and performance of competition lifts.
-
-9. **(a)** Will be responsible for inspecting all competition and personal equipment as defined in the handbook. Also, equipment that has been submitted by various manufacturers for the sole purpose of being able to use the words "IPF Approved" in their commercial advertisements. If the item or items submitted meet all current IPF rules and regulations, and the IPF Executive Committee agree with the decision of the Technical Committee, a fee for each item shall be levied by the IPF Executive and a certificate of approval will be issued by the Technical Committee.
-
-   **(b)** At the end of each year, a renewal fee for each item as levied by the IPF Executive must be submitted to the IPF for purposes of re-certification of approval. If the design has been changed, the item must be submitted to the Technical Committee for inspection and re-certification.
-
-   **(c)** If, at any time after the certificate of approval has been issued, the manufacturer changes the design of the competition or personal equipment that was previously submitted for approval and it no longer meets current IPF rules and regulations, the IPF shall withdraw approval. The IPF will not issue another certificate until changes in design have been corrected and the item or items submitted to the Technical Committee for inspection.
-
-## 9. World and International Records
-
-### 9.1. International Competitions
-
-1. World and International records may only be made at the above named. That is, Championships sanctioned and recognized by the IPF, World and International Records will be accepted without weighing the barbell or the lifter, provided that the lifter had weighed in correctly before the competition and that the referees or the Technical Committee had checked the weight of the barbell and the discs before the competition.
+1. Records cascade upward across age categories:
    Men's and women's 40-49 records exceeding the open record will be included in the open categories if appropriate.
    Men's and Women's 50-59 records exceeding those gained in the 40-49 age group will be included in the 40-49 category and Open categories if appropriate.
    Men's and Women's 60-69 records exceeding those gained in the 50-59 will be included in the 50-59 category and in the 40-49 category, and Open categories if appropriate.
    Men's and Women's 70+ records exceeding those gained in the 60-69 age group, will be included in the 60-69 category, and in the 50-59 or 40-49 category and Open categories if appropriate. Likewise, Sub-Junior 14-18 records exceeding those gained in the Junior 19-23 age group will be included in this group, and Open categories if appropriate.
    Junior 19-23 records exceeding the open record will be included in the open if appropriate.
-   Note: From 2021 start to register the World Games records. The records should be registered in that bodyweight category to which belongs the competitor according to his bodyweight. The starting record standards should be equal to the World records in powerlifting as for 14/07/2021
 
-2. Requirements for recognition of a World and International records are as follows:
+2. Records on individual lifts must be accompanied by a total of the three lifts. Single lift Bench Press records made at a three lift (Powerlifting) event do not need to be accompanied by a total but bona fide attempt must be made both on squat and deadlift.
 
-   **(a)** The International Competition must be held under the sanction of the IPF.
+3. In the event two (2) lifters request the same weight for a new record in an individual lift, and if the first lifter by lot number succeeds, 0.5 kg will be added by the computer secretary (if it's not a multiple of 2.5 kg's) to his/her attempt to claim the record. The record holder is the lifter who makes the record total first.
 
-   **(b)** Each of the adjudicating referees must hold a current IPF International Referee's Card and be a member of a national federation affiliated to the IPF. It must be referees from three different nations on the stage and there must be a three member Jury.
+4. New Records are only valid if they exceed the previous record by at least 0.5 kg.
 
-   **(c)** The good faith and competence of referees of all member nations is beyond dispute.
+5. Should a lifter exceed the single lift bench press record whilst lifting in a three-lift powerlifting contest, he/she may claim the single lift bench press record if bona fide attempts are made on both squat and deadlift. A lifter in a single lift bench press contest cannot claim the three-lift powerlifting record.
 
-   **(d)** Only bars and discs and racks that are listed on the IPF Approved list of apparel and equipment for use at IPF sanctioned competition, as current at the time, maybe used in the setting of World and International records.
+## 8. Jury Override
 
-   **(e)** Records on individual lifts must be accompanied by a total of the three lifts. Single lift Bench Press records made at a three lift (Powerlifting) event do not need to be accompanied by a total but bona fide attempt must be made both on squat and deadlift.
+1. If a serious mistake occurs in the refereeing which is contrary to the technical rules, the Jury may take appropriate action to correct the mistake. They may at their discretion, grant the lifter a further attempt.
 
-   **(f)** In the event two (2) lifters request the same weight for a new record in an individual lift, and if the first lifter by lot number succeeds, 0.5 kg will be added by the computer secretary (if it's not a multiple of 2.5 kg's) to his/her attempt to claim the record. The record holder is the lifter who makes the record total first.
-
-   **(g)** New Records are only valid if they exceed the previous record by at least 0.5 kg.
-
-   **(h)** If a lifter is attempting to set a World record in the deadlift and is placed at the end of the round by virtue of a protest, the remaining lifters in the group attempting the World record will have to increase their attempt by 0.5 kg. If more than one lifter is attempting to set a World record in the same discipline and a lifter gets a new attempt by virtue of a protest the lifter must following him/herself.
-
-   **(i)** All records broken under the same conditions as that listed above shall be recognized and registered.
-
-3. World single lift bench press records may be made at any of the forenamed Championships known as single lift or as in (a) below. The same criterion applies to that of all world powerlifting records.
-
-   **(a)** Should a lifter exceed the single lift bench press record whilst lifting in a three-lift powerlifting contest, he/she may claim the single lift bench press record if bona fide attempts are made on both squat and deadlift.
-
-   **(b)** Should a lifter in a single lift bench press contest exceed the three-lift powerlifting record he/she cannot claim the three-lift powerlifting record.
-
-## 10. Coach Responsibilities
-
-#### The Aims of a Coach Responsibility
-Is to ensure the successful coaching of their lifters at international level, to encourage participation in the sport of Powerlifting, to help each lifter to achieve the best results that their potential indicates,
-
-#### What Is the Coach Responsibility?
-The Coach has many duties associated with the above aims, he/she needs to have a strong character and disciplined approach at all times, he/she must always be in charge.
-
-#### Being a Coach, You Must Ensure the Following
-
-**Warm-up area:**
-
-| Athletes | Coaches |
-|----------|---------|
-| 1 | 3 |
-| 2 (same group) | 3 |
-| 2 (different groups) | 5 |
-| 3 (same group) | 5 |
-| 3 (different groups) | 6 |
-| 4 | 6 (maximum) |
-
-**Preparation/wrapping area (Equipped):**
-
-| Athletes | Coaches |
-|----------|---------|
-| 1 | 2 |
-| 2 | 4 |
-| 3 | 5 |
-| 4 | 6 (maximum) |
-
-**Preparation area (Classic):**
-
-| Athletes | Coaches |
-|----------|---------|
-| 1 (one group) | max 2 |
-| 2 (one group) | max 2 |
-| 3 (one group) | max 2 |
-| 3 (two groups) | max 3 |
-| 4 (two groups) | max 4 (maximum) |
-
-4. Promoters to install a Coach Observation zone in the wrapping area with a TV monitor link to the Lifting platform for coaches to be able to follow the lifting, if this is not possible then an Observation Zone behind the speaker table for coaches to view the lifting.
-
-5. The Head Coach must ensure only one coach goes with the athletes to the coaching zone and must be properly dressed.
-
-6. The behaviors of the coaches and lifters in the warm up and wrapping area is the responsibility of the Head Coach.
-
-7. The Head Coach must ensure each of his assistant coaches receive a badge with photo to gain access to the warm up, wrapping and lifting area.
-
-8. The Head Coach must arrange with the organizer a fix training time for his/her team.
-
-9. The Head Coach must ensure all equipment used during training is replace on racks and the platforms is left tidy and the trainings area leaves in clean conditions (no garbage etc.) same applies after the Competition.
-
-10. The Head Coach must ensure at weigh-in his/her lifters must present the following to the Referees: Appendix 2, Lifters profile and passport.
-
-11. The Head Coach must ensure at the equipment check lifters equipment is in accordance with IPF Technical rules.
-
-12. The Head Coach and assistant coaches in the warm-up, wrapping and lifting area must acknowledge their Requirement to adhere to all the IPF Anti-Doping rules.
-
-13. The head coach is responsible that no family member or any children is present in the warm up area, preparation arena.
-
-14. The Head Coach to ensure the lifters is prepared and ready to take the platform when his/her name is called for the victory ceremony.
-
-15. Concerning warm-up and wrapping, any drinking of alcohol by Head Coach, assistant coaches, and your lifters in the mentioned areas above is strictly forbidden, under no circumstance can any person under the influence of alcohol be in the warmup room at any time and this shall be ensured by the Head Coach
-
-16. Eligible Coaches/Lifters: The nominated coaches must be members of the National Powerlifting Federation/Association. Each national federation has the autonomy to establish its own rules and procedures for its coaches and national team lifters.
-
-10. Pictures and Filming: In the warm-up area, for some lifters, it's necessary to view their lifts in a video to fully understand the minor corrections needed in their movements. This facilitates communication between a coach and a lifter, which can take place on various levels.
-
-11. I acknowledge that I have read and understood the above. I understand that abuse of these expectations will render me liable for disciplinary action by the IPF Disciplinary Committee, or in case relating to item 10. above, for the review and hearing processes specified in the relevant articles of the IPF Anti-Doping Rules.
-    NAME of Head Coach…………………………………………...........................................................................................……..............................
-    Please state NAME of Coach…………………………………………………................................................................................................…………………………….
-    Please state National Federation.................................................................................................................................................................................
-    SIGNATURE ……………………………………............................................. DATE ……………............................................................................
+2. Only in extreme circumstances when there has been an obvious or blatant mistake in the refereeing will the Jury, in consultation verbally or electronically with the referees, reverse the decision. A unanimous jury vote is required with a 3-member Jury, or a majority vote with a 5-member Jury. Only 2-to-1 referees' decisions can be considered by the Jury.

--- a/docs/ipf-technical-rules-cleanup.md
+++ b/docs/ipf-technical-rules-cleanup.md
@@ -442,4 +442,50 @@ Text, sub-items (`**(a)**`-`**(f)**`), tables, and examples that belong to a num
 ## Known remaining artifacts
 
 - Spaced hyphens used as dashes/separators (e.g., `Length - not less than`) are left as-is since they function as list separators in the PDF, not compound word hyphens.
-- Section 7 item 17: `three four referees` is the actual text in the PDF -- verified against the source PDF, not an extraction artifact.
+
+## Sections removed for project relevance
+
+The full IPF Technical Rules document contains rules that will never be implemented in software. The following sections were removed to keep the reference document focused on rules that drive data models, scoring logic, meet management UI, and referee verdict submission.
+
+### Filtering criteria
+
+When processing a new rules edition, apply these criteria to decide what to keep:
+
+**Keep** content that:
+- Defines data the system stores or computes (age categories, weight classes, bodyweight, attempts, totals, points, records, IPF formula)
+- Defines scoring, placing, or ranking logic (tie-breaking, team points, best lifter awards)
+- Defines competition flow the system must enforce (round system, rising bar, attempt changes, time limits, grouping, lot numbers)
+- Defines weight increment rules (2.5 kg multiples, 0.5 kg record attempts)
+- Defines record recognition and cascading rules
+- Defines failure/disqualification reasons referees select from (the system presents these as options)
+- Defines equipment specs the system renders (disc colors for loader view, bar weight, collar weight)
+- Defines scoreboard or card layouts the system displays
+- Defines loading error handling that affects recorded results
+
+**Remove** content that:
+- Describes physical clothing, gear specifications, or personal equipment rules (suits, shirts, belts, shoes, wraps, knee sleeves, socks, headwear, medical tape, sponsor logos, lubricants)
+- Describes referee qualifications, examinations, registration, dress code, or administrative procedures
+- Describes jury composition, protest/appeal procedures, or governance
+- Describes coach responsibilities, conduct rules, dress code, or warm-up area management
+- Describes physical venue/equipment setup enforced by humans (platform surface material, scale calibration certificates, rack manufacturer approval)
+- Describes nomination, entry, or team roster submission procedures (60-day deadlines, preliminary nominations)
+- Describes medal ceremony dress code, medical personnel requirements, or conduct rules
+- Describes official appointment procedures or job descriptions (speaker, secretary, marshals, spotter/loaders, technical controller)
+
+### What was removed (2026 edition)
+
+| Original section | Removed |
+|-----------------|---------|
+| 1. General Rules | Preamble (items 1a-d: lift sequence definition, "competition takes place between lifters", rules apply to all levels). Championship list (item 2). Nomination procedures (items 3-4: 60-day deadlines, preliminary nominations, reserves, team rosters). Referee requirement per nation for team scoring (item 7). Medal ceremony dress code and participation mementos (item 10 partial). Whipping rule (item 11). Medical personnel requirement (item 12). |
+| 3. Personal Equipment | Entire section (3.1-3.14): suits, t-shirts, supportive shirts, briefs, socks, belts, shoes, knee sleeves, wraps, headwear, medical tape, equipment inspection, sponsor logos, general attire rules. |
+| 4. Rules of Performance | Lift performance prose descriptions (squat items 1-6, bench items 1-9, deadlift items 1-4). Disabled athlete rules prose (4.2.2) -- the amputee weight addition table is kept in Section 5. |
+| 5. Weighing In | Clothing specifications for weigh-in (item 5 prose about singlet, t-shirt, underwear). Rack height checks (item 8). |
+| 6. Order of Competition | Official appointment procedures (6.1q sub-items a-h: speaker, secretary, marshals, spotter/loaders, technical controller). Official job descriptions (6.2 a-h). Coach staffing ratio tables (6.3 item 1). Costume/ammonia rules (6.3 item 2). Conduct and misconduct rules (6.3 items 9-13: hair, belt discarding, injury/doctor, warnings, disqualification for misconduct). Appeal procedures (6.3 items 14-15: written complaints, Euro 75 fee, jury deliberation). Referee signals table (6.3 item 15 table). Instant replay governance (6.3 item 16). |
+| 7. Referees | Entire section (items 1-30): referee count and positioning, pre-contest and during-contest duties, commentary abstention, bar cleaning, score sheet signing, selection procedures, nation restrictions, Cat 1/Cat 2 qualifications and examination procedures, dress code table, registration and re-registration, fees. |
+| 8. Jury and Technical Committee | Entire section (8.1-8.2): jury composition, jury member positioning, protest handling, referee replacement, drug testing selection, music volume, technical committee composition, referee training, equipment manufacturer approval and certification. Jury override rules (8.1 items 8-9) are kept -- see Section 8 in the trimmed document. |
+| 9. World and International Records | IPF sanction requirement (item 2a). Referee card requirements (item 2b-c). Approved equipment requirement (item 2d). World Games records note (item 1 footnote). |
+| 10. Coach Responsibilities | Entire section: coach aims, duties, warm-up area staffing tables (duplicated from 6.3), observation zone, dress code, badge requirements, training schedule, equipment tidiness, weigh-in documents, equipment check, anti-doping acknowledgment, family/children policy, victory ceremony preparation, alcohol policy, eligible coaches rule, filming policy, acknowledgment/signature form. |
+
+### Renumbering after removal
+
+Items within kept sections were renumbered to maintain sequential order. Cross-references between items were updated accordingly (e.g., team scoring cross-reference updated from "item 8" to "item 6"). The Table of Contents was rewritten to match the new structure. Section numbers in headings were updated where sections were consolidated (e.g., Section 9 became Section 7).


### PR DESCRIPTION
## Summary

- Remove IPF rule sections that will never be implemented in software: personal equipment specs (Section 3), referee qualifications/dress code (Section 7), jury governance (Section 8), coach responsibilities (Section 10), and irrelevant items from other sections
- Keep rules that drive data models, scoring, meet management, referee verdict UI, loader plate views, timer logic, and record tracking
- Update cleanup notes with filtering criteria and detailed removal inventory for processing future rules editions

## Test plan

- [ ] Verify trimmed rules document renders correctly in markdown
- [ ] Verify all kept rules are present and correctly numbered
- [ ] Verify cleanup notes accurately describe what was removed