### PR TITLE
test(webapi): slim DatabaseFixture to reference data only

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/RecordTestAthleteBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Builders/RecordTestAthleteBuilder.cs
@@ -13,7 +13,7 @@ namespace KRAFT.Results.WebApi.IntegrationTests.Builders;
 /// </summary>
 internal sealed class RecordTestAthleteBuilder(ResultsDbContext dbContext, int baseId)
 {
-    private int _meetId = TestSeedConstants.Meet.Id;
+    private int _meetId;
 
     private int _countryId = TestSeedConstants.Country.Id;
     private int _weightCategoryId = TestSeedConstants.WeightCategory.Id93Kg;

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Constants.cs
@@ -9,18 +9,7 @@ internal static class Constants
     internal const string TestAthleteSlug = TestSeedConstants.Athlete.Slug;
     internal const string TestTeamSlug = TestSeedConstants.Team.Slug;
     internal const string TestCountryName = TestSeedConstants.Country.Name;
-    internal const string TestMeetTitle = TestSeedConstants.Meet.Title;
-    internal const string TestMeetSlug = TestSeedConstants.Meet.Slug;
-
     internal static readonly DateOnly TestAthleteDateOfBirth = TestSeedConstants.Athlete.DateOfBirth;
-
-    internal static class TeamCompetition
-    {
-        internal const string AlphaTeamSlug = "alpha-team";
-        internal const string BetaTeamSlug = "beta-team";
-        internal const string TcMeet12025Slug = "tc-meet-1-2025";
-        internal const string TcMeet12026Slug = "tc-meet-1-2026";
-    }
 
     internal static class TestUser
     {

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/DatabaseFixture.cs
@@ -11,16 +11,6 @@ namespace KRAFT.Results.WebApi.IntegrationTests;
 [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "All SQL is composed from compile-time constants in BaseSeedSql and local const fields")]
 public sealed class DatabaseFixture : IAsyncLifetime
 {
-    private const int NorwayCountryId = 2;
-    private const int AlphaTeamId = 2;
-    private const int BetaTeamId = 3;
-    private const int AnnaAthleteId = 2;
-    private const int BobAthleteId = 3;
-    private const int FemaleParticipationId = 4;
-    private const int TcMeet1Id = 2;
-    private const int TcMeet2Id = 3;
-    private const int TcMeet2026Meet1Id = 4;
-    private const int TcMeet2026Meet2Id = 5;
     private const int EditorRoleId = 2;
     private const int UserRoleId = 3;
 
@@ -48,14 +38,18 @@ public sealed class DatabaseFixture : IAsyncLifetime
         await dbContext.Database.MigrateAsync();
 
         await SeedBaseDataAsync(dbContext);
-        await SeedTeamCompetitionDataAsync(dbContext);
-        await SeedBestNTestDataAsync(dbContext);
         await SeedIntegrationRolesAsync(dbContext);
     }
 
     private static async Task SeedBaseDataAsync(ResultsDbContext dbContext)
     {
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedCountry());
+        await dbContext.Database.ExecuteSqlRawAsync(
+            """
+            IF NOT EXISTS (SELECT 1 FROM Countries WHERE ISO3 = 'NOR')
+                INSERT INTO Countries (CountryId, ISO2, ISO3, Name)
+                VALUES (2, 'NO', 'NOR', 'Norway');
+            """);
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedUsersAndRoles());
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedTeam());
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedAthlete());
@@ -64,140 +58,6 @@ public sealed class DatabaseFixture : IAsyncLifetime
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedWeightCategories());
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedEras());
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedEraWeightCategories());
-        await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedMeet());
-        await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedBaseParticipations());
-        await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedBaseAttempts());
-        await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedBaseRecords());
-    }
-
-    private static async Task SeedTeamCompetitionDataAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            INSERT INTO Countries (CountryId, ISO2, ISO3, Name)
-            VALUES ({NorwayCountryId}, 'NO', 'NOR', 'Norway');
-
-            SET IDENTITY_INSERT Teams ON;
-            INSERT INTO Teams (TeamId, Title, TitleShort, TitleFull, CountryId, Slug)
-            VALUES ({AlphaTeamId}, 'Alpha Team', 'ALP', 'Alpha Team', {NorwayCountryId}, '{Constants.TeamCompetition.AlphaTeamSlug}');
-            INSERT INTO Teams (TeamId, Title, TitleShort, TitleFull, CountryId, Slug)
-            VALUES ({BetaTeamId}, 'Beta Team', 'BET', 'Beta Team', {NorwayCountryId}, '{Constants.TeamCompetition.BetaTeamSlug}');
-            SET IDENTITY_INSERT Teams OFF;
-
-            SET IDENTITY_INSERT Athletes ON;
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({AnnaAthleteId}, 'Anna', 'Test', '1990-01-01', 'f', {NorwayCountryId}, 'anna-test');
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({BobAthleteId}, 'Bob', 'Test', '1988-05-10', 'm', {NorwayCountryId}, 'bob-test');
-            SET IDENTITY_INSERT Athletes OFF;
-
-            -- Female participation in test meet (used by ApproveRecordTests for isolation)
-            -- Inserted here (before TC participations) to ensure it gets ParticipationId = 4
-            SET IDENTITY_INSERT Participations ON;
-            INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-            VALUES ({FemaleParticipationId}, {AnnaAthleteId}, {TestSeedConstants.Meet.Id}, 61.5, 3, 1, 1, 0, 110.0, 70.0, 130.0, 310.0, 250.0, 55.0, 99);
-            SET IDENTITY_INSERT Participations OFF;
-
-            SET IDENTITY_INSERT Meets ON;
-            INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-            VALUES ({TcMeet1Id}, 'TC Meet 1 2025', '{Constants.TeamCompetition.TcMeet12025Slug}', '2025-06-01', '2025-06-01', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1);
-            INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-            VALUES ({TcMeet2Id}, 'TC Meet 2 2025', 'tc-meet-2-2025', '2025-09-01', '2025-09-01', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1);
-            SET IDENTITY_INSERT Meets OFF;
-
-            -- Alpha Team male participations
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({BobAthleteId}, {TcMeet1Id}, 82.0, 1, {AlphaTeamId}, 1, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 85.5, 1, 12);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({BobAthleteId}, {TcMeet2Id}, 82.0, 1, {AlphaTeamId}, 1, 2, 0, 190.0, 120.0, 240.0, 550.0, 380.0, 80.0, 2, 9);
-
-            -- Beta Team male participations
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({BobAthleteId}, {TcMeet1Id}, 82.0, 1, {BetaTeamId}, 1, 3, 0, 180.0, 110.0, 230.0, 520.0, 360.0, 75.0, 3, 8);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({BobAthleteId}, {TcMeet2Id}, 82.0, 1, {BetaTeamId}, 1, 1, 0, 210.0, 135.0, 260.0, 605.0, 420.0, 90.0, 1, 12);
-
-            -- Alpha Team female participations
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({AnnaAthleteId}, {TcMeet1Id}, 60.0, 3, {AlphaTeamId}, 1, 1, 0, 100.0, 60.0, 120.0, 280.0, 300.0, 65.0, 4, 12);
-
-            -- Beta Team female participations
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({AnnaAthleteId}, {TcMeet1Id}, 60.0, 3, {BetaTeamId}, 1, 2, 0, 90.0, 55.0, 110.0, 255.0, 280.0, 60.0, 5, 9);
-
-            -- Disqualified participation (should be excluded)
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({BobAthleteId}, {TcMeet1Id}, 82.0, 1, {AlphaTeamId}, 1, 4, 1, 170.0, 100.0, 220.0, 490.0, 340.0, 70.0, 6, 7);
-
-            -- Participation with no team (should be excluded)
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({BobAthleteId}, {TcMeet1Id}, 82.0, 1, 1, 5, 0, 160.0, 95.0, 210.0, 465.0, 320.0, 65.0, 7, 6);
-
-            -- Participation with zero team points (should be excluded)
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({BobAthleteId}, {TcMeet1Id}, 82.0, 1, {AlphaTeamId}, 1, 6, 0, 150.0, 90.0, 200.0, 440.0, 300.0, 60.0, 8, 0);
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task SeedBestNTestDataAsync(ResultsDbContext dbContext)
-    {
-        const int tc1Id = 4;
-        const int tc2Id = 5;
-        const int tc3Id = 6;
-        const int tc4Id = 7;
-        const int tc5Id = 8;
-        const int tc6Id = 9;
-
-        string sql =
-            $"""
-            SET IDENTITY_INSERT Athletes ON;
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({tc1Id}, 'TC1', 'Test', '1990-01-01', 'm', {NorwayCountryId}, 'tc1-test');
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({tc2Id}, 'TC2', 'Test', '1990-01-01', 'm', {NorwayCountryId}, 'tc2-test');
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({tc3Id}, 'TC3', 'Test', '1990-01-01', 'm', {NorwayCountryId}, 'tc3-test');
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({tc4Id}, 'TC4', 'Test', '1990-01-01', 'm', {NorwayCountryId}, 'tc4-test');
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({tc5Id}, 'TC5', 'Test', '1990-01-01', 'm', {NorwayCountryId}, 'tc5-test');
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({tc6Id}, 'TC6', 'Test', '1990-01-01', 'm', {NorwayCountryId}, 'tc6-test');
-            SET IDENTITY_INSERT Athletes OFF;
-
-            SET IDENTITY_INSERT Meets ON;
-            INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-            VALUES ({TcMeet2026Meet1Id}, 'TC Meet 1 2026', '{Constants.TeamCompetition.TcMeet12026Slug}', '2026-06-01', '2026-06-01', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1);
-            INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-            VALUES ({TcMeet2026Meet2Id}, 'TC Meet 2 2026', 'tc-meet-2-2026', '2026-09-01', '2026-09-01', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1);
-            SET IDENTITY_INSERT Meets OFF;
-
-            -- Alpha Team: 6 male athletes in meet1 2026, all scoring 12
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc1Id}, {TcMeet2026Meet1Id}, 82.0, 1, {AlphaTeamId}, 1, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 85.0, 1, 12);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc2Id}, {TcMeet2026Meet1Id}, 82.0, 1, {AlphaTeamId}, 1, 2, 0, 195.0, 125.0, 245.0, 565.0, 390.0, 83.0, 2, 12);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc3Id}, {TcMeet2026Meet1Id}, 82.0, 1, {AlphaTeamId}, 1, 3, 0, 190.0, 120.0, 240.0, 550.0, 380.0, 81.0, 3, 12);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc4Id}, {TcMeet2026Meet1Id}, 82.0, 1, {AlphaTeamId}, 1, 4, 0, 185.0, 115.0, 235.0, 535.0, 370.0, 79.0, 4, 12);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc5Id}, {TcMeet2026Meet1Id}, 82.0, 1, {AlphaTeamId}, 1, 5, 0, 180.0, 110.0, 230.0, 520.0, 360.0, 77.0, 5, 12);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc6Id}, {TcMeet2026Meet1Id}, 82.0, 1, {AlphaTeamId}, 1, 6, 0, 175.0, 105.0, 225.0, 505.0, 350.0, 75.0, 6, 12);
-
-            -- Alpha Team: 3 male athletes in meet2 2026 scoring 12, 9, 8
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc1Id}, {TcMeet2026Meet2Id}, 82.0, 1, {AlphaTeamId}, 1, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 85.0, 1, 12);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc2Id}, {TcMeet2026Meet2Id}, 82.0, 1, {AlphaTeamId}, 1, 2, 0, 190.0, 120.0, 240.0, 550.0, 380.0, 81.0, 2, 9);
-            INSERT INTO Participations (AthleteId, MeetId, Weight, WeightCategoryId, TeamId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo, TeamPoints)
-            VALUES ({tc3Id}, {TcMeet2026Meet2Id}, 82.0, 1, {AlphaTeamId}, 1, 3, 0, 185.0, 115.0, 235.0, 535.0, 370.0, 79.0, 3, 8);
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
     }
 
     private static async Task SeedIntegrationRolesAsync(ResultsDbContext dbContext)

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/DeleteAthleteTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/DeleteAthleteTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts;
 using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
@@ -48,11 +49,29 @@ public sealed class DeleteAthleteTests(CollectionFixture fixture)
     [Fact]
     public async Task ReturnsConflict_WithErrorCode_WhenAthleteHasParticipations()
     {
-        // Arrange — the seeded athlete has participations
-        string seededAthleteSlug = Constants.TestAthleteSlug;
+        // Arrange
+        string athleteSlug = await CreateAthleteAsync();
+
+        CreateMeetCommand meetCommand = new CreateMeetCommandBuilder().Build();
+        HttpResponseMessage meetResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets", meetCommand, CancellationToken.None);
+        meetResponse.EnsureSuccessStatusCode();
+        string meetSlug = meetResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{meetSlug}", CancellationToken.None);
+        int meetId = details!.MeetId;
+
+        AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .Build();
+        HttpResponseMessage addResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants", participantCommand, CancellationToken.None);
+        addResponse.EnsureSuccessStatusCode();
 
         // Act
-        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{seededAthleteSlug}", CancellationToken.None);
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync(
+            $"{BasePath}/{athleteSlug}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Conflict);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Eras/GetErasTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Eras/GetErasTests.cs
@@ -4,14 +4,29 @@ using System.Net.Http.Json;
 using KRAFT.Results.Contracts.Eras;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
 using Shouldly;
 
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Eras;
 
 [Collection(nameof(InfraCollection))]
-public sealed class GetErasTests(CollectionFixture fixture)
+public sealed class GetErasTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string Path = "/eras";
+    private const string CreatedBy = "era-test";
+
+    // Owned IDs (5000+ range)
+    private const int OwnedAthleteId = 5000;
+    private const int OwnedHistoricalMeetId = 5000;
+    private const int OwnedCurrentMeetId = 5001;
+    private const int OwnedHistoricalParticipationId = 5000;
+    private const int OwnedCurrentParticipationId = 5001;
+    private const int OwnedHistoricalAttemptId = 5000;
+    private const int OwnedCurrentAttemptId = 5001;
+    private const int OwnedHistoricalRecordId = 5000;
+    private const int OwnedCurrentRecordId = 5001;
 
     private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
 
@@ -76,5 +91,116 @@ public sealed class GetErasTests(CollectionFixture fixture)
         historicalEra.Title.ShouldBe("Historical Era");
         historicalEra.StartDate.ShouldBe(new DateOnly(2011, 1, 1));
         historicalEra.EndDate.ShouldBe(new DateOnly(2018, 12, 31));
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        string seedSql =
+            $"""
+            -- Athlete
+            IF NOT EXISTS (SELECT 1 FROM Athletes WHERE AthleteId = {OwnedAthleteId})
+            BEGIN
+                SET IDENTITY_INSERT Athletes ON;
+                INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
+                VALUES ({OwnedAthleteId}, 'Era', 'Test', '1990-01-01', 'm', 1, 'era-test');
+                SET IDENTITY_INSERT Athletes OFF;
+            END
+
+            -- Historical era meet (date within 2011-01-01 to 2018-12-31)
+            IF NOT EXISTS (SELECT 1 FROM Meets WHERE MeetId = {OwnedHistoricalMeetId})
+            BEGIN
+                SET IDENTITY_INSERT Meets ON;
+                INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+                VALUES ({OwnedHistoricalMeetId}, 'Era Historical Meet', 'era-historical-meet', '2017-06-15', '2017-06-15', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1);
+                SET IDENTITY_INSERT Meets OFF;
+            END
+
+            -- Current era meet (date within 2019-01-01 to 2099-12-31)
+            IF NOT EXISTS (SELECT 1 FROM Meets WHERE MeetId = {OwnedCurrentMeetId})
+            BEGIN
+                SET IDENTITY_INSERT Meets ON;
+                INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
+                VALUES ({OwnedCurrentMeetId}, 'Era Current Meet', 'era-current-meet', '2025-03-15', '2025-03-15', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1);
+                SET IDENTITY_INSERT Meets OFF;
+            END
+
+            -- Historical participation
+            IF NOT EXISTS (SELECT 1 FROM Participations WHERE ParticipationId = {OwnedHistoricalParticipationId})
+            BEGIN
+                SET IDENTITY_INSERT Participations ON;
+                INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
+                VALUES ({OwnedHistoricalParticipationId}, {OwnedAthleteId}, {OwnedHistoricalMeetId}, 80.5, 1, 1, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 85.5, 1);
+                SET IDENTITY_INSERT Participations OFF;
+            END
+
+            -- Current participation
+            IF NOT EXISTS (SELECT 1 FROM Participations WHERE ParticipationId = {OwnedCurrentParticipationId})
+            BEGIN
+                SET IDENTITY_INSERT Participations ON;
+                INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
+                VALUES ({OwnedCurrentParticipationId}, {OwnedAthleteId}, {OwnedCurrentMeetId}, 80.5, 1, 1, 1, 0, 200.0, 130.0, 250.0, 580.0, 400.0, 85.5, 1);
+                SET IDENTITY_INSERT Participations OFF;
+            END
+
+            -- Historical attempt
+            IF NOT EXISTS (SELECT 1 FROM Attempts WHERE AttemptId = {OwnedHistoricalAttemptId})
+            BEGIN
+                SET IDENTITY_INSERT Attempts ON;
+                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
+                VALUES ({OwnedHistoricalAttemptId}, {OwnedHistoricalParticipationId}, 1, 1, 200.0, 1, '{CreatedBy}', '{CreatedBy}');
+                SET IDENTITY_INSERT Attempts OFF;
+            END
+
+            -- Current attempt
+            IF NOT EXISTS (SELECT 1 FROM Attempts WHERE AttemptId = {OwnedCurrentAttemptId})
+            BEGIN
+                SET IDENTITY_INSERT Attempts ON;
+                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
+                VALUES ({OwnedCurrentAttemptId}, {OwnedCurrentParticipationId}, 1, 1, 200.0, 1, '{CreatedBy}', '{CreatedBy}');
+                SET IDENTITY_INSERT Attempts OFF;
+            END
+
+            -- Historical record (EraId=1, IsCurrent=1, IsRaw=1)
+            IF NOT EXISTS (SELECT 1 FROM Records WHERE RecordId = {OwnedHistoricalRecordId})
+            BEGIN
+                SET IDENTITY_INSERT Records ON;
+                INSERT INTO Records (RecordId, EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+                VALUES ({OwnedHistoricalRecordId}, 1, 1, 1, 1, 200.0, '2017-06-15', 0, {OwnedHistoricalAttemptId}, 1, 1, '{CreatedBy}');
+                SET IDENTITY_INSERT Records OFF;
+            END
+
+            -- Current record (EraId=2, IsCurrent=1, IsRaw=1)
+            IF NOT EXISTS (SELECT 1 FROM Records WHERE RecordId = {OwnedCurrentRecordId})
+            BEGIN
+                SET IDENTITY_INSERT Records ON;
+                INSERT INTO Records (RecordId, EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+                VALUES ({OwnedCurrentRecordId}, 2, 1, 1, 1, 200.0, '2025-03-15', 0, {OwnedCurrentAttemptId}, 1, 1, '{CreatedBy}');
+                SET IDENTITY_INSERT Records OFF;
+            END
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(seedSql);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        string cleanupSql =
+            $"""
+            DELETE FROM Records WHERE CreatedBy = '{CreatedBy}';
+            DELETE FROM Attempts WHERE CreatedBy = '{CreatedBy}';
+            DELETE FROM Participations WHERE ParticipationId IN ({OwnedHistoricalParticipationId}, {OwnedCurrentParticipationId});
+            DELETE FROM Meets WHERE MeetId IN ({OwnedHistoricalMeetId}, {OwnedCurrentMeetId});
+            DELETE FROM Athletes WHERE AthleteId = {OwnedAthleteId};
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(cleanupSql);
+
+        _httpClient.Dispose();
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/DeleteMeetTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/DeleteMeetTests.cs
@@ -48,11 +48,22 @@ public sealed class DeleteMeetTests(CollectionFixture fixture)
     [Fact]
     public async Task ReturnsConflict_WithErrorCode_WhenMeetHasParticipations()
     {
-        // Arrange — the seeded meet has participations
-        string slug = Constants.TestMeetSlug;
+        // Arrange
+        string slug = await CreateMeetAsync();
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"{BasePath}/{slug}", CancellationToken.None);
+        int meetId = details!.MeetId;
+
+        AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(Constants.TestAthleteSlug)
+            .Build();
+        HttpResponseMessage addResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            $"{BasePath}/{meetId}/participants", participantCommand, CancellationToken.None);
+        addResponse.EnsureSuccessStatusCode();
 
         // Act
-        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync($"{BasePath}/{slug}", CancellationToken.None);
+        HttpResponseMessage response = await _authorizedHttpClient.DeleteAsync(
+            $"{BasePath}/{slug}", CancellationToken.None);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Conflict);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/ComputeRecordsTests.cs
@@ -205,7 +205,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -286,7 +285,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -518,7 +516,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -591,7 +588,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -656,7 +652,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -721,7 +716,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -785,7 +779,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -1019,7 +1012,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationAId, participationBId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -1141,7 +1133,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         finally
         {
             await CleanupEndpointTestParticipationsAsync(dbContext, participationAId, participationBId);
-            await RestoreSeedRecordStateAsync(dbContext);
         }
     }
 
@@ -1984,33 +1975,16 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
         }
         finally
         {
-            // Backfill may have modified global records; do a full restore
+            // Scoped cleanup: only remove records linked to the two test athletes' attempts
             string cleanupSql =
                 $"""
-                DELETE FROM Records;
+                DELETE FROM Records WHERE AttemptId IN ({athleteA.SquatAttemptId}, {athleteA.BenchAttemptId}, {athleteA.DeadliftAttemptId}, {athleteB.SquatAttemptId}, {athleteB.BenchAttemptId}, {athleteB.DeadliftAttemptId});
                 DELETE FROM Attempts WHERE AttemptId IN ({athleteA.SquatAttemptId}, {athleteA.BenchAttemptId}, {athleteA.DeadliftAttemptId}, {athleteB.SquatAttemptId}, {athleteB.BenchAttemptId}, {athleteB.DeadliftAttemptId});
                 DELETE FROM Participations WHERE ParticipationId IN ({athleteA.ParticipationId}, {athleteB.ParticipationId});
                 DELETE FROM Athletes WHERE AthleteId IN ({athleteA.AthleteId}, {athleteB.AthleteId});
                 """;
 
             await dbContext.Database.ExecuteSqlRawAsync(cleanupSql, TestContext.Current.CancellationToken);
-
-            await dbContext.Database.ExecuteSqlRawAsync(
-                BaseSeedSql.SeedBaseRecords(),
-                TestContext.Current.CancellationToken);
-
-            // Restore corruption test records that were seeded in DatabaseFixture
-            // but are not included in SeedBaseRecords() (they have auto-assigned IDs)
-            await dbContext.Database.ExecuteSqlRawAsync(
-                """
-                INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-                VALUES (2, 1, 2, 2, 150.0, '2025-06-01', 0, 2, 0, 0, 'seed');
-                INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-                VALUES (2, 1, 2, 2, 140.0, '2025-05-01', 0, 2, 1, 0, 'seed');
-                INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-                VALUES (2, 1, 1, 5, 130.0, '2025-03-15', 1, 2, 1, 0, 'seed');
-                """,
-                TestContext.Current.CancellationToken);
         }
     }
 
@@ -2107,20 +2081,6 @@ public sealed class ComputeRecordsTests(CollectionFixture fixture) : IAsyncLifet
             """;
 
         await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task RestoreSeedRecordStateAsync(ResultsDbContext dbContext)
-    {
-        // Slot rebuilds may create additional record rows for seed attempts and flip IsCurrent flags.
-        // Delete all raw records for seed attempts, then restore the canonical seed record.
-        string sql =
-            $"""
-            DELETE FROM Records WHERE AttemptId IN (1, 2, 3) AND IsRaw = 1;
-            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-            VALUES ({TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.OpenId}, {TestSeedConstants.WeightCategory.Id83Kg}, 1, 195.0, '2025-03-15', 0, 1, 1, 1, 'seed');
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql, TestContext.Current.CancellationToken);
     }
 
     private async Task RecordAttempt(


### PR DESCRIPTION
## Summary
- Strips `DatabaseFixture` down to seeding only immutable reference data (countries, users/roles, teams, athletes, age/weight categories, eras)
- Removes `SeedTeamCompetitionDataAsync`, `SeedBestNTestDataAsync`, and all calls to `BaseSeedSql.SeedMeet/SeedBaseParticipations/SeedBaseAttempts/SeedBaseRecords`
- Removes mutable constants from `Constants.cs` (`TestMeetTitle`, `TestMeetSlug`, `TeamCompetition`)
- Removes default `_meetId` from `RecordTestAthleteBuilder` (every caller already chains `.WithMeetId()`)
- Migrates `DeleteMeetTests` and `DeleteAthleteTests` conflict tests to create own meet+participation via API
- Migrates `GetErasTests` to own minimal record data (eras endpoint requires current records to return results)
- Removes `RestoreSeedRecordStateAsync` from `ComputeRecordsTests` and scopes backfill cleanup to owned data

Closes #419

## Test plan
- [ ] `dotnet test` passes — all 403 integration tests green
- [ ] `DatabaseFixture` seeds only reference data (no meets, participations, attempts, or records)
- [ ] `Constants.cs` contains no mutable-entity IDs
- [ ] No builder defaults reference removed seed constants