### PR TITLE
test(webapi): isolate GetMeetParticipationsTests into dedicated collection

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/GetMeetParticipationsCollection.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/GetMeetParticipationsCollection.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+[CollectionDefinition(nameof(GetMeetParticipationsCollection))]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "xUnit collection definition")]
+public sealed class GetMeetParticipationsCollection : ICollectionFixture<CollectionFixture>
+{
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -12,7 +12,7 @@ using Shouldly;
 
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
 
-[Collection(nameof(MeetsCollection))]
+[Collection(nameof(GetMeetParticipationsCollection))]
 public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();


### PR DESCRIPTION
## Summary

- Create dedicated `GetMeetParticipationsCollection` xUnit collection for test isolation
- Move `GetMeetParticipationsTests` from shared `MeetsCollection` to its own collection
- Entity creation already uses HTTP endpoints — no migration needed, only isolation

Closes #435

## Test plan

- [x] All 10 GetMeetParticipationsTests pass
- [x] Full test suite (403 tests) passes with no regressions