### PR TITLE
refactor(webapi): move Ban entity into Athlete aggregate

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Athletes/Athlete.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Athlete.cs
@@ -1,5 +1,4 @@
 ﻿using KRAFT.Results.WebApi.Abstractions;
-using KRAFT.Results.WebApi.Features.Bans;
 using KRAFT.Results.WebApi.Features.Countries;
 using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.Features.Teams;

--- a/src/KRAFT.Results.WebApi/Features/Athletes/AthleteConfiguration.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/AthleteConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using KRAFT.Results.WebApi.Features.Bans;
-using KRAFT.Results.WebApi.ValueObjects;
+﻿using KRAFT.Results.WebApi.ValueObjects;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Ban.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Ban.cs
@@ -1,7 +1,6 @@
-﻿using KRAFT.Results.WebApi.Abstractions;
-using KRAFT.Results.WebApi.Features.Athletes;
+using KRAFT.Results.WebApi.Abstractions;
 
-namespace KRAFT.Results.WebApi.Features.Bans;
+namespace KRAFT.Results.WebApi.Features.Athletes;
 
 internal sealed class Ban
 {

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Ban.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Ban.cs
@@ -1,4 +1,4 @@
-using KRAFT.Results.WebApi.Abstractions;
+﻿using KRAFT.Results.WebApi.Abstractions;
 
 namespace KRAFT.Results.WebApi.Features.Athletes;
 

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanConfiguration.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanConfiguration.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace KRAFT.Results.WebApi.Features.Bans;
+namespace KRAFT.Results.WebApi.Features.Athletes;
 
 internal sealed class BanConfiguration : IEntityTypeConfiguration<Ban>
 {

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanConfiguration.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace KRAFT.Results.WebApi.Features.Athletes;

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanErrors.cs
@@ -1,6 +1,6 @@
-﻿using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Abstractions;
 
-namespace KRAFT.Results.WebApi.Features.Bans;
+namespace KRAFT.Results.WebApi.Features.Athletes;
 
 internal static class BanErrors
 {

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanErrors.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanErrors.cs
@@ -1,4 +1,4 @@
-using KRAFT.Results.WebApi.Abstractions;
+﻿using KRAFT.Results.WebApi.Abstractions;
 
 namespace KRAFT.Results.WebApi.Features.Athletes;
 

--- a/src/KRAFT.Results.WebApi/Migrations/20251127130413_InitialMigration.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20251127130413_InitialMigration.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20251127130826_Update_Users_Password_MaxLength_to_256.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20251127130826_Update_Users_Password_MaxLength_to_256.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20251128172809_Update_Athletes_Slug_NotNullable.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20251128172809_Update_Athletes_Slug_NotNullable.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20251129113851_Update_Teams_Slug_NotNullable.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20251129113851_Update_Teams_Slug_NotNullable.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20251129150246_Update_WeightCategories_Gender_NotNullable.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20251129150246_Update_WeightCategories_Gender_NotNullable.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20251129150516_Update_WeightCategories_Slug_NotNullable.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20251129150516_Update_WeightCategories_Slug_NotNullable.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20260326104637_AddEraWeightCategoryIndex.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260326104637_AddEraWeightCategoryIndex.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20260326123036_Seed_Era_Slugs.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260326123036_Seed_Era_Slugs.Designer.cs
@@ -222,7 +222,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20260327211601_RenameDisciplineProperty.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260327211601_RenameDisciplineProperty.Designer.cs
@@ -223,7 +223,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20260405231028_AddTextMaxLength.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260405231028_AddTextMaxLength.Designer.cs
@@ -223,7 +223,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/20260412101945_AddAthleteBansNavigation.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260412101945_AddAthleteBansNavigation.Designer.cs
@@ -223,7 +223,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()
@@ -1138,7 +1138,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.Navigation("Participation");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.HasOne("KRAFT.Results.WebApi.Features.Athletes.Athlete", "Athlete")
                         .WithMany("Bans")

--- a/src/KRAFT.Results.WebApi/Migrations/20260415120020_ReplaceMeetTypeWithMeetCategory.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260415120020_ReplaceMeetTypeWithMeetCategory.Designer.cs
@@ -223,7 +223,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()

--- a/src/KRAFT.Results.WebApi/Migrations/ResultsDbContextModelSnapshot.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/ResultsDbContextModelSnapshot.cs
@@ -220,7 +220,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.ToTable("Attempts", "dbo");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.Property<int>("BanId")
                         .ValueGeneratedOnAdd()
@@ -1122,7 +1122,7 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.Navigation("Participation");
                 });
 
-            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Bans.Ban", b =>
+            modelBuilder.Entity("KRAFT.Results.WebApi.Features.Athletes.Ban", b =>
                 {
                     b.HasOne("KRAFT.Results.WebApi.Features.Athletes.Athlete", "Athlete")
                         .WithMany("Bans")

--- a/tests/KRAFT.Results.WebApi.UnitTests/Builders/BanBuilder.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Builders/BanBuilder.cs
@@ -1,4 +1,4 @@
-using KRAFT.Results.WebApi.Features.Bans;
+using KRAFT.Results.WebApi.Features.Athletes;
 
 namespace KRAFT.Results.WebApi.UnitTests.Builders;
 

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/IsEligibleForRecord/IsEligibleForRecordTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/IsEligibleForRecord/IsEligibleForRecordTests.cs
@@ -1,4 +1,4 @@
-using KRAFT.Results.WebApi.Features.Bans;
+using KRAFT.Results.WebApi.Features.Athletes;
 using KRAFT.Results.WebApi.Features.Countries;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.UnitTests.Builders;

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/BanTests/Create.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/BanTests/Create.cs
@@ -1,9 +1,9 @@
 using KRAFT.Results.WebApi.Abstractions;
-using KRAFT.Results.WebApi.Features.Bans;
+using KRAFT.Results.WebApi.Features.Athletes;
 
 using Shouldly;
 
-namespace KRAFT.Results.WebApi.UnitTests.Features.Bans.BanTests;
+namespace KRAFT.Results.WebApi.UnitTests.Features.Athletes.BanTests;
 
 public sealed class Create
 {


### PR DESCRIPTION
## Summary

Moves `Ban`, `BanConfiguration`, and `BanErrors` from `Features/Bans/` into `Features/Athletes/` to reflect that Ban is a child entity of the Athlete aggregate with no independent lifecycle, endpoints, or service registration.

- Moved all three source files with namespace update to `Features.Athletes`
- Removed `Features/Bans/` folder entirely
- Updated EF Core migration Designer files and ModelSnapshot string literals
- Moved unit tests to `Features/Athletes/BanTests/`
- Updated all namespace imports across source and test projects

Closes #385