### PR TITLE
test(webapi): migrate GetRankingsTests to own its test data

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Rankings/GetRankingsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Rankings/GetRankingsTests.cs
@@ -2,19 +2,99 @@ using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.Contracts.Rankings;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
 
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Rankings;
 
 [Collection(nameof(RankingsCollection))]
-public sealed class GetRankingsTests(CollectionFixture fixture)
+public sealed class GetRankingsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string Path = "/rankings";
+    private const int MeetYear = 2020;
+    private const decimal P1Squat = 200.0m;
+    private const decimal P1Bench = 130.0m;
+    private const decimal P1Deadlift = 250.0m;
+    private const decimal P1Total = 580.0m;
+    private const decimal P1Wilks = 400.0m;
+    private const decimal P2Total = 550.0m;
+    private const decimal P2Wilks = 370.0m;
 
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
     private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
+    private readonly string _suffix = UniqueShortCode.Next();
+    private readonly List<string> _athleteSlugs = [];
+
+    private string _meet1Slug = string.Empty;
+    private string _meet2Slug = string.Empty;
+    private int _meet1Id;
+    private int _meet2Id;
+
+    public async ValueTask InitializeAsync()
+    {
+        string athleteASlug = await CreateAthleteAsync("RnkA", "m");
+        string athleteBSlug = await CreateAthleteAsync("RnkB", "m");
+
+        _meet1Slug = await CreateMeetAsync(new DateOnly(MeetYear, 6, 1));
+        MeetDetails? meet1Details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meet1Slug}", CancellationToken.None);
+        _meet1Id = meet1Details!.MeetId;
+
+        _meet2Slug = await CreateMeetAsync(new DateOnly(MeetYear, 9, 1));
+        MeetDetails? meet2Details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meet2Slug}", CancellationToken.None);
+        _meet2Id = meet2Details!.MeetId;
+
+        // P1: athlete A in meet1, place 1, best result
+        int p1Id = await AddParticipantAsync(_meet1Id, athleteASlug);
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Participations SET Squat = {P1Squat}, Benchpress = {P1Bench}, Deadlift = {P1Deadlift}, Total = {P1Total}, Wilks = {P1Wilks}, Place = 1 WHERE ParticipationId = {p1Id}");
+
+        // P2: athlete A in meet2, place 1, second-best result
+        int p2Id = await AddParticipantAsync(_meet2Id, athleteASlug);
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Participations SET Squat = 180.0, Benchpress = 120.0, Deadlift = 230.0, Total = {P2Total}, Wilks = {P2Wilks}, Place = 1 WHERE ParticipationId = {p2Id}");
+
+        // P3: athlete B in meet1, disqualified
+        int p3Id = await AddParticipantAsync(_meet1Id, athleteBSlug);
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Participations SET Squat = 180.0, Benchpress = 120.0, Deadlift = 230.0, Total = 530.0, Wilks = 360.0, Place = 3, Disqualified = 1 WHERE ParticipationId = {p3Id}");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Clean up via SQL for reliability — cascade-deleting meets removes participations
+        if (_meet1Id != 0)
+        {
+            await fixture.ExecuteSqlAsync(
+                $"DELETE FROM Participations WHERE MeetId = {_meet1Id}");
+            await fixture.ExecuteSqlAsync(
+                $"DELETE FROM Meets WHERE MeetId = {_meet1Id}");
+        }
+
+        if (_meet2Id != 0)
+        {
+            await fixture.ExecuteSqlAsync(
+                $"DELETE FROM Participations WHERE MeetId = {_meet2Id}");
+            await fixture.ExecuteSqlAsync(
+                $"DELETE FROM Meets WHERE MeetId = {_meet2Id}");
+        }
+
+        foreach (string slug in _athleteSlugs)
+        {
+            await fixture.ExecuteSqlAsync(
+                $"DELETE FROM Athletes WHERE Slug = {slug}");
+        }
+
+        _authorizedHttpClient.Dispose();
+        _httpClient.Dispose();
+    }
 
     [Fact]
     public async Task ReturnsOk()
@@ -22,7 +102,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        HttpResponseMessage response = await _httpClient.GetAsync(Path, CancellationToken.None);
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -34,7 +115,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(Path, CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
         // Assert
         response.ShouldNotBeNull();
@@ -47,23 +129,29 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(Path, CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
-        response.Items[0].Result.ShouldBe(580.0m);
+        response.Items[0].Result.ShouldBe(P1Total);
     }
 
     [Fact]
-    public async Task FiltersbyYear()
+    public async Task FiltersByYear()
     {
         // Arrange
+        int differentYear = MeetYear + 1;
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?year=2025", CancellationToken.None);
+        PagedResponse<RankingEntry>? matchingYear = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
+        PagedResponse<RankingEntry>? differentYearResponse = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={differentYear}", CancellationToken.None);
 
         // Assert
-        response!.Items.ShouldNotBeEmpty();
+        matchingYear!.Items.ShouldNotBeEmpty();
+        differentYearResponse!.Items.ShouldBeEmpty();
     }
 
     [Fact]
@@ -72,7 +160,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?year=1900", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year=1900", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldBeEmpty();
@@ -84,7 +173,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?gender=m", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&gender=m", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
@@ -96,7 +186,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?gender=f", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&gender=f", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldBeEmpty();
@@ -108,7 +199,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?equipmentType=classic", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&equipmentType=classic", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
@@ -120,7 +212,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?equipmentType=equipped", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&equipmentType=equipped", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldBeEmpty();
@@ -132,11 +225,12 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?discipline=squat", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&discipline=squat", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
-        response.Items[0].Result.ShouldBe(200.0m);
+        response.Items[0].Result.ShouldBe(P1Squat);
     }
 
     [Fact]
@@ -145,11 +239,12 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?discipline=bench", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&discipline=bench", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
-        response.Items[0].Result.ShouldBe(130.0m);
+        response.Items[0].Result.ShouldBe(P1Bench);
     }
 
     [Fact]
@@ -158,20 +253,22 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?discipline=deadlift", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&discipline=deadlift", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
-        response.Items[0].Result.ShouldBe(250.0m);
+        response.Items[0].Result.ShouldBe(P1Deadlift);
     }
 
     [Fact]
     public async Task ExcludesDisqualified()
     {
-        // Arrange
+        // Arrange — athlete B is DQ'd, only athlete A should appear
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?year=2025", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
         // Assert
         response!.TotalCount.ShouldBe(1);
@@ -180,16 +277,17 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
     [Fact]
     public async Task ShowsBestResultPerAthlete()
     {
-        // Arrange — seed has two non-DQ participations for athlete 1 (IPF 85.5 and 75.0)
+        // Arrange — athlete A has two non-DQ participations in separate meets
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?year=2025", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
-        // Assert — grouping should keep only the best (calculated IPF, 580 total)
+        // Assert — grouping keeps only the best (highest calculated IPF points, P1 with 580 total)
         response!.Items.Count.ShouldBe(1);
         response.Items[0].IpfPoints.ShouldNotBeNull();
         response.Items[0].IpfPoints!.Value.ShouldBeGreaterThan(0m);
-        response.Items[0].Result.ShouldBe(580.0m);
+        response.Items[0].Result.ShouldBe(P1Total);
     }
 
     [Fact]
@@ -198,7 +296,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(Path, CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
@@ -213,11 +312,12 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(Path, CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
-        response.Items[0].Wilks.ShouldBe(400.0m);
+        response.Items[0].Wilks.ShouldBe(P1Wilks);
     }
 
     [Fact]
@@ -226,7 +326,8 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>($"{Path}?page=1&pageSize=1", CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}&page=1&pageSize=1", CancellationToken.None);
 
         // Assert
         response!.Items.Count.ShouldBe(1);
@@ -240,10 +341,63 @@ public sealed class GetRankingsTests(CollectionFixture fixture)
         // Arrange
 
         // Act
-        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(Path, CancellationToken.None);
+        PagedResponse<RankingEntry>? response = await _httpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(
+            $"{Path}?year={MeetYear}", CancellationToken.None);
 
         // Assert
         response!.Items.ShouldNotBeEmpty();
         response.Items[0].Rank.ShouldBe(1);
+    }
+
+    private async Task<string> CreateMeetAsync(DateOnly startDate)
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder()
+            .WithStartDate(startDate)
+            .WithIsRaw(true)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        return response.Headers.Location!.ToString().TrimStart('/');
+    }
+
+    private async Task<string> CreateAthleteAsync(string prefix, string gender)
+    {
+        string firstName = $"{prefix}{_suffix}";
+        string lastName = "Rk";
+
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
+            .WithFirstName(firstName)
+            .WithLastName(lastName)
+            .WithGender(gender)
+            .WithDateOfBirth(new DateOnly(1990, 1, 1))
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = Slug.Create($"{firstName} {lastName}");
+        _athleteSlugs.Add(slug);
+        return slug;
+    }
+
+    private async Task<int> AddParticipantAsync(int meetId, string athleteSlug)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(80.5m)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        return result!.ParticipationId;
     }
 }


### PR DESCRIPTION
## Summary
- Migrate `GetRankingsTests` from shared seed data to `IAsyncLifetime` with full data ownership
- Tests create their own athletes, meets, and participations in `InitializeAsync`, clean up in `DisposeAsync`
- All tests filter by `year=2020` to isolate from other test data
- `FiltersByYear` strengthened to verify year exclusion (queries both test year and a different year)

Closes #415

## Test plan
- [x] `dotnet test --filter GetRankingsTests` — all 18 tests pass
- [ ] Full `dotnet test` passes (CI)