### PR TITLE
test(webapi): migrate BackfillRecordsTests to endpoint-based seeding

### DIFF
--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/BackfillRecordsTestsCollection.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/BackfillRecordsTestsCollection.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+[CollectionDefinition(nameof(BackfillRecordsTestsCollection))]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "xUnit collection definition")]
+public sealed class BackfillRecordsTestsCollection
+    : ICollectionFixture<CollectionFixture>
+{
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/BackfillRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/BackfillRecordsTests.cs
@@ -55,6 +55,19 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     {
         (_authorizedHttpClient, _channel) = fixture.CreateAuthorizedHttpClientWithRecordComputation();
 
+        // The 105kg weight category exists in seed data but is only linked to the historical era.
+        // Tests that need the 105kg slot in the current era require this temporary link.
+        await using AsyncServiceScope eraScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext eraDb = eraScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        await eraDb.Database.ExecuteSqlRawAsync(
+            """
+            IF NOT EXISTS (SELECT 1 FROM EraWeightCategories WHERE EraId = 2 AND WeightCategoryId = 5)
+            INSERT INTO EraWeightCategories (EraId, WeightCategoryId, FromDate, ToDate)
+            VALUES (2, 5, '2019-01-01', '2099-12-31');
+            """,
+            TestContext.Current.CancellationToken);
+
         // Raw/classic powerlifting meet
         _rawMeetId = await CreateMeetAndGetIdAsync(isRaw: true);
 
@@ -1077,6 +1090,10 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
 
         await dbContext.Database.ExecuteSqlRawAsync(
             "DELETE FROM Records WHERE CreatedBy = 'duplicate';",
+            TestContext.Current.CancellationToken);
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "DELETE FROM EraWeightCategories WHERE EraId = 2 AND WeightCategoryId = 5;",
             TestContext.Current.CancellationToken);
     }
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/BackfillRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/BackfillRecordsTests.cs
@@ -61,10 +61,16 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         ResultsDbContext eraDb = eraScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
         await eraDb.Database.ExecuteSqlRawAsync(
-            """
-            IF NOT EXISTS (SELECT 1 FROM EraWeightCategories WHERE EraId = 2 AND WeightCategoryId = 5)
+            $"""
+            IF NOT EXISTS (
+                SELECT 1 FROM EraWeightCategories
+                WHERE EraId = {TestSeedConstants.Era.CurrentId}
+                AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id105Kg})
             INSERT INTO EraWeightCategories (EraId, WeightCategoryId, FromDate, ToDate)
-            VALUES (2, 5, '2019-01-01', '2099-12-31');
+            VALUES (
+                {TestSeedConstants.Era.CurrentId},
+                {TestSeedConstants.WeightCategory.Id105Kg},
+                '2019-01-01', '2099-12-31');
             """,
             TestContext.Current.CancellationToken);
 
@@ -216,6 +222,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
         List<RecordEntity> allCurrentRecords = await assertDb.Set<RecordEntity>()
+            .Where(r => r.EraId == TestSeedConstants.Era.CurrentId)
             .Where(r => r.IsCurrent)
             .ToListAsync(CancellationToken.None);
 
@@ -542,7 +549,8 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         int squat2AttemptId = await GetAttemptIdByRoundAsync(
             idDb, participation2Id, Discipline.Squat, 1, TestContext.Current.CancellationToken);
 
-        // Clear the slot so backfill rebuilds from scratch
+        // ClearSlotAsync is needed (not ResetRecordSlotAsync) because the compute pipeline
+        // cascades records to all eligible age categories — this clears them all at once.
         await SeedRecordAthlete.ClearSlotAsync(
             idDb, TestSeedConstants.WeightCategory.Id93Kg, TestContext.Current.CancellationToken);
 
@@ -1081,19 +1089,14 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
         await dbContext.Database.ExecuteSqlRawAsync(
-            "DELETE FROM Records WHERE CreatedBy = 'backfill-test';",
-            TestContext.Current.CancellationToken);
-
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "DELETE FROM Attempts WHERE Round = 4 AND CreatedBy = 'backfill-test';",
-            TestContext.Current.CancellationToken);
-
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "DELETE FROM Records WHERE CreatedBy = 'duplicate';",
-            TestContext.Current.CancellationToken);
-
-        await dbContext.Database.ExecuteSqlRawAsync(
-            "DELETE FROM EraWeightCategories WHERE EraId = 2 AND WeightCategoryId = 5;",
+            $"""
+            DELETE FROM Records WHERE CreatedBy = 'backfill-test';
+            DELETE FROM Records WHERE CreatedBy = 'duplicate';
+            DELETE FROM Attempts WHERE Round = 4 AND CreatedBy = 'backfill-test';
+            DELETE FROM EraWeightCategories
+            WHERE EraId = {TestSeedConstants.Era.CurrentId}
+            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id105Kg};
+            """,
             TestContext.Current.CancellationToken);
     }
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/BackfillRecordsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Records/BackfillRecordsTests.cs
@@ -1,8 +1,16 @@
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.Tests.Shared;
 using KRAFT.Results.WebApi.Enums;
+using KRAFT.Results.WebApi.Features.Attempts;
 using KRAFT.Results.WebApi.Features.Records;
+using KRAFT.Results.WebApi.Features.Records.ComputeRecords;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,69 +22,133 @@ using RecordEntity = KRAFT.Results.WebApi.Features.Records.Record;
 
 namespace KRAFT.Results.WebApi.IntegrationTests.Features.Records;
 
-[Collection(nameof(RecordsCollection))]
+[Collection(nameof(BackfillRecordsTestsCollection))]
 public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLifetime
 {
-    // Owned infrastructure entity IDs
-    private const int OwnedAthleteId = 510;
-    private const int OwnedMeetId = 510;
-    private const int OwnedDeadliftMeetId = 511;
+    private const int NorwayCountryId = 2;
     private const int DeadliftMeetTypeId = 3;
 
-    // Owned base participation + attempts for corruption records
-    private const int OwnedBaseParticipationId = 510;
-    private const int OwnedBaseAttemptSquatId = 510;
-    private const int OwnedBaseAttemptBenchId = 511;
-    private const int OwnedBaseAttemptDeadliftId = 512;
+    // Body weights used when adding participants
+    private const decimal OpenBodyWeight = 90.0m;
+    private const decimal HeavyBodyWeight = 103.0m;
+    private const decimal LightBodyWeight = 80.5m;
 
-    // Owned standard record
-    private const int OwnedStandardRecordId = 510;
+    private readonly string _suffix = UniqueShortCode.Next();
+    private readonly List<string> _athleteSlugs = [];
+    private readonly List<string> _meetSlugs = [];
+    private readonly List<(int MeetId, int ParticipationId)> _participations = [];
 
-    // Per-test entity IDs
-    private const int BackfillTestParticipationId = 500;
-    private const int BackfillTestAttemptLowId = 500;
-    private const int BackfillTestAttemptHighId = 501;
-    private const int BackfillTestBenchAttemptId = 502;
-    private const int BackfillTestDeadliftAttemptId = 503;
-    private const int DeadliftMeetParticipationId = 600;
-    private const int DeadliftMeetAttemptId = 600;
-    private const int NonIcelandicAthleteBaseId = 700;
+    // Shared meet IDs populated in InitializeAsync
+    private int _rawMeetId;
+    private int _deadliftMeetId;
 
-    // Two athletes whose squat AttemptIds are inversely ordered relative to their weights,
-    // mirroring production data where records were entered in descending weight order.
-    // Athlete1 (baseId=800): squatAttemptId=800, squat=140 kg (lower ID, higher weight).
-    // Athlete2 (baseId=803): squatAttemptId=803, squat=110 kg (higher ID, lower weight).
-    // With the buggy sort (by AttemptId), 800 (140 kg) is processed first and becomes
-    // runningMax; 803 (110 kg < 140 kg) is skipped and its record would be created fresh
-    // only if it appears — but since 110 < 140 it never enters the chain, so no record.
-    // With the fix (sort by weight first), 803 (110 kg) comes before 800 (140 kg),
-    // both enter the chain, and both records are created.
-    private const int SortOrderAthlete1BaseId = 800; // squatAttemptId=800, 140 kg
-    private const int SortOrderAthlete2BaseId = 803; // squatAttemptId=803, 110 kg
+    // Base participation ID (anchor for corruption records)
+    private int _baseParticipationId;
 
-    private const int SingleLiftAthleteBaseId = 900;
-    private const int StandardRecordAthleteABaseId = 1000;
-    private const int StandardRecordAthleteBBaseId = 1003;
-    private const int IntermediateTotalAthleteBaseId = 1010;
-    private const int IntermediateTotalDlRound2AttemptId = 1013;
-    private const int IntermediateTotalDlRound3AttemptId = 1014;
-    private const int FourthAttemptAthleteBaseId = 1020;
-    private const int FourthAttemptRound4AttemptId = 1024;
-    private const int DuplicateRecordAthleteBaseId = 1030;
+    // Base attempt ID for bench — used to anchor corruption records
+    private int _baseBenchAttemptId;
 
-    private const int NorwayCountryId = 2;
+    private HttpClient _authorizedHttpClient = null!;
+    private RecordComputationChannel _channel = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        (_authorizedHttpClient, _channel) = fixture.CreateAuthorizedHttpClientWithRecordComputation();
+
+        // Raw/classic powerlifting meet
+        _rawMeetId = await CreateMeetAndGetIdAsync(isRaw: true);
+
+        // Raw deadlift-only meet (MeetTypeId=3)
+        _deadliftMeetId = await CreateMeetAndGetIdAsync(isRaw: true, meetTypeId: DeadliftMeetTypeId);
+
+        // Base athlete: Icelandic, born 2003-01-01 (junior eligible)
+        string baseAthleteSlug = await CreateAthleteAsync("BkfBase", "m", new DateOnly(2003, 1, 1));
+
+        // Base participation + all three attempts — anchors the corruption records seeded below.
+        _baseParticipationId = await AddParticipantAsync(_rawMeetId, baseAthleteSlug, OpenBodyWeight);
+        await RecordAttemptAsync(_rawMeetId, _baseParticipationId, Discipline.Squat, 1, 150.0m);
+        await RecordAttemptAsync(_rawMeetId, _baseParticipationId, Discipline.Bench, 1, 100.0m);
+        await RecordAttemptAsync(_rawMeetId, _baseParticipationId, Discipline.Deadlift, 1, 180.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope idScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext idDb = idScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        _baseBenchAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, _baseParticipationId, Discipline.Bench, 1, TestContext.Current.CancellationToken);
+
+        // Standard record (equipped/masters4/93kg/squat, IsStandard=1).
+        // Endpoints cannot create standard records — SQL is required.
+        await InsertStandardRecordIfAbsentAsync();
+
+        // Corruption records referencing the base bench attempt.
+        await InsertCorruptionRecordsAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Delete per-test participations (all except the base participation)
+        List<(int MeetId, int ParticipationId)> testParticipations = _participations
+            .Where(p => p.ParticipationId != _baseParticipationId)
+            .ToList();
+
+        foreach ((int meetId, int participationId) in testParticipations)
+        {
+            await _authorizedHttpClient.DeleteAsync(
+                $"/meets/{meetId}/participants/{participationId}", CancellationToken.None);
+        }
+
+        // Remove SQL-only state that endpoints cannot delete
+        await CleanupSqlOnlyStateAsync();
+
+        // Delete base participation via endpoint (cascades to attempts and records)
+        await _authorizedHttpClient.DeleteAsync(
+            $"/meets/{_rawMeetId}/participants/{_baseParticipationId}", CancellationToken.None);
+
+        foreach (string slug in _meetSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{slug}", CancellationToken.None);
+        }
+
+        foreach (string slug in _athleteSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+    }
 
     [Fact]
     public async Task WhenBackfillRuns_RecordChainIsCorrect()
     {
-        // Arrange
-        await ResetToBaseStateAsync();
+        // Arrange — clear the junior/93kg/squat/raw slot, seed two squat attempts (180kg and 220kg)
+        // and two orphan records with null AttemptId. After backfill the orphans are deleted and
+        // the chain is 180kg then 220kg as current.
+        await ResetRecordSlotAsync(
+            TestSeedConstants.AgeCategory.JuniorId,
+            TestSeedConstants.WeightCategory.Id93Kg);
+
+        string athleteSlug = await CreateAthleteAsync("BkfChain", "m", new DateOnly(2003, 1, 1));
+        int participationId = await AddParticipantAsync(_rawMeetId, athleteSlug, OpenBodyWeight);
+
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 1, 180.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 2, 220.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Bench, 1, 140.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 1, 260.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope idScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext idDb = idScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        int highAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Squat, 2, TestContext.Current.CancellationToken);
+
+        // Orphan records (AttemptId=NULL) — endpoints cannot produce these; SQL required.
+        await InsertOrphanRecordsAsync(
+            TestSeedConstants.AgeCategory.JuniorId,
+            TestSeedConstants.WeightCategory.Id93Kg);
 
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        await SeedBackfillTestDataAsync(dbContext);
-
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -84,10 +156,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
-        // Assert — slot: era=2, ageCategory=junior(2), weightCategory=93kg(2), squat(1), isRaw=true.
-        // Expected chain: attempt 500 (180kg) -> attempt 501 (220kg, current).
-        // The orphan seed record at 150kg (no attempt) should be deleted.
-        // The corrupt record at 160kg (no matching attempt) should be deleted.
+        // Assert
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
@@ -103,21 +172,16 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
 
         RecordEntity currentRecord = slotRecords.Single(r => r.IsCurrent);
         currentRecord.Weight.ShouldBe(220.0m);
-        currentRecord.AttemptId.ShouldBe(BackfillTestAttemptHighId);
+        currentRecord.AttemptId.ShouldBe(highAttemptId);
 
-        // The orphan seed records (AttemptId = null) should have been deleted
-        slotRecords.ShouldNotContain(r => r.AttemptId == null);
-
-        // The corrupt 160kg record should have been deleted
-        slotRecords.ShouldNotContain(r => r.Weight == 160.0m);
+        slotRecords.ShouldNotContain(r => r.AttemptId == null, "orphan records should be deleted");
+        slotRecords.ShouldNotContain(r => r.Weight == 160.0m, "corrupt 160kg orphan should be deleted");
     }
 
     [Fact]
     public async Task WhenBackfillRunsTwice_ResultIsIdempotent()
     {
         // Arrange
-        await ResetToBaseStateAsync();
-
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
 
@@ -134,7 +198,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
             await (secondRun.ExecuteTask ?? Task.CompletedTask);
         }
 
-        // Assert — the record chain should be consistent after two runs
+        // Assert — each slot should have exactly one current record
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
@@ -142,7 +206,6 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
             .Where(r => r.IsCurrent)
             .ToListAsync(CancellationToken.None);
 
-        // Group by slot and verify each slot has exactly one current record
         IEnumerable<IGrouping<string, RecordEntity>> slots = allCurrentRecords
             .GroupBy(r => $"{r.EraId}-{r.AgeCategoryId}-{r.WeightCategoryId}-{r.RecordCategoryId}-{r.IsRaw}");
 
@@ -155,14 +218,37 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     [Fact]
     public async Task WhenBackfillRuns_TotalRecordIsCreated()
     {
-        // Arrange
-        await ResetToBaseStateAsync();
+        // Arrange — athlete with all three disciplines gives a valid total; clear total records
+        // so backfill re-creates them from the attempts. Squat=220, Bench=140, Deadlift=260, Total=620.
+        await ResetRecordSlotAsync(
+            TestSeedConstants.AgeCategory.JuniorId,
+            TestSeedConstants.WeightCategory.Id93Kg);
+
+        string athleteSlug = await CreateAthleteAsync("BkfTotal", "m", new DateOnly(2003, 1, 1));
+        int participationId = await AddParticipantAsync(_rawMeetId, athleteSlug, OpenBodyWeight);
+
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 1, 220.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Bench, 1, 140.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 1, 260.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope clearScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext clearDb = clearScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        string deleteTotalSql =
+            $"""
+            DELETE FROM Records
+            WHERE EraId = {TestSeedConstants.Era.CurrentId}
+            AND AgeCategoryId = {TestSeedConstants.AgeCategory.JuniorId}
+            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id93Kg}
+            AND RecordCategoryId = {(int)RecordCategory.Total}
+            AND IsRaw = 1;
+            """;
+
+        await clearDb.Database.ExecuteSqlRawAsync(
+            deleteTotalSql, TestContext.Current.CancellationToken);
 
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        await SeedBackfillTotalTestDataAsync(dbContext);
-
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -170,7 +256,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
-        // Assert — Total record should exist for the participation with Total=620
+        // Assert
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
@@ -190,14 +276,36 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     [Fact]
     public async Task WhenBackfillRuns_DeadliftSingleRecordIsCreated()
     {
-        // Arrange
-        await ResetToBaseStateAsync();
+        // Arrange — a deadlift attempt at a deadlift-only meet should create a DeadliftSingle record.
+        await ResetRecordSlotAsync(
+            TestSeedConstants.AgeCategory.OpenId,
+            TestSeedConstants.WeightCategory.Id83Kg,
+            recordCategory: RecordCategory.DeadliftSingle);
+
+        string athleteSlug = await CreateAthleteAsync("BkfDlSgl", "m", new DateOnly(1985, 7, 2));
+        int participationId = await AddParticipantAsync(_deadliftMeetId, athleteSlug, LightBodyWeight);
+
+        await RecordAttemptAsync(_deadliftMeetId, participationId, Discipline.Deadlift, 1, 280.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Clear the slot so backfill re-creates the record
+        await using AsyncServiceScope clearScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext clearDb = clearScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        string deleteDlSingleSql =
+            $"""
+            DELETE FROM Records
+            WHERE EraId = {TestSeedConstants.Era.CurrentId}
+            AND AgeCategoryId = {TestSeedConstants.AgeCategory.OpenId}
+            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg}
+            AND RecordCategoryId = {(int)RecordCategory.DeadliftSingle}
+            AND IsRaw = 1;
+            """;
+
+        await clearDb.Database.ExecuteSqlRawAsync(
+            deleteDlSingleSql, TestContext.Current.CancellationToken);
 
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        await SeedDeadliftMeetBackfillDataAsync(dbContext);
-
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -205,7 +313,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
-        // Assert — DeadliftSingle record should exist
+        // Assert
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
@@ -225,11 +333,9 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     [Fact]
     public async Task WhenBackfillRuns_StandardRecordIsNotDeleted()
     {
-        // Arrange — owned standard record (RecordId=510) in the
-        // equipped / masters4 / 93 kg / squat slot with no athlete attempts.
-        // The expected chain for that slot is empty, so the buggy code deletes it.
-        await ResetToBaseStateAsync();
-
+        // Arrange — a standard record (IsStandard=1) in the equipped/masters4/93kg/squat slot
+        // is seeded in InitializeAsync. The slot has no athlete attempt, so the expected
+        // chain is empty. The buggy code deleted standard records in this situation.
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
@@ -238,7 +344,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
-        // Assert — the standard record in the 93 kg equipped masters4 squat slot must survive
+        // Assert — the standard record in the equipped masters4 93kg squat slot must survive
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
@@ -257,24 +363,30 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     public async Task WhenNonIcelandicAthleteCompetes_BackfillDoesNotCreateRecord()
     {
         // Arrange
-        await ResetToBaseStateAsync();
-
-        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
         int weightCategoryId = TestSeedConstants.WeightCategory.Id105Kg;
 
-        await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, CancellationToken.None);
+        await ResetRecordSlotAsync(TestSeedConstants.AgeCategory.Masters4Id, weightCategoryId);
 
-        SeedRecordAthlete norwegianAthlete = await new RecordTestAthleteBuilder(dbContext, NonIcelandicAthleteBaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithCountryId(NorwayCountryId)
-            .WithWeightCategoryId(weightCategoryId)
-            .WithSquat(300m)
-            .WithBench(200m)
-            .WithDeadlift(350m)
-            .BuildAsync(CancellationToken.None);
+        string norwegianSlug = await CreateAthleteAsync(
+            "BkfNor", "m", new DateOnly(1950, 1, 1), countryId: NorwayCountryId);
+        int participationId = await AddParticipantAsync(_rawMeetId, norwegianSlug, HeavyBodyWeight);
 
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 1, 300.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Bench, 1, 200.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 1, 350.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope idScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext idDb = idScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        int squatAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Squat, 1, TestContext.Current.CancellationToken);
+        int benchAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Bench, 1, TestContext.Current.CancellationToken);
+        int deadliftAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Deadlift, 1, TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -282,18 +394,16 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
-        // Assert — no records should exist for the non-Icelandic athlete's slot
+        // Assert — no records should reference the Norwegian athlete's attempts
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
         List<RecordEntity> slotRecords = await assertDb.Set<RecordEntity>()
             .Where(r => r.EraId == TestSeedConstants.Era.CurrentId)
-            .Where(r => r.AgeCategoryId == TestSeedConstants.AgeCategory.Masters4Id)
             .Where(r => r.WeightCategoryId == weightCategoryId)
-            .Where(r => r.IsRaw)
-            .Where(r => r.AttemptId == norwegianAthlete.SquatAttemptId
-                || r.AttemptId == norwegianAthlete.BenchAttemptId
-                || r.AttemptId == norwegianAthlete.DeadliftAttemptId)
+            .Where(r => r.AttemptId == squatAttemptId
+                || r.AttemptId == benchAttemptId
+                || r.AttemptId == deadliftAttemptId)
             .ToListAsync(CancellationToken.None);
 
         slotRecords.ShouldBeEmpty("non-Icelandic athletes should not get records via backfill");
@@ -302,24 +412,46 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     [Fact]
     public async Task WhenBackfillRuns_BenchAndDeadliftFromPowerliftingMeetAlsoCreateSingleLiftRecords()
     {
-        // Arrange — a bench attempt from a powerlifting meet should create BOTH a Bench
-        // (Cat=2) record AND a BenchSingle (Cat=5) record, mirroring production data where
-        // both slots tracked lifts from full powerlifting competitions.
-        // Likewise, a deadlift attempt should produce both Deadlift (Cat=3) and
+        // Arrange — a bench attempt from a powerlifting meet should create Bench (Cat=2) and
+        // BenchSingle (Cat=5) records. Likewise a deadlift creates Deadlift (Cat=3) and
         // DeadliftSingle (Cat=6) records.
-        await ResetToBaseStateAsync();
+        int weightCategoryId = TestSeedConstants.WeightCategory.Id105Kg;
+
+        await ResetRecordSlotAsync(TestSeedConstants.AgeCategory.Masters4Id, weightCategoryId);
+
+        string athleteSlug = await CreateAthleteAsync("BkfSglLft", "m", new DateOnly(1950, 1, 1));
+        int participationId = await AddParticipantAsync(_rawMeetId, athleteSlug, HeavyBodyWeight);
+
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 1, 200.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Bench, 1, 130.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 1, 250.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope idScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext idDb = idScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        int benchAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Bench, 1, TestContext.Current.CancellationToken);
+        int deadliftAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Deadlift, 1, TestContext.Current.CancellationToken);
+
+        // Clear single-lift slots so backfill re-creates them
+        string deleteSingleLiftSql =
+            $"""
+            DELETE FROM Records
+            WHERE EraId = {TestSeedConstants.Era.CurrentId}
+            AND AgeCategoryId = {TestSeedConstants.AgeCategory.Masters4Id}
+            AND WeightCategoryId = {weightCategoryId}
+            AND RecordCategoryId IN (
+                {(int)RecordCategory.Bench}, {(int)RecordCategory.BenchSingle},
+                {(int)RecordCategory.Deadlift}, {(int)RecordCategory.DeadliftSingle})
+            AND IsRaw = 1;
+            """;
+
+        await idDb.Database.ExecuteSqlRawAsync(
+            deleteSingleLiftSql, TestContext.Current.CancellationToken);
 
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(dbContext, SingleLiftAthleteBaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(TestSeedConstants.WeightCategory.Id105Kg)
-            .WithSquat(200m)
-            .WithBench(130m)
-            .WithDeadlift(250m)
-            .BuildAsync(CancellationToken.None);
-
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -327,19 +459,17 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
-        // Assert — both Bench and BenchSingle records should be created for the bench attempt.
+        // Assert
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
         RecordEntity? benchRecord = await assertDb.Set<RecordEntity>()
-            .Where(r => r.AttemptId == athlete.BenchAttemptId)
-            .Where(r => r.RecordCategoryId == RecordCategory.Bench)
-            .FirstOrDefaultAsync(CancellationToken.None);
+            .Where(r => r.AttemptId == benchAttemptId)
+            .FirstOrDefaultAsync(r => r.RecordCategoryId == RecordCategory.Bench, CancellationToken.None);
 
         RecordEntity? benchSingleRecord = await assertDb.Set<RecordEntity>()
-            .Where(r => r.AttemptId == athlete.BenchAttemptId)
-            .Where(r => r.RecordCategoryId == RecordCategory.BenchSingle)
-            .FirstOrDefaultAsync(CancellationToken.None);
+            .Where(r => r.AttemptId == benchAttemptId)
+            .FirstOrDefaultAsync(r => r.RecordCategoryId == RecordCategory.BenchSingle, CancellationToken.None);
 
         benchRecord.ShouldNotBeNull("bench from powerlifting meet should produce a Bench record");
         benchRecord.Weight.ShouldBe(130m);
@@ -348,16 +478,13 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
             "bench from powerlifting meet should also produce a BenchSingle record");
         benchSingleRecord.Weight.ShouldBe(130m);
 
-        // Also verify Deadlift and DeadliftSingle records.
         RecordEntity? deadliftRecord = await assertDb.Set<RecordEntity>()
-            .Where(r => r.AttemptId == athlete.DeadliftAttemptId)
-            .Where(r => r.RecordCategoryId == RecordCategory.Deadlift)
-            .FirstOrDefaultAsync(CancellationToken.None);
+            .Where(r => r.AttemptId == deadliftAttemptId)
+            .FirstOrDefaultAsync(r => r.RecordCategoryId == RecordCategory.Deadlift, CancellationToken.None);
 
         RecordEntity? deadliftSingleRecord = await assertDb.Set<RecordEntity>()
-            .Where(r => r.AttemptId == athlete.DeadliftAttemptId)
-            .Where(r => r.RecordCategoryId == RecordCategory.DeadliftSingle)
-            .FirstOrDefaultAsync(CancellationToken.None);
+            .Where(r => r.AttemptId == deadliftAttemptId)
+            .FirstOrDefaultAsync(r => r.RecordCategoryId == RecordCategory.DeadliftSingle, CancellationToken.None);
 
         deadliftRecord.ShouldNotBeNull("deadlift from powerlifting meet should produce a Deadlift record");
         deadliftRecord.Weight.ShouldBe(250m);
@@ -370,41 +497,43 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     [Fact]
     public async Task WhenBackfillRuns_AttemptWithLowerIdButHigherWeightDoesNotSuppressRecord()
     {
-        // Arrange — two athletes in the same slot (open / 93 kg / squat / raw).
-        // Athlete1 (baseId=800): squatAttemptId=800, squat=140 kg (lower ID, higher weight).
-        // Athlete2 (baseId=803): squatAttemptId=803, squat=110 kg (higher ID, lower weight).
-        // The lower AttemptId has the higher weight, mirroring production data where
-        // records were entered in descending weight order.
-        // With the buggy sort (by AttemptId), 800 (140 kg) is processed first and sets
-        // runningMax=140; 803 (110 kg < 140 kg) is skipped and never enters the chain.
-        // After the fix (sort by weight first), 803 (110 kg) is processed first, 800
-        // (140 kg) second — both enter the chain and both records are created.
-        await ResetToBaseStateAsync();
+        // Arrange — two athletes in the same slot (masters4 / 93kg / squat / raw), lifting 140kg
+        // and 110kg respectively. Both should appear in the chain regardless of insertion order.
+        // The buggy sort (by AttemptId ascending) could suppress the lower-weight record if the
+        // higher-weight attempt happened to have the lower AttemptId.
+        await ResetRecordSlotAsync(
+            TestSeedConstants.AgeCategory.Masters4Id,
+            TestSeedConstants.WeightCategory.Id93Kg);
+
+        string athlete1Slug = await CreateAthleteAsync("BkfSort1", "m", new DateOnly(1950, 1, 1));
+        int participation1Id = await AddParticipantAsync(_rawMeetId, athlete1Slug, OpenBodyWeight);
+
+        await RecordAttemptAsync(_rawMeetId, participation1Id, Discipline.Squat, 1, 140.0m);
+        await RecordAttemptAsync(_rawMeetId, participation1Id, Discipline.Bench, 1, 100.0m);
+        await RecordAttemptAsync(_rawMeetId, participation1Id, Discipline.Deadlift, 1, 150.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        string athlete2Slug = await CreateAthleteAsync("BkfSort2", "m", new DateOnly(1950, 1, 1));
+        int participation2Id = await AddParticipantAsync(_rawMeetId, athlete2Slug, OpenBodyWeight);
+
+        await RecordAttemptAsync(_rawMeetId, participation2Id, Discipline.Squat, 1, 110.0m);
+        await RecordAttemptAsync(_rawMeetId, participation2Id, Discipline.Bench, 1, 80.0m);
+        await RecordAttemptAsync(_rawMeetId, participation2Id, Discipline.Deadlift, 1, 130.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope idScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext idDb = idScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        int squat1AttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participation1Id, Discipline.Squat, 1, TestContext.Current.CancellationToken);
+        int squat2AttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participation2Id, Discipline.Squat, 1, TestContext.Current.CancellationToken);
+
+        // Clear the slot so backfill rebuilds from scratch
+        await SeedRecordAthlete.ClearSlotAsync(
+            idDb, TestSeedConstants.WeightCategory.Id93Kg, TestContext.Current.CancellationToken);
 
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
-        await SeedRecordAthlete.ClearSlotAsync(
-            dbContext,
-            TestSeedConstants.WeightCategory.Id93Kg,
-            CancellationToken.None);
-
-        SeedRecordAthlete athlete1 = await new RecordTestAthleteBuilder(dbContext, SortOrderAthlete1BaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(TestSeedConstants.WeightCategory.Id93Kg)
-            .WithSquat(140m)
-            .WithBench(100m)
-            .WithDeadlift(150m)
-            .BuildAsync(CancellationToken.None);
-
-        SeedRecordAthlete athlete2 = await new RecordTestAthleteBuilder(dbContext, SortOrderAthlete2BaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(TestSeedConstants.WeightCategory.Id93Kg)
-            .WithSquat(110m)
-            .WithBench(80m)
-            .WithDeadlift(130m)
-            .BuildAsync(CancellationToken.None);
-
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -412,44 +541,44 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
-        // Assert — both squat records must be created; athlete1 (140 kg) is current,
-        // athlete2 (110 kg) is the predecessor in the progressive chain.
+        // Assert — both records must appear in the chain
         await using AsyncServiceScope assertScope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext assertDb = assertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
         List<RecordEntity> slotRecords = await assertDb.Set<RecordEntity>()
             .Where(r => r.EraId == TestSeedConstants.Era.CurrentId)
-            .Where(r => r.AgeCategoryId == TestSeedConstants.AgeCategory.OpenId)
+            .Where(r => r.AgeCategoryId == TestSeedConstants.AgeCategory.Masters4Id)
             .Where(r => r.WeightCategoryId == TestSeedConstants.WeightCategory.Id93Kg)
             .Where(r => r.RecordCategoryId == RecordCategory.Squat)
             .Where(r => r.IsRaw)
             .ToListAsync(CancellationToken.None);
 
         slotRecords.ShouldContain(
-            r => r.AttemptId == athlete1.SquatAttemptId,
-            "higher-weight attempt (lower ID) should be in chain");
+            r => r.AttemptId == squat1AttemptId,
+            "higher-weight attempt should be in chain");
 
         slotRecords.ShouldContain(
-            r => r.AttemptId == athlete2.SquatAttemptId,
-            "lower-weight attempt (higher ID) should not be suppressed by sort order bug");
+            r => r.AttemptId == squat2AttemptId,
+            "lower-weight attempt should not be suppressed by sort order");
 
         RecordEntity currentRecord = slotRecords.Single(r => r.IsCurrent);
-        currentRecord.AttemptId.ShouldBe(athlete1.SquatAttemptId, "current record should be the highest weight");
+        currentRecord.AttemptId.ShouldBe(squat1AttemptId, "current record should be the highest weight");
         currentRecord.Weight.ShouldBe(140m);
     }
 
     [Fact]
     public async Task WhenStandardRecordExists_ChainStartsFromStandardWeight()
     {
-        // Arrange
-        await ResetToBaseStateAsync();
-
-        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
+        // Arrange — standard record at 250kg. Athlete A lifts 240kg which is below the standard
+        // so no record is expected. Athlete B lifts 260kg which is above the standard
+        // and should produce exactly one record.
         int weightCategoryId = TestSeedConstants.WeightCategory.Id105Kg;
 
-        await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, CancellationToken.None);
+        await ResetRecordSlotAsync(TestSeedConstants.AgeCategory.Masters4Id, weightCategoryId);
+
+        // Endpoints cannot create standard records — SQL is required.
+        await using AsyncServiceScope insertScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext insertDb = insertScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
         string insertStandardSql =
             $"""
@@ -464,22 +593,41 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
                 250.0, '2020-06-01', 1, NULL, 1, 1, 'backfill-test');
             """;
 
-        await dbContext.Database.ExecuteSqlRawAsync(
-            insertStandardSql,
-            TestContext.Current.CancellationToken);
+        await insertDb.Database.ExecuteSqlRawAsync(
+            insertStandardSql, TestContext.Current.CancellationToken);
 
-        await new RecordTestAthleteBuilder(dbContext, StandardRecordAthleteABaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(weightCategoryId)
-            .WithSquat(240m)
-            .BuildAsync(CancellationToken.None);
+        // Athlete A: squat=240 (below standard — should NOT produce a record)
+        string athleteASlug = await CreateAthleteAsync("BkfStdA", "m", new DateOnly(1950, 1, 1));
+        int participationAId = await AddParticipantAsync(_rawMeetId, athleteASlug, HeavyBodyWeight);
+        await RecordAttemptAsync(_rawMeetId, participationAId, Discipline.Squat, 1, 240.0m);
+        await RecordAttemptAsync(_rawMeetId, participationAId, Discipline.Bench, 1, 130.0m);
+        await RecordAttemptAsync(_rawMeetId, participationAId, Discipline.Deadlift, 1, 250.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
 
-        await new RecordTestAthleteBuilder(dbContext, StandardRecordAthleteBBaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(weightCategoryId)
-            .WithSquat(260m)
-            .BuildAsync(CancellationToken.None);
+        // Athlete B: squat=260 (above standard — SHOULD produce a record)
+        string athleteBSlug = await CreateAthleteAsync("BkfStdB", "m", new DateOnly(1950, 1, 1));
+        int participationBId = await AddParticipantAsync(_rawMeetId, athleteBSlug, HeavyBodyWeight);
+        await RecordAttemptAsync(_rawMeetId, participationBId, Discipline.Squat, 1, 260.0m);
+        await RecordAttemptAsync(_rawMeetId, participationBId, Discipline.Bench, 1, 130.0m);
+        await RecordAttemptAsync(_rawMeetId, participationBId, Discipline.Deadlift, 1, 250.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
 
+        // Clear non-standard records so backfill re-evaluates from the standard weight
+        string deleteNonStandardSql =
+            $"""
+            DELETE FROM Records
+            WHERE EraId = {TestSeedConstants.Era.CurrentId}
+            AND AgeCategoryId = {TestSeedConstants.AgeCategory.Masters4Id}
+            AND WeightCategoryId = {weightCategoryId}
+            AND RecordCategoryId = {(int)RecordCategory.Squat}
+            AND IsRaw = 1
+            AND IsStandard = 0;
+            """;
+
+        await insertDb.Database.ExecuteSqlRawAsync(
+            deleteNonStandardSql, TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -499,9 +647,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
             .Where(r => r.IsRaw)
             .ToListAsync(CancellationToken.None);
 
-        slotRecords.ShouldContain(
-            r => r.IsStandard,
-            "standard record should still exist after backfill");
+        slotRecords.ShouldContain(r => r.IsStandard, "standard record should still exist after backfill");
 
         List<RecordEntity> nonStandardRecords = slotRecords
             .Where(r => !r.IsStandard)
@@ -519,52 +665,53 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     [Fact]
     public async Task WhenMultipleGoodDeadlifts_IntermediateTotalRecordsAreCreated()
     {
-        // Arrange
-        await ResetToBaseStateAsync();
-
-        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
+        // Arrange — athlete has squat + bench + three improving deadlifts (rounds 1, 2, 3).
+        // Each improving deadlift produces a new best total; backfill should create one Total
+        // record per improving deadlift: 580 (dl=250), 590 (dl=260), 600 (dl=270, current).
         int weightCategoryId = TestSeedConstants.WeightCategory.Id105Kg;
 
-        await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, CancellationToken.None);
+        await ResetRecordSlotAsync(TestSeedConstants.AgeCategory.Masters4Id, weightCategoryId);
 
-        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(
-                dbContext,
-                IntermediateTotalAthleteBaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(weightCategoryId)
-            .WithSquat(200m)
-            .WithBench(130m)
-            .WithDeadlift(250m)
-            .BuildAsync(CancellationToken.None);
+        string athleteSlug = await CreateAthleteAsync("BkfIntTot", "m", new DateOnly(1950, 1, 1));
+        int participationId = await AddParticipantAsync(_rawMeetId, athleteSlug, HeavyBodyWeight);
 
-        string extraDeadliftsSql =
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 1, 200.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Bench, 1, 130.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 1, 250.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Rounds 2 and 3 for deadlift (endpoint supports all three rounds)
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 2, 260.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 3, 270.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope idScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext idDb = idScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        int dl1AttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Deadlift, 1, TestContext.Current.CancellationToken);
+        int dl2AttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Deadlift, 2, TestContext.Current.CancellationToken);
+        int dl3AttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Deadlift, 3, TestContext.Current.CancellationToken);
+
+        // Clear total records so backfill re-creates all three
+        string deleteTotalSql =
             $"""
-            SET IDENTITY_INSERT Attempts ON;
-            INSERT INTO Attempts (
-                AttemptId, ParticipationId, DisciplineId, Round, Weight, Good,
-                CreatedBy, ModifiedBy)
-            VALUES (
-                {IntermediateTotalDlRound2AttemptId},
-                {athlete.ParticipationId}, 3, 2, 260.0, 1, 'test', 'test');
-            INSERT INTO Attempts (
-                AttemptId, ParticipationId, DisciplineId, Round, Weight, Good,
-                CreatedBy, ModifiedBy)
-            VALUES (
-                {IntermediateTotalDlRound3AttemptId},
-                {athlete.ParticipationId}, 3, 3, 270.0, 1, 'test', 'test');
-            SET IDENTITY_INSERT Attempts OFF;
-
-            UPDATE Participations
-            SET Deadlift = 270.0, Total = 600.0
-            WHERE ParticipationId = {athlete.ParticipationId};
+            DELETE FROM Records
+            WHERE EraId = {TestSeedConstants.Era.CurrentId}
+            AND AgeCategoryId = {TestSeedConstants.AgeCategory.Masters4Id}
+            AND WeightCategoryId = {weightCategoryId}
+            AND RecordCategoryId = {(int)RecordCategory.Total}
+            AND IsRaw = 1;
             """;
 
-        await dbContext.Database.ExecuteSqlRawAsync(
-            extraDeadliftsSql,
-            TestContext.Current.CancellationToken);
+        await idDb.Database.ExecuteSqlRawAsync(
+            deleteTotalSql, TestContext.Current.CancellationToken);
 
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -588,57 +735,67 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
         totalRecords.Count.ShouldBe(3, "one total record per improving deadlift attempt");
 
         totalRecords[0].Weight.ShouldBe(580.0m);
-        totalRecords[0].AttemptId.ShouldBe(athlete.DeadliftAttemptId);
+        totalRecords[0].AttemptId.ShouldBe(dl1AttemptId);
         totalRecords[0].IsCurrent.ShouldBeFalse();
 
         totalRecords[1].Weight.ShouldBe(590.0m);
-        totalRecords[1].AttemptId.ShouldBe(IntermediateTotalDlRound2AttemptId);
+        totalRecords[1].AttemptId.ShouldBe(dl2AttemptId);
         totalRecords[1].IsCurrent.ShouldBeFalse();
 
         totalRecords[2].Weight.ShouldBe(600.0m);
-        totalRecords[2].AttemptId.ShouldBe(IntermediateTotalDlRound3AttemptId);
+        totalRecords[2].AttemptId.ShouldBe(dl3AttemptId);
         totalRecords[2].IsCurrent.ShouldBeTrue();
     }
 
     [Fact]
     public async Task WhenFourthAttemptExists_TotalExcludesRoundFourWeight()
     {
-        // Arrange
-        await ResetToBaseStateAsync();
-
-        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
+        // Arrange — standard squat/bench/deadlift via endpoints, plus a round-4 squat inserted
+        // via SQL (the endpoint does not support round 4). Round 4 is not a valid competition
+        // attempt for totals; the total should be 200+130+250=580, not 220+130+250=600.
         int weightCategoryId = TestSeedConstants.WeightCategory.Id105Kg;
 
-        await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, CancellationToken.None);
+        await ResetRecordSlotAsync(TestSeedConstants.AgeCategory.Masters4Id, weightCategoryId);
 
-        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(
-                dbContext,
-                FourthAttemptAthleteBaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(weightCategoryId)
-            .WithSquat(200m)
-            .WithBench(130m)
-            .WithDeadlift(250m)
-            .BuildAsync(CancellationToken.None);
+        string athleteSlug = await CreateAthleteAsync("BkfR4", "m", new DateOnly(1950, 1, 1));
+        int participationId = await AddParticipantAsync(_rawMeetId, athleteSlug, HeavyBodyWeight);
 
-        string round4SquatSql =
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 1, 200.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Bench, 1, 130.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 1, 250.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope sqlScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext sqlDb = sqlScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        // Round 4 squat: endpoint does not support round 4; SQL required to simulate
+        // production data where extra-attempt records exist.
+        string insertRound4Sql =
             $"""
-            SET IDENTITY_INSERT Attempts ON;
             INSERT INTO Attempts (
-                AttemptId, ParticipationId, DisciplineId, Round, Weight, Good,
-                CreatedBy, ModifiedBy)
+                ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
             VALUES (
-                {FourthAttemptRound4AttemptId},
-                {athlete.ParticipationId}, 1, 4, 220.0, 1, 'test', 'test');
-            SET IDENTITY_INSERT Attempts OFF;
+                {participationId}, 1, 4, 220.0, 1, 'backfill-test', 'backfill-test');
             """;
 
-        await dbContext.Database.ExecuteSqlRawAsync(
-            round4SquatSql,
-            TestContext.Current.CancellationToken);
+        await sqlDb.Database.ExecuteSqlRawAsync(
+            insertRound4Sql, TestContext.Current.CancellationToken);
 
+        // Clear total records so backfill re-creates
+        string deleteTotalSql =
+            $"""
+            DELETE FROM Records
+            WHERE EraId = {TestSeedConstants.Era.CurrentId}
+            AND AgeCategoryId = {TestSeedConstants.AgeCategory.Masters4Id}
+            AND WeightCategoryId = {weightCategoryId}
+            AND RecordCategoryId = {(int)RecordCategory.Total}
+            AND IsRaw = 1;
+            """;
+
+        await sqlDb.Database.ExecuteSqlRawAsync(
+            deleteTotalSql, TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
@@ -669,33 +826,26 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
     public async Task WhenDuplicateRecordsExistForSameAttempt_BackfillDeduplicates()
     {
         // Arrange
-        await ResetToBaseStateAsync();
-
-        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
-        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
-
         int weightCategoryId = TestSeedConstants.WeightCategory.Id105Kg;
 
-        await SeedRecordAthlete.ClearSlotAsync(dbContext, weightCategoryId, CancellationToken.None);
+        await ResetRecordSlotAsync(TestSeedConstants.AgeCategory.Masters4Id, weightCategoryId);
 
-        SeedRecordAthlete athlete = await new RecordTestAthleteBuilder(
-                dbContext,
-                DuplicateRecordAthleteBaseId)
-            .WithMeetId(OwnedMeetId)
-            .WithWeightCategoryId(weightCategoryId)
-            .WithSquat(200m)
-            .WithBench(130m)
-            .WithDeadlift(250m)
-            .BuildAsync(CancellationToken.None);
+        string athleteSlug = await CreateAthleteAsync("BkfDup", "m", new DateOnly(1950, 1, 1));
+        int participationId = await AddParticipantAsync(_rawMeetId, athleteSlug, HeavyBodyWeight);
 
-        IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Squat, 1, 200.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Bench, 1, 130.0m);
+        await RecordAttemptAsync(_rawMeetId, participationId, Discipline.Deadlift, 1, 250.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
 
-        using (BackfillRecordsJob firstRun = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance))
-        {
-            await firstRun.StartAsync(CancellationToken.None);
-            await (firstRun.ExecuteTask ?? Task.CompletedTask);
-        }
+        await using AsyncServiceScope idScope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext idDb = idScope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
+        int squatAttemptId = await GetAttemptIdByRoundAsync(
+            idDb, participationId, Discipline.Squat, 1, TestContext.Current.CancellationToken);
+
+        // Insert a duplicate record for the same attempt — endpoints prevent duplicates; SQL required
+        // to simulate the corrupt production data that backfill must deduplicate.
         string insertDuplicateSql =
             $"""
             INSERT INTO Records (
@@ -705,16 +855,18 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
                 EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId,
                 Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, 'duplicate'
             FROM Records
-            WHERE AttemptId = {athlete.SquatAttemptId}
+            WHERE AttemptId = {squatAttemptId}
             AND RecordCategoryId = {(int)RecordCategory.Squat};
             """;
 
-        await dbContext.Database.ExecuteSqlRawAsync(
-            insertDuplicateSql,
-            TestContext.Current.CancellationToken);
+        await idDb.Database.ExecuteSqlRawAsync(
+            insertDuplicateSql, TestContext.Current.CancellationToken);
+
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        IServiceScopeFactory scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
+        using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
 
         // Act
-        using BackfillRecordsJob job = new(scopeFactory, NullLogger<BackfillRecordsJob>.Instance);
         await job.StartAsync(CancellationToken.None);
         await (job.ExecuteTask ?? Task.CompletedTask);
 
@@ -729,7 +881,7 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
             .Where(r => r.RecordCategoryId == RecordCategory.Squat)
             .Where(r => r.IsRaw)
             .Where(r => !r.IsStandard)
-            .Where(r => r.AttemptId == athlete.SquatAttemptId)
+            .Where(r => r.AttemptId == squatAttemptId)
             .ToListAsync(CancellationToken.None);
 
         squatRecords.Count.ShouldBe(
@@ -737,393 +889,282 @@ public sealed class BackfillRecordsTests(CollectionFixture fixture) : IAsyncLife
             "duplicate records for the same attempt should be deduplicated");
     }
 
-    public async ValueTask InitializeAsync()
+    private static async Task<int> GetAttemptIdByRoundAsync(
+        ResultsDbContext dbContext,
+        int participationId,
+        Discipline discipline,
+        int round,
+        CancellationToken cancellationToken)
     {
-        await SeedOwnedInfrastructureAsync();
+        return await dbContext.Set<Attempt>()
+            .Where(a => a.ParticipationId == participationId)
+            .Where(a => a.Discipline == discipline)
+            .Where(a => a.Round == round)
+            .Select(a => a.AttemptId)
+            .SingleAsync(cancellationToken);
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        await CleanupOwnedDataAsync();
-    }
-
-    private static async Task SeedDeadliftMeetBackfillDataAsync(ResultsDbContext dbContext)
-    {
-        string sql =
-            $"""
-            DELETE FROM Records
-            WHERE RecordCategoryId = {(int)RecordCategory.DeadliftSingle}
-            AND IsRaw = 1
-            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id83Kg};
-
-            DELETE FROM Attempts WHERE AttemptId IN ({DeadliftMeetAttemptId});
-            DELETE FROM Participations WHERE ParticipationId = {DeadliftMeetParticipationId};
-
-            SET IDENTITY_INSERT Participations ON;
-            INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-            VALUES ({DeadliftMeetParticipationId}, {OwnedAthleteId}, {OwnedDeadliftMeetId}, 80.5, {TestSeedConstants.WeightCategory.Id83Kg}, {TestSeedConstants.AgeCategory.OpenId}, 1, 0, 0.0, 0.0, 280.0, 0.0, 0.0, 0.0, 1);
-            SET IDENTITY_INSERT Participations OFF;
-
-            SET IDENTITY_INSERT Attempts ON;
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({DeadliftMeetAttemptId}, {DeadliftMeetParticipationId}, 3, 1, 280.0, 1, 'test', 'test');
-            SET IDENTITY_INSERT Attempts OFF;
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task SeedBackfillTotalTestDataAsync(ResultsDbContext dbContext)
-    {
-        await SeedBackfillTestDataAsync(dbContext);
-
-        // Add bench and deadlift attempts so participation has valid total for backfill
-        string sql =
-            $"""
-            SET IDENTITY_INSERT Attempts ON;
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({BackfillTestBenchAttemptId}, {BackfillTestParticipationId}, 2, 1, 140.0, 1, 'test', 'test');
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({BackfillTestDeadliftAttemptId}, {BackfillTestParticipationId}, 3, 1, 260.0, 1, 'test', 'test');
-            SET IDENTITY_INSERT Attempts OFF;
-
-            DELETE FROM Records
-            WHERE EraId = {TestSeedConstants.Era.CurrentId}
-            AND AgeCategoryId = {TestSeedConstants.AgeCategory.JuniorId}
-            AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id93Kg}
-            AND RecordCategoryId = {(int)RecordCategory.Total}
-            AND IsRaw = 1;
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(sql);
-    }
-
-    private static async Task SeedBackfillTestDataAsync(ResultsDbContext dbContext)
-    {
-        // Use an isolated slot: era=2, junior(2), 93kg(2), squat, raw=true.
-        // No other test uses this combination.
-        int eraId = TestSeedConstants.Era.CurrentId;
-        int ageCategoryId = TestSeedConstants.AgeCategory.JuniorId;
-        int weightCategoryId = TestSeedConstants.WeightCategory.Id93Kg;
-
-        string cleanupSql =
-            $"""
-            DELETE FROM Records
-            WHERE EraId = {eraId}
-            AND AgeCategoryId = {ageCategoryId}
-            AND WeightCategoryId = {weightCategoryId}
-            AND RecordCategoryId = {(int)RecordCategory.Squat}
-            AND IsRaw = 1;
-
-            DELETE FROM Attempts WHERE AttemptId IN ({BackfillTestAttemptLowId}, {BackfillTestAttemptHighId});
-            DELETE FROM Participations WHERE ParticipationId = {BackfillTestParticipationId};
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(cleanupSql);
-
-        // Create a participation in junior age category, 93kg, in the owned meet
-        // Owned athlete DOB is 2003-01-01, which resolves to junior age category
-        string seedDataSql =
-            $"""
-            SET IDENTITY_INSERT Participations ON;
-            INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-            VALUES ({BackfillTestParticipationId}, {OwnedAthleteId}, {OwnedMeetId}, 90.0, {weightCategoryId}, {ageCategoryId}, 1, 0, 220.0, 140.0, 260.0, 620.0, 420.0, 90.0, 99);
-            SET IDENTITY_INSERT Participations OFF;
-
-            SET IDENTITY_INSERT Attempts ON;
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({BackfillTestAttemptLowId}, {BackfillTestParticipationId}, 1, 1, 180.0, 1, 'test', 'test');
-            INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-            VALUES ({BackfillTestAttemptHighId}, {BackfillTestParticipationId}, 1, 2, 220.0, 1, 'test', 'test');
-            SET IDENTITY_INSERT Attempts OFF;
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(seedDataSql);
-
-        // Seed corrupt records in this slot:
-        // 1. Orphan seed record (no attempt) at 150kg marked as current — should be deleted
-        // 2. Corrupt record at 160kg with no matching attempt, marked as current — should be deleted
-        string corruptRecordsSql =
-            $"""
-            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-            VALUES ({eraId}, {ageCategoryId}, {weightCategoryId}, 1, 150.0, '2025-01-01', 0, NULL, 1, 1, 'backfill-test');
-
-            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-            VALUES ({eraId}, {ageCategoryId}, {weightCategoryId}, 1, 160.0, '2025-02-01', 0, NULL, 1, 1, 'backfill-test');
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(corruptRecordsSql);
-    }
-
-    private async Task ResetToBaseStateAsync()
+    private async Task ResetRecordSlotAsync(
+        int ageCategoryId,
+        int weightCategoryId,
+        RecordCategory? recordCategory = null)
     {
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        // Builder-created entities: athlete=baseId, participation=baseId, attempts=baseId/baseId+1/baseId+2
-        int[] baseIds =
-        [
-            NonIcelandicAthleteBaseId,
-            SortOrderAthlete1BaseId, SortOrderAthlete2BaseId,
-            SingleLiftAthleteBaseId,
-            StandardRecordAthleteABaseId, StandardRecordAthleteBBaseId,
-            IntermediateTotalAthleteBaseId,
-            FourthAttemptAthleteBaseId,
-            DuplicateRecordAthleteBaseId
-        ];
+        string deleteSql;
 
-        // Per-test attempt IDs (excludes owned infrastructure attempts which must persist)
-        List<int> perTestAttemptIds =
-        [
-            BackfillTestAttemptLowId, BackfillTestAttemptHighId,
-            BackfillTestBenchAttemptId, BackfillTestDeadliftAttemptId,
-            DeadliftMeetAttemptId,
-            IntermediateTotalDlRound2AttemptId, IntermediateTotalDlRound3AttemptId,
-            FourthAttemptRound4AttemptId
-        ];
-
-        foreach (int baseId in baseIds)
+        if (recordCategory.HasValue)
         {
-            perTestAttemptIds.Add(baseId);
-            perTestAttemptIds.Add(baseId + 1);
-            perTestAttemptIds.Add(baseId + 2);
+            deleteSql =
+                $"""
+                DELETE FROM Records
+                WHERE EraId = {TestSeedConstants.Era.CurrentId}
+                AND AgeCategoryId = {ageCategoryId}
+                AND WeightCategoryId = {weightCategoryId}
+                AND RecordCategoryId = {(int)recordCategory.Value}
+                AND IsRaw = 1
+                AND IsStandard = 0;
+                """;
+        }
+        else
+        {
+            deleteSql =
+                $"""
+                DELETE FROM Records
+                WHERE EraId = {TestSeedConstants.Era.CurrentId}
+                AND AgeCategoryId = {ageCategoryId}
+                AND WeightCategoryId = {weightCategoryId}
+                AND IsRaw = 1
+                AND IsStandard = 0;
+                """;
         }
 
-        string perTestAttemptIdsCsv = string.Join(", ", perTestAttemptIds);
+        await dbContext.Database.ExecuteSqlRawAsync(deleteSql, TestContext.Current.CancellationToken);
+    }
 
-        // Delete records: per-test attempts + owned infra attempts + CreatedBy marker
-        string deleteRecordsSql =
-            $"""
-            DELETE FROM Records WHERE AttemptId IN (
-                {perTestAttemptIdsCsv},
-                {OwnedBaseAttemptSquatId}, {OwnedBaseAttemptBenchId}, {OwnedBaseAttemptDeadliftId});
-            DELETE FROM Records WHERE CreatedBy = 'backfill-test';
-            """;
+    private async Task InsertStandardRecordIfAbsentAsync()
+    {
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        await dbContext.Database.ExecuteSqlRawAsync(deleteRecordsSql);
-
-        // Delete per-test attempts (owned infrastructure attempts are kept)
-        string deleteAttemptsSql =
-            $"""
-            DELETE FROM Attempts WHERE AttemptId IN ({perTestAttemptIdsCsv});
-            """;
-        await dbContext.Database.ExecuteSqlRawAsync(deleteAttemptsSql);
-
-        // Delete test-created participations
-        string deleteParticipationsSql =
-            $"""
-            DELETE FROM Participations WHERE ParticipationId IN (
-                {BackfillTestParticipationId}, {DeadliftMeetParticipationId});
-            """;
-        await dbContext.Database.ExecuteSqlRawAsync(deleteParticipationsSql);
-
-        // Delete builder-created participations and athletes
-        foreach (int baseId in baseIds)
-        {
-            string deleteParticipation =
-                $"DELETE FROM Participations WHERE ParticipationId = {baseId};";
-            await dbContext.Database.ExecuteSqlRawAsync(deleteParticipation);
-            string deleteAthlete =
-                $"DELETE FROM Athletes WHERE AthleteId = {baseId};";
-            await dbContext.Database.ExecuteSqlRawAsync(deleteAthlete);
-        }
-
-        // Re-seed corruption records (they get deleted during record cleanup)
-        string corruptionRecordsSql =
+        // Endpoints cannot create standard records — SQL is required.
+        string sql =
             $"""
             IF NOT EXISTS (
                 SELECT 1 FROM Records
                 WHERE EraId = {TestSeedConstants.Era.CurrentId}
                 AND AgeCategoryId = {TestSeedConstants.AgeCategory.Masters4Id}
                 AND WeightCategoryId = {TestSeedConstants.WeightCategory.Id93Kg}
+                AND RecordCategoryId = {(int)RecordCategory.Squat}
+                AND IsRaw = 0
+                AND IsStandard = 1
+                AND CreatedBy = 'backfill-test')
+            BEGIN
+                INSERT INTO Records (
+                    EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId,
+                    Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+                VALUES (
+                    {TestSeedConstants.Era.CurrentId},
+                    {TestSeedConstants.AgeCategory.Masters4Id},
+                    {TestSeedConstants.WeightCategory.Id93Kg},
+                    {(int)RecordCategory.Squat},
+                    220.0, '2025-01-01', 1, NULL, 1, 0, 'backfill-test');
+            END
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(sql, TestContext.Current.CancellationToken);
+    }
+
+    private async Task InsertCorruptionRecordsAsync()
+    {
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        // Corruption records represent intentionally corrupt data states that endpoints cannot produce:
+        // - Two Records rows for the same AttemptId in different states (IsCurrent=0, IsCurrent=1)
+        // - A BenchSingle record with IsStandard=1
+        // Guard prevents double-insertion on test reruns.
+        string sql =
+            $"""
+            IF NOT EXISTS (
+                SELECT 1 FROM Records
+                WHERE AttemptId = {_baseBenchAttemptId}
                 AND RecordCategoryId = {(int)RecordCategory.Bench}
                 AND Weight = 150.0
                 AND CreatedBy = 'backfill-test')
             BEGIN
-                INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+                INSERT INTO Records (
+                    EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId,
+                    Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
                 VALUES (
                     {TestSeedConstants.Era.CurrentId},
                     {TestSeedConstants.AgeCategory.Masters4Id},
                     {TestSeedConstants.WeightCategory.Id93Kg},
                     {(int)RecordCategory.Bench},
-                    150.0, '2025-06-01', 0, {OwnedBaseAttemptBenchId}, 0, 0, 'backfill-test');
+                    150.0, '2025-06-01', 0, {_baseBenchAttemptId}, 0, 0, 'backfill-test');
 
-                INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+                INSERT INTO Records (
+                    EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId,
+                    Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
                 VALUES (
                     {TestSeedConstants.Era.CurrentId},
                     {TestSeedConstants.AgeCategory.Masters4Id},
                     {TestSeedConstants.WeightCategory.Id93Kg},
                     {(int)RecordCategory.Bench},
-                    140.0, '2025-05-01', 0, {OwnedBaseAttemptBenchId}, 1, 0, 'backfill-test');
+                    140.0, '2025-05-01', 0, {_baseBenchAttemptId}, 1, 0, 'backfill-test');
 
-                INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+                INSERT INTO Records (
+                    EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId,
+                    Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
                 VALUES (
                     {TestSeedConstants.Era.CurrentId},
                     {TestSeedConstants.AgeCategory.Masters4Id},
                     {TestSeedConstants.WeightCategory.Id83Kg},
                     {(int)RecordCategory.BenchSingle},
-                    130.0, '2025-03-15', 1, {OwnedBaseAttemptBenchId}, 1, 0, 'backfill-test');
+                    130.0, '2025-03-15', 1, {_baseBenchAttemptId}, 1, 0, 'backfill-test');
             END
             """;
 
-        await dbContext.Database.ExecuteSqlRawAsync(corruptionRecordsSql);
-
-        // Re-seed standard record if deleted
-        string standardRecordSql =
-            $"""
-            IF NOT EXISTS (SELECT 1 FROM Records WHERE RecordId = {OwnedStandardRecordId})
-            BEGIN
-                SET IDENTITY_INSERT Records ON;
-                INSERT INTO Records (RecordId, EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-                VALUES ({OwnedStandardRecordId}, {TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.Masters4Id}, {TestSeedConstants.WeightCategory.Id93Kg}, {(int)RecordCategory.Squat}, 220.0, '2025-01-01', 1, NULL, 1, 0, 'backfill-test');
-                SET IDENTITY_INSERT Records OFF;
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(standardRecordSql);
+        await dbContext.Database.ExecuteSqlRawAsync(sql, TestContext.Current.CancellationToken);
     }
 
-    private async Task SeedOwnedInfrastructureAsync()
+    private async Task InsertOrphanRecordsAsync(int ageCategoryId, int weightCategoryId)
     {
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        // Owned athlete — Icelandic, DOB 2003-01-01 for junior eligibility
-        string athleteSql =
+        // Orphan records have AttemptId=NULL — endpoints never produce this state.
+        // SQL is required to simulate corrupt production data that backfill must delete.
+        string sql =
             $"""
-            IF NOT EXISTS (SELECT 1 FROM Athletes WHERE AthleteId = {OwnedAthleteId})
-            BEGIN
-                SET IDENTITY_INSERT Athletes ON;
-                INSERT INTO Athletes (AthleteId, Firstname, Lastname, DateOfBirth, Gender, CountryId, Slug)
-                VALUES ({OwnedAthleteId}, 'Backfill', 'Test', '2003-01-01', 'm', {TestSeedConstants.Country.Id}, 'backfill-test');
-                SET IDENTITY_INSERT Athletes OFF;
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(athleteSql);
-
-        // Owned powerlifting meet — IsRaw=1, RecordsPossible=1
-        string meetSql =
-            $"""
-            IF NOT EXISTS (SELECT 1 FROM Meets WHERE MeetId = {OwnedMeetId})
-            BEGIN
-                SET IDENTITY_INSERT Meets ON;
-                INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-                VALUES ({OwnedMeetId}, 'Backfill Test Meet', 'backfill-test-meet', '2025-03-15', '2025-03-15', 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1);
-                SET IDENTITY_INSERT Meets OFF;
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(meetSql);
-
-        // Owned deadlift meet
-        string deadliftMeetSql =
-            $"""
-            IF NOT EXISTS (SELECT 1 FROM Meets WHERE MeetId = {OwnedDeadliftMeetId})
-            BEGIN
-                SET IDENTITY_INSERT Meets ON;
-                INSERT INTO Meets (MeetId, Title, Slug, StartDate, EndDate, CalcPlaces, PublishedResults, ResultModeId, IsRaw, MeetTypeId, IsInTeamCompetition, ShowWilks, ShowTeamPoints, ShowBodyWeight, ShowTeams, RecordsPossible, PublishedInCalendar)
-                VALUES ({OwnedDeadliftMeetId}, 'Backfill DL Meet', 'backfill-dl-meet', '2025-06-01', '2025-06-01', 1, 1, 1, 1, {DeadliftMeetTypeId}, 0, 1, 0, 1, 0, 1, 1);
-                SET IDENTITY_INSERT Meets OFF;
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(deadliftMeetSql);
-
-        // Owned base participation + attempts for corruption records to reference
-        string baseParticipationSql =
-            $"""
-            IF NOT EXISTS (SELECT 1 FROM Participations WHERE ParticipationId = {OwnedBaseParticipationId})
-            BEGIN
-                SET IDENTITY_INSERT Participations ON;
-                INSERT INTO Participations (ParticipationId, AthleteId, MeetId, Weight, WeightCategoryId, AgeCategoryId, Place, Disqualified, Squat, Benchpress, Deadlift, Total, Wilks, IPFPoints, LotNo)
-                VALUES ({OwnedBaseParticipationId}, {OwnedAthleteId}, {OwnedMeetId}, 90.0, {TestSeedConstants.WeightCategory.Id93Kg}, {TestSeedConstants.AgeCategory.OpenId}, 1, 1, 150.0, 100.0, 180.0, 430.0, 300.0, 70.0, 99);
-                SET IDENTITY_INSERT Participations OFF;
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(baseParticipationSql);
-
-        string baseAttemptsSql =
-            $"""
-            IF NOT EXISTS (SELECT 1 FROM Attempts WHERE AttemptId = {OwnedBaseAttemptSquatId})
-            BEGIN
-                SET IDENTITY_INSERT Attempts ON;
-                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-                VALUES ({OwnedBaseAttemptSquatId}, {OwnedBaseParticipationId}, 1, 1, 150.0, 0, 'backfill-test', 'backfill-test');
-                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-                VALUES ({OwnedBaseAttemptBenchId}, {OwnedBaseParticipationId}, 2, 1, 100.0, 0, 'backfill-test', 'backfill-test');
-                INSERT INTO Attempts (AttemptId, ParticipationId, DisciplineId, Round, Weight, Good, CreatedBy, ModifiedBy)
-                VALUES ({OwnedBaseAttemptDeadliftId}, {OwnedBaseParticipationId}, 3, 1, 180.0, 0, 'backfill-test', 'backfill-test');
-                SET IDENTITY_INSERT Attempts OFF;
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(baseAttemptsSql);
-
-        // Owned standard record — equipped / open / 93kg / squat, IsStandard=1
-        string standardRecordSql =
-            $"""
-            IF NOT EXISTS (SELECT 1 FROM Records WHERE RecordId = {OwnedStandardRecordId})
-            BEGIN
-                SET IDENTITY_INSERT Records ON;
-                INSERT INTO Records (RecordId, EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-                VALUES ({OwnedStandardRecordId}, {TestSeedConstants.Era.CurrentId}, {TestSeedConstants.AgeCategory.Masters4Id}, {TestSeedConstants.WeightCategory.Id93Kg}, {(int)RecordCategory.Squat}, 220.0, '2025-01-01', 1, NULL, 1, 0, 'backfill-test');
-                SET IDENTITY_INSERT Records OFF;
-            END
-            """;
-
-        await dbContext.Database.ExecuteSqlRawAsync(standardRecordSql);
-
-        // Corruption records — reference owned attempts
-        string corruptionRecordsSql =
-            $"""
-            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+            INSERT INTO Records (
+                EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId,
+                Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
             VALUES (
                 {TestSeedConstants.Era.CurrentId},
-                {TestSeedConstants.AgeCategory.Masters4Id},
-                {TestSeedConstants.WeightCategory.Id93Kg},
-                {(int)RecordCategory.Bench},
-                150.0, '2025-06-01', 0, {OwnedBaseAttemptBenchId}, 0, 0, 'backfill-test');
+                {ageCategoryId},
+                {weightCategoryId},
+                {(int)RecordCategory.Squat},
+                150.0, '2025-01-01', 0, NULL, 1, 1, 'backfill-test');
 
-            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
+            INSERT INTO Records (
+                EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId,
+                Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
             VALUES (
                 {TestSeedConstants.Era.CurrentId},
-                {TestSeedConstants.AgeCategory.Masters4Id},
-                {TestSeedConstants.WeightCategory.Id93Kg},
-                {(int)RecordCategory.Bench},
-                140.0, '2025-05-01', 0, {OwnedBaseAttemptBenchId}, 1, 0, 'backfill-test');
-
-            INSERT INTO Records (EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, Weight, Date, IsStandard, AttemptId, IsCurrent, IsRaw, CreatedBy)
-            VALUES (
-                {TestSeedConstants.Era.CurrentId},
-                {TestSeedConstants.AgeCategory.Masters4Id},
-                {TestSeedConstants.WeightCategory.Id83Kg},
-                {(int)RecordCategory.BenchSingle},
-                130.0, '2025-03-15', 1, {OwnedBaseAttemptBenchId}, 1, 0, 'backfill-test');
+                {ageCategoryId},
+                {weightCategoryId},
+                {(int)RecordCategory.Squat},
+                160.0, '2025-02-01', 0, NULL, 1, 1, 'backfill-test');
             """;
 
-        await dbContext.Database.ExecuteSqlRawAsync(corruptionRecordsSql);
+        await dbContext.Database.ExecuteSqlRawAsync(sql, TestContext.Current.CancellationToken);
     }
 
-    private async Task CleanupOwnedDataAsync()
+    private async Task CleanupSqlOnlyStateAsync()
     {
-        await ResetToBaseStateAsync();
-
         await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
         ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
 
-        // Delete owned infrastructure in FK-safe order
-        string cleanupSql =
-            $"""
-            DELETE FROM Records WHERE RecordId = {OwnedStandardRecordId};
-            DELETE FROM Records WHERE CreatedBy = 'backfill-test';
-            DELETE FROM Attempts WHERE AttemptId IN ({OwnedBaseAttemptSquatId}, {OwnedBaseAttemptBenchId}, {OwnedBaseAttemptDeadliftId});
-            DELETE FROM Participations WHERE ParticipationId = {OwnedBaseParticipationId};
-            DELETE FROM Meets WHERE MeetId IN ({OwnedMeetId}, {OwnedDeadliftMeetId});
-            DELETE FROM Athletes WHERE AthleteId = {OwnedAthleteId};
-            """;
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "DELETE FROM Records WHERE CreatedBy = 'backfill-test';",
+            TestContext.Current.CancellationToken);
 
-        await dbContext.Database.ExecuteSqlRawAsync(cleanupSql);
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "DELETE FROM Attempts WHERE Round = 4 AND CreatedBy = 'backfill-test';",
+            TestContext.Current.CancellationToken);
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            "DELETE FROM Records WHERE CreatedBy = 'duplicate';",
+            TestContext.Current.CancellationToken);
+    }
+
+    private async Task<string> CreateAthleteAsync(
+        string prefix, string gender, DateOnly dateOfBirth, int countryId = 1)
+    {
+        string firstName = $"{prefix}{_suffix}";
+        string lastName = "Bf";
+
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
+            .WithFirstName(firstName)
+            .WithLastName(lastName)
+            .WithGender(gender)
+            .WithDateOfBirth(dateOfBirth)
+            .WithCountryId(countryId)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = Slug.Create($"{firstName} {lastName}");
+        _athleteSlugs.Add(slug);
+        return slug;
+    }
+
+    private async Task<int> CreateMeetAndGetIdAsync(bool isRaw, int? meetTypeId = null)
+    {
+        CreateMeetCommandBuilder builder = new CreateMeetCommandBuilder()
+            .WithIsRaw(isRaw)
+            .WithRecordsPossible(true)
+            .WithStartDate(new DateOnly(2025, 3, 15));
+
+        if (meetTypeId.HasValue)
+        {
+            builder.WithMeetTypeId(meetTypeId.Value);
+        }
+
+        CreateMeetCommand command = builder.Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+        _meetSlugs.Add(slug);
+
+        MeetDetails? meetDetails = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{slug}", CancellationToken.None);
+
+        return meetDetails!.MeetId;
+    }
+
+    private async Task<int> AddParticipantAsync(int meetId, string athleteSlug, decimal bodyWeight)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(bodyWeight)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        int participationId = result!.ParticipationId;
+        _participations.Add((meetId, participationId));
+        return participationId;
+    }
+
+    private async Task RecordAttemptAsync(
+        int meetId,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
     }
 }


### PR DESCRIPTION
## Summary

Migrates `BackfillRecordsTests` from raw SQL seeding to HTTP endpoint-based seeding, following the canonical `GetRecordsTests` pattern.

- Athletes, meets, participations, and attempts are now created via HTTP endpoints
- SQL retained only for states endpoints cannot produce: standard records, orphan records, corruption records, round-4 attempts, and the temporary `EraWeightCategory` link for the 105kg category
- Cleanup uses endpoint DELETE calls in reverse FK order, with SQL cleanup for SQL-only state
- Dedicated `BackfillRecordsTestsCollection` for xUnit isolation

Closes #445

## Test plan

- [x] All 12 BackfillRecordsTests pass
- [x] Full integration suite (398 tests) passes with zero regressions
- [x] Security, performance, code, and architecture reviews completed