### PR TITLE
test(webapi): remove seed entity dependencies from ComputeRecordsTests

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
@@ -28,24 +28,4 @@ internal static class Constants
         internal const string Password = TestSeedConstants.User.Password;
         internal const string Email = TestSeedConstants.User.Email;
     }
-
-    internal static class NoRecordsMeet
-    {
-        internal const int Id = 9;
-        internal const string Slug = "no-records-meet";
-    }
-
-    internal static class DeadliftMeet
-    {
-        internal const int Id = 10;
-        internal const string Slug = "rettstakeppni-2025";
-    }
-
-    internal static class BannedAthlete
-    {
-        internal const int Id = 12;
-        internal const string Slug = "banned-athlete";
-        internal static readonly DateOnly BanStartDate = new(2025, 1, 1);
-        internal static readonly DateOnly BanEndDate = new(2025, 12, 31);
-    }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
@@ -21,10 +21,6 @@ public sealed class DatabaseFixture : IAsyncLifetime
     private const int TcMeet2Id = 3;
     private const int TcMeet2026Meet1Id = 4;
     private const int TcMeet2026Meet2Id = 5;
-    private const int NoRecordsMeetId = 9;
-    private const int DeadliftMeetId = 10;
-    private const int DeadliftMeetTypeId = 3;
-    private const int BannedAthleteId = 12;
     private const int EditorRoleId = 2;
     private const int UserRoleId = 3;
 
@@ -53,12 +49,7 @@ public sealed class DatabaseFixture : IAsyncLifetime
 
         await SeedBaseDataAsync(dbContext);
         await SeedTeamCompetitionDataAsync(dbContext);
-        await SeedIntegrationTestAttemptsAsync(dbContext);
         await SeedBestNTestDataAsync(dbContext);
-
-        await SeedNoRecordsMeetAsync(dbContext);
-        await SeedDeadliftMeetAsync(dbContext);
-        await SeedBanDataAsync(dbContext);
         await SeedIntegrationRolesAsync(dbContext);
     }
 
@@ -150,32 +141,6 @@ public sealed class DatabaseFixture : IAsyncLifetime
         await dbContext.Database.ExecuteSqlRawAsync(sql);
     }
 
-    private static async Task SeedIntegrationTestAttemptsAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            SET IDENTITY_INSERT Attempts ON;
-            -- Attempt 4: record-breaking squat (210 > current record of 200 for classic/open/83kg/male)
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES (4, 1, 1, 2, 210.0, 1, 'seed', 'seed');
-
-            -- Attempt 5: non-record-breaking squat (190 <= current record of 200 for equipped/open/83kg/male)
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES (5, 1, 1, 1, 190.0, 1, 'seed', 'seed');
-
-            -- Attempt 6: female squat for open/63kg raw slot (no existing raw record for this slot)
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES (6, {FemaleParticipationId}, 1, 3, 110.0, 1, 'seed', 'seed');
-
-            -- Attempt 7: zero-weight good bench attempt
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES (7, 1, 2, 1, 0.0, 1, 'seed', 'seed');
-            SET IDENTITY_INSERT Attempts OFF;
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
     private static async Task SeedBestNTestDataAsync(ResultsDbContext dbContext)
     {
         const int tc1Id = 4;
@@ -230,48 +195,6 @@ public sealed class DatabaseFixture : IAsyncLifetime
             VALUES ({tc2Id}, {TcMeet2026Meet2Id}, 82.0, 1, {AlphaTeamId}, 1, 2, 0, 190.0, 120.0, 240.0, 550.0, 380.0, 81.0, 2, 9);
             INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
             VALUES ({tc3Id}, {TcMeet2026Meet2Id}, 82.0, 1, {AlphaTeamId}, 1, 3, 0, 185.0, 115.0, 235.0, 535.0, 370.0, 79.0, 3, 8);
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task SeedNoRecordsMeetAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            SET IDENTITY_INSERT Meets ON;
-            INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-            VALUES ({NoRecordsMeetId}, 'No Records Meet', '{Constants.NoRecordsMeet.Slug}', '2025-12-01', '2025-12-01', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1);
-            SET IDENTITY_INSERT Meets OFF;
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task SeedDeadliftMeetAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            SET IDENTITY_INSERT Meets ON;
-            INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-            VALUES ({DeadliftMeetId}, 'Réttstakeppni 2025', '{Constants.DeadliftMeet.Slug}', '2025-06-01', '2025-06-01', 1, 1, 1, 1, {DeadliftMeetTypeId}, 0, 1, 0, 1, 0, 1, 1);
-            SET IDENTITY_INSERT Meets OFF;
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task SeedBanDataAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            SET IDENTITY_INSERT Athletes ON;
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({BannedAthleteId}, 'Banned', 'Athlete', '1990-01-01', 'm', {NorwayCountryId}, '{Constants.BannedAthlete.Slug}');
-            SET IDENTITY_INSERT Athletes OFF;
-
-            INSERT INTO Bans (AthleteId, FromDate, ToDate)
-            VALUES ({BannedAthleteId}, '2025-01-01', '2025-12-31');
             """;
 
         await dbContext.Database.ExecuteSqlRawAsync(sql);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
@@ -170,8 +170,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             // Record bench and deadlift first so the participation has valid totals
@@ -207,7 +205,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -247,8 +245,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
 
         int participationId = participantResult!.ParticipationId;
-
-        await ClearAllRecordCategoriesAsync(dbContext);
 
         try
         {
@@ -290,7 +286,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -486,8 +482,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             // Record bench and deadlift first to establish valid total
@@ -524,7 +518,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -566,8 +560,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         int participationId = participantResult!.ParticipationId;
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             // Record bench and deadlift first so the participation has valid totals
@@ -599,7 +591,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -640,8 +632,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         int participationId = participantResult!.ParticipationId;
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             // Record squat, bench, then deadlift (deadlift triggers the last event)
@@ -666,7 +656,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -707,8 +697,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         int participationId = participantResult!.ParticipationId;
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             // Record squat first (no valid total yet), then bench, then deadlift
@@ -733,7 +721,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -774,8 +762,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         int participationId = participantResult!.ParticipationId;
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             await RecordAttempt(client, participationId, Discipline.Squat, 1, 210.0m);
@@ -799,7 +785,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -993,8 +979,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         int participationBId = participantBResult!.ParticipationId;
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             // Give both athletes valid totals
@@ -1035,7 +1019,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationAId, participationBId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -1104,8 +1088,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         int participationBId = participantBResult!.ParticipationId;
 
-        await ClearAllRecordCategoriesAsync(dbContext);
-
         try
         {
             // Give both athletes valid totals
@@ -1159,7 +1141,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationAId, participationBId);
-            await RestoreClassic83KgSeedRecordAsync(dbContext);
+            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -2127,51 +2109,18 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         await dbContext.Database.ExecuteSqlRawAsync(sql);
     }
 
-    private static async Task RestoreClassic83KgSeedRecordAsync(ResultsDbContext dbContext)
+    private static async Task RestoreSeedRecordStateAsync(ResultsDbContext dbContext)
     {
-        // Slot rebuilds create chain records for seed attempts (AttemptId=1,2,3) across all age categories.
-        // Delete all classic records for those attempts first, then restore the canonical seed record.
-        // Also restore seed AttemptIds 4,5 (squats for ParticipationId=1) that ClearAllRecordCategoriesAsync deletes.
+        // Slot rebuilds may create additional record rows for seed attempts and flip IsCurrent flags.
+        // Delete all raw records for seed attempts, then restore the canonical seed record.
         string sql =
             $"""
             DELETE FROM Records WHERE AttemptId IN (1, 2, 3) AND IsRaw = 1;
             INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
             VALUES ({TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.OpenId}, {TestSeedConstants.WeightCategory.Id83Kg}, 1, 195.0, '2025-03-15', 0, 1, 1, 1, 'seed');
-
-            IF NOT EXISTS (SELECT 1 FROM Attempts WHERE AttemptId = 4)
-            BEGIN
-                SET IDENTITY_INSERT Attempts ON;
-                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-                VALUES (4, 1, 1, 2, 210.0, 1, 'seed', 'seed');
-                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-                VALUES (5, 1, 1, 1, 190.0, 1, 'seed', 'seed');
-                SET IDENTITY_INSERT Attempts OFF;
-            END
             """;
 
         await dbContext.Database.ExecuteSqlRawAsync(sql, TestContext.Current.CancellationToken);
-    }
-
-    private static async Task ClearAllRecordCategoriesAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            DELETE FROM Records
-            WHERE AgeCategoryId IN (
-                {TestSeedConstants.AgeCategory.OpenId},
-                {TestSeedConstants.AgeCategory.Masters1Id},
-                {TestSeedConstants.AgeCategory.Masters2Id},
-                {TestSeedConstants.AgeCategory.Masters3Id},
-                {TestSeedConstants.AgeCategory.Masters4Id})
-            AND RecordCategoryId IN (1, 2, 3, 4, 5, 6)
-            AND IsRaw = 1
-            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg};
-
-            DELETE FROM Records WHERE AttemptId IN (4, 5);
-            DELETE FROM Attempts WHERE AttemptId IN (4, 5);
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
     }
 
     private async Task RecordAttempt(

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
@@ -29,12 +29,22 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 {
     private const decimal AttemptWeight = 300.0m;
 
+    // Owned infrastructure entity IDs
+    private const int OwnedBannedAthleteId = 1100;
+    private const string OwnedBannedAthleteSlug = "compute-banned";
+    private const int OwnedNoRecordsMeetId = 1101;
+    private const int OwnedDeadliftMeetId = 1102;
+    private const int DeadliftMeetTypeId = 3;
+    private const int OwnedBaseMeetId = 1103;
+
     private readonly HttpClient _setupHttpClient = fixture.CreateAuthorizedHttpClient();
     private int _meetId;
     private string _meetSlug = string.Empty;
 
     public async ValueTask InitializeAsync()
     {
+        await SeedOwnedInfrastructureAsync();
+
         CreateMeetCommand meetCommand = new CreateMeetCommandBuilder()
             .WithIsRaw(true)
             .Build();
@@ -57,6 +67,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
     public async ValueTask DisposeAsync()
     {
+        await CleanupOwnedDataAsync();
+
         if (_meetId != 0)
         {
             await _setupHttpClient.DeleteAsync(
@@ -79,7 +91,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, 600)
+        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, 1110)
+            .WithMeetId(OwnedBaseMeetId)
             .WithWeightCategoryId(weightCategoryId)
             .WithSquat(AttemptWeight)
             .BuildAsync(TestContext.Current.CancellationToken);
@@ -288,7 +301,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         (HttpClient client, RecordComputationChannel channel) = fixture.CreateAuthorizedHttpClientWithRecordComputation();
 
         AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
-            .WithAthleteSlug(Constants.BannedAthlete.Slug)
+            .WithAthleteSlug(OwnedBannedAthleteSlug)
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
@@ -318,7 +331,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         List<RecordEntity> createdRecords = await dbContext.Set<RecordEntity>()
             .Include(r => r.Attempt!)
                 .ThenInclude(a => a.Participation)
-            .Where(r => r.Attempt!.Participation.AthleteId == Constants.BannedAthlete.Id)
+            .Where(r => r.Attempt!.Participation.AthleteId == OwnedBannedAthleteId)
             .Where(r => r.IsCurrent)
             .ToListAsync(CancellationToken.None);
 
@@ -349,7 +362,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{Constants.NoRecordsMeet.Id}/participants",
+            $"/meets/{OwnedNoRecordsMeetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -361,11 +374,11 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         int participationId = participantResult!.ParticipationId;
 
         // Record bench and deadlift so total would be valid
-        await RecordAttemptForMeet(client, Constants.NoRecordsMeet.Id, participationId, Discipline.Bench, 1, 130.0m);
-        await RecordAttemptForMeet(client, Constants.NoRecordsMeet.Id, participationId, Discipline.Deadlift, 1, 250.0m);
+        await RecordAttemptForMeet(client, OwnedNoRecordsMeetId, participationId, Discipline.Bench, 1, 130.0m);
+        await RecordAttemptForMeet(client, OwnedNoRecordsMeetId, participationId, Discipline.Deadlift, 1, 250.0m);
 
         // Act â€" record squat at a meet where RecordsPossible = false
-        await RecordAttemptForMeet(client, Constants.NoRecordsMeet.Id, participationId, Discipline.Squat, 1, AttemptWeight);
+        await RecordAttemptForMeet(client, OwnedNoRecordsMeetId, participationId, Discipline.Squat, 1, AttemptWeight);
         await channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
 
         // Assert â€" no records should be created
@@ -812,7 +825,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .Build();
 
         HttpResponseMessage participantResponse = await client.PostAsJsonAsync(
-            $"/meets/{Constants.DeadliftMeet.Id}/participants",
+            $"/meets/{OwnedDeadliftMeetId}/participants",
             participantCommand,
             CancellationToken.None);
 
@@ -831,7 +844,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         {
             await RecordAttemptForMeet(
                 client,
-                Constants.DeadliftMeet.Id,
+                OwnedDeadliftMeetId,
                 participationId,
                 Discipline.Deadlift,
                 1,
@@ -1158,11 +1171,11 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
         RecordComputationService service = scope.ServiceProvider.GetRequiredService<RecordComputationService>();
 
-        const int athleteId = 300;
-        const int participationId = 300;
-        const int squatAttemptId = 300;
-        const int benchAttemptId = 301;
-        const int deadliftAttemptId = 302;
+        const int athleteId = 1300;
+        const int participationId = 1300;
+        const int squatAttemptId = 1300;
+        const int benchAttemptId = 1301;
+        const int deadliftAttemptId = 1302;
         const int weightCategoryId = TestSeedConstants.WeightCategory.Id93Kg;
 
         string seedSql =
@@ -1183,7 +1196,7 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
             SET IDENTITY_INSERT Participations ON;
             INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-            VALUES ({participationId}, {athleteId}, {TestSeedConstants.Meet.Id}, 90.0, {weightCategoryId}, {TestSeedConstants.AgeCategory.Masters4Id}, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 90.0, 50);
+            VALUES ({participationId}, {athleteId}, {OwnedBaseMeetId}, 90.0, {weightCategoryId}, {TestSeedConstants.AgeCategory.Masters4Id}, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 90.0, 50);
             SET IDENTITY_INSERT Participations OFF;
 
             SET IDENTITY_INSERT Attempts ON;
@@ -1265,7 +1278,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
         RecordComputationService service = scope.ServiceProvider.GetRequiredService<RecordComputationService>();
 
-        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, 310)
+        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, 1113)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(200m).WithBench(130m).WithDeadlift(200m)
             .BuildAsync(TestContext.Current.CancellationToken);
 
@@ -1358,7 +1372,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
         RecordComputationService service = scope.ServiceProvider.GetRequiredService<RecordComputationService>();
 
-        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 320)
+        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 1116)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(200m).WithBench(130m).WithDeadlift(250m)
             .BuildAsync(TestContext.Current.CancellationToken);
 
@@ -1381,7 +1396,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
             recordsAfterA.ShouldNotBeEmpty();
 
-            athleteB = await new RecordTestAthleteBuilder(dbContext, 330)
+            athleteB = await new RecordTestAthleteBuilder(dbContext, 1119)
+                .WithMeetId(OwnedBaseMeetId)
                 .WithSquat(210m).WithBench(130m).WithDeadlift(250m)
                 .BuildAsync(TestContext.Current.CancellationToken);
 
@@ -1453,7 +1469,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
         RecordComputationService service = scope.ServiceProvider.GetRequiredService<RecordComputationService>();
 
-        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, 340)
+        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, 1122)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(200m).WithBench(130m).WithDeadlift(250m)
             .BuildAsync(TestContext.Current.CancellationToken);
 
@@ -1530,7 +1547,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 350)
+        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 1125)
+            .WithMeetId(OwnedBaseMeetId)
             .WithBench(150m)
             .BuildAsync(TestContext.Current.CancellationToken);
 
@@ -1548,7 +1566,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
             aTotalRecords.ShouldNotBeEmpty();
 
-            athleteB = await new RecordTestAthleteBuilder(dbContext, 360)
+            athleteB = await new RecordTestAthleteBuilder(dbContext, 1128)
+                .WithMeetId(OwnedBaseMeetId)
                 .WithSquat(250m)
                 .WithBench(150m)
                 .WithDeadlift(300m)
@@ -1625,19 +1644,22 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 400)
+        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 1131)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(210m)
             .WithBench(140m)
             .WithDeadlift(260m)
             .BuildAsync(TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athleteB = await new RecordTestAthleteBuilder(dbContext, 403)
+        SeedRecordAthlete athleteB = await new RecordTestAthleteBuilder(dbContext, 1134)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(210m)
             .WithBench(140m)
             .WithDeadlift(270m)
             .BuildAsync(TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athleteC = await new RecordTestAthleteBuilder(dbContext, 406)
+        SeedRecordAthlete athleteC = await new RecordTestAthleteBuilder(dbContext, 1137)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(210m)
             .WithBench(140m)
             .WithDeadlift(280m)
@@ -1690,7 +1712,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 410)
+        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 1140)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(211m)
             .WithBench(140m)
             .WithDeadlift(260m)
@@ -1711,7 +1734,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             recordsAfterA.ShouldNotBeEmpty();
 
             // Seed athlete B with squat=220 (beats A's 211)
-            athleteB = await new RecordTestAthleteBuilder(dbContext, 420)
+            athleteB = await new RecordTestAthleteBuilder(dbContext, 1143)
+                .WithMeetId(OwnedBaseMeetId)
                 .WithSquat(220m)
                 .WithBench(140m)
                 .WithDeadlift(260m)
@@ -1796,11 +1820,11 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
         RecordComputationService service = scope.ServiceProvider.GetRequiredService<RecordComputationService>();
 
-        const int benchMeetId = 50;
+        const int benchMeetId = 1310;
         const int benchMeetTypeId = 2;
-        const int athleteId = 430;
-        const int participationId = 430;
-        const int benchAttemptId = 430;
+        const int athleteId = 1311;
+        const int participationId = 1311;
+        const int benchAttemptId = 1311;
         const int weightCategoryId = TestSeedConstants.WeightCategory.Id93Kg;
 
         string seedSql =
@@ -1902,10 +1926,12 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 440)
+        SeedRecordAthlete athleteA = await new RecordTestAthleteBuilder(dbContext, 1146)
+            .WithMeetId(OwnedBaseMeetId)
             .BuildAsync(TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete athleteB = await new RecordTestAthleteBuilder(dbContext, 450)
+        SeedRecordAthlete athleteB = await new RecordTestAthleteBuilder(dbContext, 1149)
+            .WithMeetId(OwnedBaseMeetId)
             .WithSquat(220m)
             .WithBench(140m)
             .WithDeadlift(260m)
@@ -2019,7 +2045,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
 
         await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete norwegianAthlete = await new RecordTestAthleteBuilder(dbContext, 500)
+        SeedRecordAthlete norwegianAthlete = await new RecordTestAthleteBuilder(dbContext, 1152)
+            .WithMeetId(OwnedBaseMeetId)
             .WithCountryId(norwayCountryId)
             .WithWeightCategoryId(weightCategoryId)
             .WithSquat(250m)
@@ -2027,7 +2054,8 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             .WithDeadlift(300m)
             .BuildAsync(TestContext.Current.CancellationToken);
 
-        SeedRecordAthlete icelandicAthlete = await new RecordTestAthleteBuilder(dbContext, 510)
+        SeedRecordAthlete icelandicAthlete = await new RecordTestAthleteBuilder(dbContext, 1155)
+            .WithMeetId(OwnedBaseMeetId)
             .WithWeightCategoryId(weightCategoryId)
             .BuildAsync(TestContext.Current.CancellationToken);
 
@@ -2154,5 +2182,95 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         decimal weight)
     {
         await RecordAttemptForMeet(client, _meetId, participationId, discipline, round, weight);
+    }
+
+    private async Task SeedOwnedInfrastructureAsync()
+    {
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        // Owned banned athlete + ban record
+        string bannedAthleteSql =
+            $"""
+            IF NOT EXISTS (SELECT 1 FROM Athletes WHERE AthleteId = {OwnedBannedAthleteId})
+            BEGIN
+                SET IDENTITY_INSERT Athletes ON;
+                INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
+                VALUES ({OwnedBannedAthleteId}, 'Compute', 'Banned', '1990-01-01', 'm', 2, '{OwnedBannedAthleteSlug}');
+                SET IDENTITY_INSERT Athletes OFF;
+
+                INSERT INTO Bans (AthleteId, FromDate, ToDate)
+                VALUES ({OwnedBannedAthleteId}, '2025-01-01', '2025-12-31');
+            END
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(bannedAthleteSql);
+
+        // Owned no-records meet (RecordsPossible=0)
+        string noRecordsMeetSql =
+            $"""
+            IF NOT EXISTS (SELECT 1 FROM Meets WHERE MeetId = {OwnedNoRecordsMeetId})
+            BEGIN
+                SET IDENTITY_INSERT Meets ON;
+                INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+                VALUES ({OwnedNoRecordsMeetId}, 'Compute No Records Meet', 'compute-no-records-meet', '2025-12-01', '2025-12-01', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1);
+                SET IDENTITY_INSERT Meets OFF;
+            END
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(noRecordsMeetSql);
+
+        // Owned deadlift meet (MeetTypeId=3)
+        string deadliftMeetSql =
+            $"""
+            IF NOT EXISTS (SELECT 1 FROM Meets WHERE MeetId = {OwnedDeadliftMeetId})
+            BEGIN
+                SET IDENTITY_INSERT Meets ON;
+                INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+                VALUES ({OwnedDeadliftMeetId}, 'Compute DL Meet', 'compute-dl-meet', '2025-06-01', '2025-06-01', 1, 1, 1, 1, {DeadliftMeetTypeId}, 0, 1, 0, 1, 0, 1, 1);
+                SET IDENTITY_INSERT Meets OFF;
+            END
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(deadliftMeetSql);
+
+        // Owned base powerlifting meet (IsRaw=1, RecordsPossible=1)
+        string baseMeetSql =
+            $"""
+            IF NOT EXISTS (SELECT 1 FROM Meets WHERE MeetId = {OwnedBaseMeetId})
+            BEGIN
+                SET IDENTITY_INSERT Meets ON;
+                INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+                VALUES ({OwnedBaseMeetId}, 'Compute Base Meet', 'compute-base-meet', '2025-03-15', '2025-03-15', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1);
+                SET IDENTITY_INSERT Meets OFF;
+            END
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(baseMeetSql);
+    }
+
+    private async Task CleanupOwnedDataAsync()
+    {
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        // Delete owned data in FK-safe order
+        string cleanupSql =
+            """
+            DELETE FROM Records WHERE AttemptId IN (
+                SELECT AttemptId FROM Attempts WHERE ParticipationId IN (
+                    SELECT ParticipationId FROM Participations WHERE MeetId IN (1101, 1102, 1103)
+                )
+            ) OR CreatedBy = 'compute-test';
+            DELETE FROM Attempts WHERE ParticipationId IN (
+                SELECT ParticipationId FROM Participations WHERE MeetId IN (1101, 1102, 1103)
+            );
+            DELETE FROM Participations WHERE MeetId IN (1101, 1102, 1103);
+            DELETE FROM Bans WHERE AthleteId = 1100;
+            DELETE FROM Athletes WHERE AthleteId = 1100;
+            DELETE FROM Meets WHERE MeetId IN (1101, 1102, 1103);
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(cleanupSql);
     }
 }


### PR DESCRIPTION
## Summary
- Migrates `ComputeRecordsTests` to fully own its test data via `IAsyncLifetime`, replacing all shared seed entity dependencies
- Adds owned infrastructure (banned athlete, no-records meet, deadlift meet, base meet) in ID range 1100-1399
- Removes 4 seed methods from `DatabaseFixture` (`SeedBanDataAsync`, `SeedNoRecordsMeetAsync`, `SeedDeadliftMeetAsync`, `SeedIntegrationTestAttemptsAsync`)
- Removes shared-state helpers (`ClearAllRecordCategoriesAsync`, `RestoreClassic83KgSeedRecordAsync`) and 3 unused `Constants` nested classes

Closes #418

## Test plan
- [ ] `dotnet test --filter ComputeRecordsTests` passes
- [ ] Full `dotnet test` passes (no regressions from removed seed data)
- [ ] No remaining references to `Constants.BannedAthlete`, `Constants.NoRecordsMeet`, `Constants.DeadliftMeet`, or `TestSeedConstants.Meet.Id` in ComputeRecordsTests