### PR TITLE
test(webapi): migrate GetRecordHistoryTests to endpoint-based seeding

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/GetRecordHistoryTestsCollection.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/GetRecordHistoryTestsCollection.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+[CollectionDefinition(nameof(GetRecordHistoryTestsCollection))]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "xUnit collection definition")]
+public sealed class GetRecordHistoryTestsCollection : ICollectionFixture<CollectionFixture>
+{
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/GetRecordHistoryTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/GetRecordHistoryTests.cs
@@ -1,110 +1,105 @@
 using System.Net;
 using System.Net.Http.Json;
 
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.Contracts.Records;
-using KRAFT.Results.Tests.Shared;
+using KRAFT.Results.WebApi.Features.Records.ComputeRecords;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
 
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Records;
 
-[Collection(nameof(RecordsCollection))]
+[Collection(nameof(GetRecordHistoryTestsCollection))]
 public sealed class GetRecordHistoryTests(CollectionFixture fixture) : IAsyncLifetime
 {
     private const string RecordsPath = "/records";
-
-    // Entity IDs — 4000+ range to avoid collisions with GetRecordsByEraTests (3000+)
-    private const int AthleteId = 4000;
-    private const int MeetId = 4000;
-    private const int ParticipationId = 4000;
-    private const int AttemptId = 4000;
-
-    // Record IDs — a chain of 3 records in the same group (era, ageCategory, weightCategory, recordCategory)
-    private const int RecordOldest = 4001;
-    private const int RecordMiddle = 4002;
-    private const int RecordCurrent = 4003;
-
-    // Weight constants
-    private const decimal OldestWeight = 180.0m;
-    private const decimal MiddleWeight = 195.0m;
-    private const decimal CurrentWeight = 210.0m;
+    private const decimal OldestSquatWeight = 180.0m;
+    private const decimal MiddleSquatWeight = 195.0m;
+    private const decimal CurrentSquatWeight = 210.0m;
+    private const decimal BenchWeight = 100.0m;
+    private const decimal DeadliftWeight = 200.0m;
 
     private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
+    private readonly string _suffix = UniqueShortCode.Next();
+    private readonly List<string> _athleteSlugs = [];
+    private readonly List<string> _meetSlugs = [];
+    private readonly List<(int MeetId, int ParticipationId)> _participations = [];
+    private HttpClient _authorizedHttpClient = null!;
+    private RecordComputationChannel _channel = null!;
+    private int _currentRecordId;
 
     public async ValueTask InitializeAsync()
     {
-        // Athlete
-        await fixture.ExecuteSqlAsync(
-            $"""
-            SET IDENTITY_INSERT Athletes ON;
-            INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-            VALUES ({AthleteId}, 'HistA', 'Test', '1985-07-02', 'm', {TestSeedConstants.Country.Id}, 'hista-test');
-            SET IDENTITY_INSERT Athletes OFF;
-            """);
+        (_authorizedHttpClient, _channel) = fixture.CreateAuthorizedHttpClientWithRecordComputation();
 
-        // Meet
-        await fixture.ExecuteSqlAsync(
-            $"""
-            SET IDENTITY_INSERT Meets ON;
-            INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-            VALUES ({MeetId}, 'GetRecordHistory Meet', 'getrecordhistory-meet', '2025-03-15', '2025-03-15', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1);
-            SET IDENTITY_INSERT Meets OFF;
-            """);
+        string athleteSlug = await CreateAthleteAsync("HistA", "m", new DateOnly(1985, 7, 2));
 
-        // Participation
-        await fixture.ExecuteSqlAsync(
-            $"""
-            SET IDENTITY_INSERT Participations ON;
-            INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-            VALUES ({ParticipationId}, {AthleteId}, {MeetId}, 80.5, {TestSeedConstants.WeightCategory.Id83Kg}, {TestSeedConstants.AgeCategory.OpenId}, 1, 0, {CurrentWeight}, 130.0, 250.0, 590.0, 400.0, 85.5, 1);
-            SET IDENTITY_INSERT Participations OFF;
-            """);
+        // Three classic meets with increasing dates — each produces progressively higher squat records
+        int meet1Id = await CreateMeetAndGetIdAsync(new DateOnly(2023, 6, 10), isRaw: true);
+        int meet2Id = await CreateMeetAndGetIdAsync(new DateOnly(2024, 3, 15), isRaw: true);
+        int meet3Id = await CreateMeetAndGetIdAsync(new DateOnly(2025, 3, 15), isRaw: true);
 
-        // Attempt
-        await fixture.ExecuteSqlAsync(
-            $"""
-            SET IDENTITY_INSERT Attempts ON;
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({AttemptId}, {ParticipationId}, 1, 3, {CurrentWeight}, 1, 'test-setup', 'test-setup');
-            SET IDENTITY_INSERT Attempts OFF;
-            """);
+        // Meet 1: oldest squat record (180.0)
+        int p1Id = await AddParticipantAsync(meet1Id, athleteSlug, 90.0m);
+        _participations.Add((meet1Id, p1Id));
+        await RecordAttemptAsync(meet1Id, p1Id, Discipline.Squat, 1, OldestSquatWeight);
+        await RecordAttemptAsync(meet1Id, p1Id, Discipline.Bench, 1, BenchWeight);
+        await RecordAttemptAsync(meet1Id, p1Id, Discipline.Deadlift, 1, DeadliftWeight);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
 
-        // Records — 3 records in the same group (classic squat 93kg, open), different dates, one current
-        // Uses IsRaw=1 + WeightCategory 93kg to avoid collisions with other test classes
-        await fixture.ExecuteSqlAsync(
-            $"""
-            SET IDENTITY_INSERT Records ON;
-            INSERT INTO Records (RecordId, EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-            VALUES
-                -- Oldest record (not current)
-                ({RecordOldest}, {TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.OpenId}, {TestSeedConstants.WeightCategory.Id93Kg}, 1, {OldestWeight}, '2023-06-10', 0, {AttemptId}, 0, 1, 'test-setup'),
-                -- Middle record (not current)
-                ({RecordMiddle}, {TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.OpenId}, {TestSeedConstants.WeightCategory.Id93Kg}, 1, {MiddleWeight}, '2024-03-15', 0, {AttemptId}, 0, 1, 'test-setup'),
-                -- Current record
-                ({RecordCurrent}, {TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.OpenId}, {TestSeedConstants.WeightCategory.Id93Kg}, 1, {CurrentWeight}, '2025-03-15', 0, {AttemptId}, 1, 1, 'test-setup');
-            SET IDENTITY_INSERT Records OFF;
-            """);
+        // Meet 2: middle squat record (195.0)
+        int p2Id = await AddParticipantAsync(meet2Id, athleteSlug, 90.0m);
+        _participations.Add((meet2Id, p2Id));
+        await RecordAttemptAsync(meet2Id, p2Id, Discipline.Squat, 1, MiddleSquatWeight);
+        await RecordAttemptAsync(meet2Id, p2Id, Discipline.Bench, 1, BenchWeight);
+        await RecordAttemptAsync(meet2Id, p2Id, Discipline.Deadlift, 1, DeadliftWeight);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Meet 3: current squat record (210.0)
+        int p3Id = await AddParticipantAsync(meet3Id, athleteSlug, 90.0m);
+        _participations.Add((meet3Id, p3Id));
+        await RecordAttemptAsync(meet3Id, p3Id, Discipline.Squat, 1, CurrentSquatWeight);
+        await RecordAttemptAsync(meet3Id, p3Id, Discipline.Bench, 1, BenchWeight);
+        await RecordAttemptAsync(meet3Id, p3Id, Discipline.Deadlift, 1, DeadliftWeight);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Discover the current squat record ID from the records endpoint
+        List<RecordGroup>? groups = await _httpClient.GetFromJsonAsync<List<RecordGroup>>(
+            $"{RecordsPath}?gender=m&ageCategory=open&equipmentType=classic",
+            CancellationToken.None);
+
+        RecordEntry squatRecord = groups!
+            .First(g => g.Category == "Hnébeygja")
+            .Records
+            .First(r => r.WeightCategory == "93");
+
+        _currentRecordId = squatRecord.Id;
     }
 
     public async ValueTask DisposeAsync()
     {
-        // Delete in FK-safe reverse order
-        await fixture.ExecuteSqlAsync(
-            $"DELETE FROM Records WHERE RecordId IN ({RecordOldest},{RecordMiddle},{RecordCurrent})");
+        foreach ((int meetId, int participationId) in _participations)
+        {
+            await _authorizedHttpClient.DeleteAsync(
+                $"/meets/{meetId}/participants/{participationId}", CancellationToken.None);
+        }
 
-        await fixture.ExecuteSqlAsync(
-            $"DELETE FROM Attempts WHERE AttemptId IN ({AttemptId})");
+        foreach (string slug in _meetSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{slug}", CancellationToken.None);
+        }
 
-        await fixture.ExecuteSqlAsync(
-            $"DELETE FROM Participations WHERE ParticipationId = {ParticipationId}");
+        foreach (string slug in _athleteSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
+        }
 
-        await fixture.ExecuteSqlAsync(
-            $"DELETE FROM Meets WHERE MeetId = {MeetId}");
-
-        await fixture.ExecuteSqlAsync(
-            $"DELETE FROM Athletes WHERE AthleteId = {AthleteId}");
-
+        _authorizedHttpClient.Dispose();
         _httpClient.Dispose();
     }
 
@@ -115,7 +110,7 @@ public sealed class GetRecordHistoryTests(CollectionFixture fixture) : IAsyncLif
 
         // Act
         HttpResponseMessage response = await _httpClient.GetAsync(
-            $"{RecordsPath}/{RecordCurrent}/history",
+            $"{RecordsPath}/{_currentRecordId}/history",
             CancellationToken.None);
 
         // Assert
@@ -144,7 +139,7 @@ public sealed class GetRecordHistoryTests(CollectionFixture fixture) : IAsyncLif
 
         // Act
         RecordHistoryResponse? history = await _httpClient.GetFromJsonAsync<RecordHistoryResponse>(
-            $"{RecordsPath}/{RecordCurrent}/history",
+            $"{RecordsPath}/{_currentRecordId}/history",
             CancellationToken.None);
 
         // Assert
@@ -165,7 +160,7 @@ public sealed class GetRecordHistoryTests(CollectionFixture fixture) : IAsyncLif
 
         // Act
         RecordHistoryResponse? history = await _httpClient.GetFromJsonAsync<RecordHistoryResponse>(
-            $"{RecordsPath}/{RecordCurrent}/history",
+            $"{RecordsPath}/{_currentRecordId}/history",
             CancellationToken.None);
 
         // Assert
@@ -180,7 +175,7 @@ public sealed class GetRecordHistoryTests(CollectionFixture fixture) : IAsyncLif
 
         // Act
         RecordHistoryResponse? history = await _httpClient.GetFromJsonAsync<RecordHistoryResponse>(
-            $"{RecordsPath}/{RecordCurrent}/history",
+            $"{RecordsPath}/{_currentRecordId}/history",
             CancellationToken.None);
 
         // Assert
@@ -190,5 +185,82 @@ public sealed class GetRecordHistoryTests(CollectionFixture fixture) : IAsyncLif
         history.AgeCategory.ShouldNotBeNullOrWhiteSpace();
         history.Gender.ShouldNotBeNullOrWhiteSpace();
         history.EquipmentType.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    private async Task<string> CreateAthleteAsync(string prefix, string gender, DateOnly dateOfBirth)
+    {
+        string firstName = $"{prefix}{_suffix}";
+        string lastName = "Rc";
+
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
+            .WithFirstName(firstName)
+            .WithLastName(lastName)
+            .WithGender(gender)
+            .WithDateOfBirth(dateOfBirth)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = Slug.Create($"{firstName} {lastName}");
+        _athleteSlugs.Add(slug);
+        return slug;
+    }
+
+    private async Task<int> CreateMeetAndGetIdAsync(DateOnly startDate, bool isRaw)
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder()
+            .WithStartDate(startDate)
+            .WithIsRaw(isRaw)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+        _meetSlugs.Add(slug);
+
+        MeetDetails? meetDetails = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{slug}", CancellationToken.None);
+
+        return meetDetails!.MeetId;
+    }
+
+    private async Task<int> AddParticipantAsync(int meetId, string athleteSlug, decimal bodyWeight)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(bodyWeight)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        return result!.ParticipationId;
+    }
+
+    private async Task RecordAttemptAsync(
+        int meetId,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
     }
 }


### PR DESCRIPTION
## Summary

- Replaced all raw SQL seeding and cleanup in `GetRecordHistoryTests` with HTTP endpoint calls
- Creates 3 classic meets with increasing squat weights (180, 195, 210) to produce a record history chain via the record computation pipeline
- Discovers record IDs at runtime from the records endpoint instead of hard-coding IDENTITY_INSERT values
- Cleanup uses endpoint DELETE calls in reverse FK order (participations → meets → athletes)
- Added dedicated `GetRecordHistoryTestsCollection` for test isolation

Closes #441

## Test plan

- [x] All 5 existing tests pass with endpoint-based seeding
- [x] Zero raw SQL remaining in the test file
- [x] Build passes with 0 warnings