### PR TITLE
feat(webapi): compute places and team points automatically

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
@@ -13,6 +13,7 @@ using KRAFT.Results.WebApi.Features.Meets.RemoveParticipant;
 using KRAFT.Results.WebApi.Features.Meets.Update;
 using KRAFT.Results.WebApi.Features.Meets.UpdateAgeCategory;
 using KRAFT.Results.WebApi.Features.Meets.UpdateBodyWeight;
+using KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
 
 namespace KRAFT.Results.WebApi.Features.Meets;
 
@@ -32,6 +33,7 @@ internal static class MeetServices
         services.AddScoped<UpdateMeetHandler>();
         services.AddScoped<UpdateAgeCategoryHandler>();
         services.AddScoped<UpdateBodyWeightHandler>();
+        services.AddScoped<PlaceComputationService>();
         services.AddScoped<RecordAttemptHandler>();
         services.AddScoped<RemoveParticipantHandler>();
         services.AddScoped<DeleteMeetHandler>();

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
@@ -23,20 +23,20 @@ internal static class MeetServices
     {
         services.AddScoped<AddParticipantHandler>();
         services.AddScoped<CreateMeetHandler>();
-        services.AddScoped<GetMeetTypesHandler>();
-        services.AddScoped<GetMeetsHandler>();
+        services.AddScoped<DeleteMeetHandler>();
         services.AddScoped<GetMeetDetailsHandler>();
         services.AddScoped<GetMeetParticipationHandler>();
         services.AddScoped<GetMeetParticipationsHandler>();
-        services.AddScoped<GetMeetTeamPointsHandler>();
         services.AddScoped<GetMeetRecordsHandler>();
-        services.AddScoped<UpdateMeetHandler>();
-        services.AddScoped<UpdateAgeCategoryHandler>();
-        services.AddScoped<UpdateBodyWeightHandler>();
+        services.AddScoped<GetMeetsHandler>();
+        services.AddScoped<GetMeetTeamPointsHandler>();
+        services.AddScoped<GetMeetTypesHandler>();
         services.AddScoped<PlaceComputationService>();
         services.AddScoped<RecordAttemptHandler>();
         services.AddScoped<RemoveParticipantHandler>();
-        services.AddScoped<DeleteMeetHandler>();
+        services.AddScoped<UpdateAgeCategoryHandler>();
+        services.AddScoped<UpdateBodyWeightHandler>();
+        services.AddScoped<UpdateMeetHandler>();
 
         return services;
     }

--- a/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
@@ -3,6 +3,7 @@ using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Attempts;
 using KRAFT.Results.WebApi.Features.Participations;
+using KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.Services;
 
@@ -18,15 +19,18 @@ internal sealed class RecordAttemptHandler
     private readonly ILogger<RecordAttemptHandler> _logger;
     private readonly ResultsDbContext _dbContext;
     private readonly IHttpContextService _httpContextService;
+    private readonly PlaceComputationService _placeComputationService;
 
     public RecordAttemptHandler(
         ILogger<RecordAttemptHandler> logger,
         ResultsDbContext dbContext,
-        IHttpContextService httpContextService)
+        IHttpContextService httpContextService,
+        PlaceComputationService placeComputationService)
     {
         _logger = logger;
         _dbContext = dbContext;
         _httpContextService = httpContextService;
+        _placeComputationService = placeComputationService;
     }
 
     public async Task<Result> Handle(
@@ -45,6 +49,7 @@ internal sealed class RecordAttemptHandler
 
         Participation? participation = await _dbContext.Set<Participation>()
             .Include(p => p.Attempts)
+            .Include(p => p.Meet)
             .Where(p => p.ParticipationId == participationId)
             .FirstOrDefaultAsync(
                 p => p.MeetId == meetId,
@@ -99,6 +104,8 @@ internal sealed class RecordAttemptHandler
         }
 
         participation.RecalculateTotals();
+
+        await _placeComputationService.ComputePlacesAsync(participation, cancellationToken);
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/KRAFT.Results.WebApi/Features/Meets/RemoveParticipant/RemoveParticipantHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/RemoveParticipant/RemoveParticipantHandler.cs
@@ -2,6 +2,7 @@ using System.Data;
 
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Participations;
+using KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
 using KRAFT.Results.WebApi.Features.Records;
 using KRAFT.Results.WebApi.Features.Records.ComputeRecords;
 
@@ -15,21 +16,25 @@ internal sealed class RemoveParticipantHandler
     private readonly ILogger<RemoveParticipantHandler> _logger;
     private readonly ResultsDbContext _dbContext;
     private readonly RecordComputationService _recordComputationService;
+    private readonly PlaceComputationService _placeComputationService;
 
     public RemoveParticipantHandler(
         ILogger<RemoveParticipantHandler> logger,
         ResultsDbContext dbContext,
-        RecordComputationService recordComputationService)
+        RecordComputationService recordComputationService,
+        PlaceComputationService placeComputationService)
     {
         _logger = logger;
         _dbContext = dbContext;
         _recordComputationService = recordComputationService;
+        _placeComputationService = placeComputationService;
     }
 
     public async Task<Result> Handle(int meetId, int participationId, CancellationToken cancellationToken)
     {
         Participation? participation = await _dbContext.Set<Participation>()
             .Include(p => p.Attempts)
+            .Include(p => p.Meet)
             .Where(p => p.ParticipationId == participationId)
             .Where(p => p.MeetId == meetId)
             .FirstOrDefaultAsync(cancellationToken);
@@ -39,6 +44,11 @@ internal sealed class RemoveParticipantHandler
             _logger.LogWarning("Participation {ParticipationId} in meet {MeetId} was not found", participationId, meetId);
             return Result.Failure(MeetErrors.ParticipationNotFound);
         }
+
+        int groupMeetId = participation.MeetId;
+        int groupWeightCategoryId = participation.WeightCategoryId;
+        int groupAgeCategoryId = participation.AgeCategoryId;
+        bool calcPlaces = participation.Meet.CalcPlaces;
 
         List<int> attemptIds = participation.Attempts
             .Select(a => a.AttemptId)
@@ -70,6 +80,15 @@ internal sealed class RemoveParticipantHandler
             await _dbContext.SaveChangesAsync(cancellationToken);
 
             _dbContext.Set<Participation>().Remove(participation);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            await _placeComputationService.RecomputeGroupAsync(
+                groupMeetId,
+                groupWeightCategoryId,
+                groupAgeCategoryId,
+                calcPlaces,
+                cancellationToken);
+
             await _dbContext.SaveChangesAsync(cancellationToken);
 
             if (affectedSlots.Count > 0)

--- a/src/KRAFT.Results.WebApi/Features/Meets/UpdateBodyWeight/UpdateBodyWeightHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/UpdateBodyWeight/UpdateBodyWeightHandler.cs
@@ -1,6 +1,7 @@
 using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Participations;
+using KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.Services;
 
@@ -13,15 +14,18 @@ internal sealed class UpdateBodyWeightHandler
     private readonly ILogger<UpdateBodyWeightHandler> _logger;
     private readonly ResultsDbContext _dbContext;
     private readonly IHttpContextService _httpContextService;
+    private readonly PlaceComputationService _placeComputationService;
 
     public UpdateBodyWeightHandler(
         ILogger<UpdateBodyWeightHandler> logger,
         ResultsDbContext dbContext,
-        IHttpContextService httpContextService)
+        IHttpContextService httpContextService,
+        PlaceComputationService placeComputationService)
     {
         _logger = logger;
         _dbContext = dbContext;
         _httpContextService = httpContextService;
+        _placeComputationService = placeComputationService;
     }
 
     public async Task<Result> Handle(
@@ -31,6 +35,7 @@ internal sealed class UpdateBodyWeightHandler
         CancellationToken cancellationToken)
     {
         Participation? participation = await _dbContext.Set<Participation>()
+            .Include(p => p.Meet)
             .FirstOrDefaultAsync(
                 p => p.ParticipationId == participationId && p.MeetId == meetId,
                 cancellationToken);
@@ -59,6 +64,8 @@ internal sealed class UpdateBodyWeightHandler
         {
             return updateResult;
         }
+
+        await _placeComputationService.ComputePlacesAsync(participation, cancellationToken);
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
+
+internal sealed class PlaceComputationService(ResultsDbContext dbContext)
+{
+    public async Task ComputePlacesAsync(Participation participation, CancellationToken cancellationToken)
+    {
+        if (!participation.Meet.CalcPlaces)
+        {
+            return;
+        }
+
+        List<Participation> groupParticipations = await dbContext.Set<Participation>()
+            .Include(p => p.Attempts)
+            .Where(p => p.MeetId == participation.MeetId)
+            .Where(p => p.WeightCategoryId == participation.WeightCategoryId)
+            .Where(p => p.AgeCategoryId == participation.AgeCategoryId)
+            .ToListAsync(cancellationToken);
+
+        List<Participation> ranked = groupParticipations
+            .Where(p => p.Total > 0)
+            .OrderByDescending(p => p.Total)
+            .ThenBy(p => p.Weight.Value)
+            .ThenBy(p => p.LotNo)
+            .ToList();
+
+        int rank = 1;
+
+        foreach (Participation p in ranked)
+        {
+            p.UpdateRanking(rank);
+            rank++;
+        }
+
+        foreach (Participation p in groupParticipations.Where(p => p.Total == 0 && p.Disqualified))
+        {
+            p.UpdateRanking(0);
+        }
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -11,13 +11,38 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
             return;
         }
 
+        await RecomputeGroupAsync(
+            participation.MeetId,
+            participation.WeightCategoryId,
+            participation.AgeCategoryId,
+            calcPlaces: true,
+            cancellationToken);
+    }
+
+    public async Task RecomputeGroupAsync(
+        int meetId,
+        int weightCategoryId,
+        int ageCategoryId,
+        bool calcPlaces,
+        CancellationToken cancellationToken)
+    {
+        if (!calcPlaces)
+        {
+            return;
+        }
+
         List<Participation> groupParticipations = await dbContext.Set<Participation>()
             .Include(p => p.Attempts)
-            .Where(p => p.MeetId == participation.MeetId)
-            .Where(p => p.WeightCategoryId == participation.WeightCategoryId)
-            .Where(p => p.AgeCategoryId == participation.AgeCategoryId)
+            .Where(p => p.MeetId == meetId)
+            .Where(p => p.WeightCategoryId == weightCategoryId)
+            .Where(p => p.AgeCategoryId == ageCategoryId)
             .ToListAsync(cancellationToken);
 
+        RankGroup(groupParticipations);
+    }
+
+    private static void RankGroup(List<Participation> groupParticipations)
+    {
         List<Participation> ranked = groupParticipations
             .Where(p => p.Total > 0)
             .OrderByDescending(p => p.Total)

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -4,7 +4,7 @@ namespace KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
 
 internal sealed class PlaceComputationService(ResultsDbContext dbContext)
 {
-    public async Task ComputePlacesAsync(Participation participation, CancellationToken cancellationToken)
+    internal async Task ComputePlacesAsync(Participation participation, CancellationToken cancellationToken)
     {
         if (!participation.Meet.CalcPlaces)
         {
@@ -19,7 +19,7 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
             cancellationToken);
     }
 
-    public async Task RecomputeGroupAsync(
+    internal async Task RecomputeGroupAsync(
         int meetId,
         int weightCategoryId,
         int ageCategoryId,
@@ -58,7 +58,7 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
             rank++;
         }
 
-        foreach (Participation p in groupParticipations.Where(p => p.Total == 0 && p.Disqualified))
+        foreach (Participation p in groupParticipations.Where(p => p.Total == 0))
         {
             p.UpdateRanking(0);
         }

--- a/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
@@ -4,6 +4,7 @@ using KRAFT.Results.WebApi.Features.AgeCategories;
 using KRAFT.Results.WebApi.Features.Athletes;
 using KRAFT.Results.WebApi.Features.Attempts;
 using KRAFT.Results.WebApi.Features.Meets;
+using KRAFT.Results.WebApi.Features.TeamCompetition;
 using KRAFT.Results.WebApi.Features.Teams;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.Features.WeightCategories;
@@ -152,6 +153,22 @@ internal sealed class Participation : AggregateRoot
     {
         attempt.Update(weight, good, modifiedBy);
         Raise(new AttemptRecordedEvent(this, attempt));
+    }
+
+    internal void UpdateRanking(int place)
+    {
+        Place = place;
+
+        int[] pointValues = TeamStandingsBuilder.TiebreakerPointValues;
+
+        if (place <= 0 || place > pointValues.Length)
+        {
+            TeamPoints = 0;
+        }
+        else
+        {
+            TeamPoints = pointValues[place - 1];
+        }
     }
 
     internal void RecalculateTotals()

--- a/src/KRAFT.Results.WebApi/Features/TeamCompetition/TeamStandingsBuilder.cs
+++ b/src/KRAFT.Results.WebApi/Features/TeamCompetition/TeamStandingsBuilder.cs
@@ -9,7 +9,7 @@ internal static class TeamStandingsBuilder
     internal const int BestNModern = 5;
     internal const int BestNLegacy = 6;
 
-    private static readonly int[] TiebreakerPointValues = [12, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    internal static readonly int[] TiebreakerPointValues = [12, 9, 8, 7, 6, 5, 4, 3, 2, 1];
 
     internal static int GetBestN(int year) =>
         year >= BestNThresholdYear ? BestNModern : BestNLegacy;

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -61,18 +61,19 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
         _bobParticipationId = await AddParticipantAsync(bobSlug);
         _annaParticipationId = await AddParticipantAsync(annaSlug);
 
+        // Charlie: Total=570 (195+125+250), BodyWeight=82.0 → Place=1 (added first, lower ParticipationId)
         await RecordFullTotalAsync(_charlieParticipationId, 195.0m, 125.0m, 250.0m);
+
+        // Delta: Total=570 (195+125+250), BodyWeight=82.0 → Place=2 (added second, higher ParticipationId)
         await RecordFullTotalAsync(_deltaParticipationId, 195.0m, 125.0m, 250.0m);
+
+        // Bob: Total=500 (170+110+220), BodyWeight=82.0 → Place=3
         await RecordFullTotalAsync(_bobParticipationId, 170.0m, 110.0m, 220.0m);
 
+        // Anna: 3 failed squats → Disqualified=true, Place=0
         await RecordAttempt(_annaParticipationId, Discipline.Squat, 1, 100.0m, false);
         await RecordAttempt(_annaParticipationId, Discipline.Squat, 2, 100.0m, false);
         await RecordAttempt(_annaParticipationId, Discipline.Squat, 3, 100.0m, false);
-
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET Place = 1 WHERE ParticipationId IN ({_charlieParticipationId}, {_deltaParticipationId})");
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET Place = 3 WHERE ParticipationId = {_bobParticipationId}");
     }
 
     public async ValueTask DisposeAsync()
@@ -147,7 +148,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
     }
 
     [Fact]
-    public async Task ParticipantsWithSameRankAreSortedAlphabetically()
+    public async Task PlacedParticipantsAreRankedByTotalDescending()
     {
         // Arrange
 
@@ -157,12 +158,18 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
 
         // Assert
         participations.ShouldNotBeNull();
-        List<MeetParticipation> tiedAtFirst = participations
-            .Where(p => p.Rank == 1)
+        List<MeetParticipation> placed = participations
+            .Where(p => p.Rank > 0)
             .ToList();
-        tiedAtFirst.Count.ShouldBe(2);
-        tiedAtFirst[0].Athlete.ShouldBe(_charlieFullName);
-        tiedAtFirst[1].Athlete.ShouldBe(_deltaFullName);
+        placed.Count.ShouldBe(3);
+
+        // Charlie and Delta have the same total (570), so they occupy ranks 1 and 2 in insertion order
+        placed[0].Rank.ShouldBe(1);
+        placed[1].Rank.ShouldBe(2);
+
+        // Bob has a lower total (500) and gets rank 3
+        placed[2].Rank.ShouldBe(3);
+        placed[2].Athlete.ShouldBe(_bobFullName);
     }
 
     [Fact]

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetParticipationsTests.cs
@@ -148,7 +148,7 @@ public sealed class GetMeetParticipationsTests(CollectionFixture fixture) : IAsy
     }
 
     [Fact]
-    public async Task PlacedParticipantsAreRankedByTotalDescending()
+    public async Task RanksParticipantsByTotal_ThenByBodyWeight_ThenByLotNo()
     {
         // Arrange
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetTeamPointsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetTeamPointsTests.cs
@@ -18,6 +18,30 @@ public sealed class GetMeetTeamPointsTests(CollectionFixture fixture) : IAsyncLi
 {
     private const string BasePath = "/meets";
 
+    // 2025 meet — men (body weight 82.0m): Place 1→12pts, Place 2→9pts, Place 3→8pts
+    private const decimal AlphaMaleSquat = 100.0m;
+    private const decimal AlphaMaleBench = 100.0m;
+    private const decimal AlphaMaleDeadlift = 100.0m;
+
+    private const decimal NoTeamSquat = 90.0m;
+    private const decimal NoTeamBench = 80.0m;
+    private const decimal NoTeamDeadlift = 80.0m;
+
+    private const decimal BetaMaleSquat = 70.0m;
+    private const decimal BetaMaleBench = 60.0m;
+    private const decimal BetaMaleDeadlift = 70.0m;
+
+    // 2025 meet — women (body weight 57.0m): Place 1→12pts, Place 2→9pts
+    private const decimal AlphaFemaleSquat = 90.0m;
+    private const decimal AlphaFemaleBench = 70.0m;
+    private const decimal AlphaFemaleDeadlift = 100.0m;
+
+    private const decimal BetaFemaleSquat = 80.0m;
+    private const decimal BetaFemaleBench = 60.0m;
+    private const decimal BetaFemaleDeadlift = 80.0m;
+
+    private const int ExpectedBestN2026TotalPoints = 42; // best 5 of 6: 12+9+8+7+6
+
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
     private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
     private readonly string _suffix = UniqueShortCode.Next();
@@ -77,37 +101,57 @@ public sealed class GetMeetTeamPointsTests(CollectionFixture fixture) : IAsyncLi
         int betaFemalePid = await AddParticipantAsync(tc2025MeetId, betaFemaleSlug, _betaTeamId, 57.0m);
         int dqAlphaMalePid = await AddParticipantAsync(tc2025MeetId, dqAlphaMaleSlug, _alphaTeamId);
         int noTeamPid = await AddParticipantAsync(tc2025MeetId, noTeamSlug, teamId: null);
-        int zeroPtsPid = await AddParticipantAsync(tc2025MeetId, zeroPtsSlug, _gammaTeamId);
+        await AddParticipantAsync(tc2025MeetId, zeroPtsSlug, _gammaTeamId);
 
-        // DQ the Alpha male participant via 3 failed squat attempts (triggers automatic DQ via RecalculateTotals)
+        // DQ the dqAlphaMale participant via 3 failed squat attempts → Place=0, TeamPoints=0
         await RecordAttemptAsync(tc2025MeetId, dqAlphaMalePid, Discipline.Squat, 1, 100.0m, good: false);
         await RecordAttemptAsync(tc2025MeetId, dqAlphaMalePid, Discipline.Squat, 2, 100.0m, good: false);
         await RecordAttemptAsync(tc2025MeetId, dqAlphaMalePid, Discipline.Squat, 3, 100.0m, good: false);
 
-        // Set TeamPoints and Place via SQL (no computation endpoints exist)
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = 12, Place = 1 WHERE ParticipationId = {alphaMalePid}");
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = 8, Place = 3 WHERE ParticipationId = {betaMalePid}");
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = 12, Place = 1 WHERE ParticipationId = {alphaFemalePid}");
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = 9, Place = 2 WHERE ParticipationId = {betaFemalePid}");
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = 7 WHERE ParticipationId = {dqAlphaMalePid}");
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = 5 WHERE ParticipationId = {noTeamPid}");
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = 0 WHERE ParticipationId = {zeroPtsPid}");
+        // Record attempts for 2025 men (same weight category, 82.0m body weight)
+        // alphaMale: Total=300 → Place 1 → TeamPoints=12
+        await RecordFullTotalAsync(tc2025MeetId, alphaMalePid, AlphaMaleSquat, AlphaMaleBench, AlphaMaleDeadlift);
 
-        // Create 6 male athletes for 2026 meet and add participations
-        for (int i = 1; i <= 6; i++)
-        {
-            string slug = await CreateAthleteAsync($"Alpha26M{i}", "m");
-            int pid = await AddParticipantAsync(tc2026MeetId, slug, _alphaTeamId);
-            await fixture.ExecuteSqlAsync(
-                $"UPDATE Participations SET TeamPoints = 12, Place = {i} WHERE ParticipationId = {pid}");
-        }
+        // noTeam: Total=250 → Place 2 → TeamPoints=9 (no team, excluded from standings)
+        await RecordFullTotalAsync(tc2025MeetId, noTeamPid, NoTeamSquat, NoTeamBench, NoTeamDeadlift);
+
+        // betaMale: Total=200 → Place 3 → TeamPoints=8
+        await RecordFullTotalAsync(tc2025MeetId, betaMalePid, BetaMaleSquat, BetaMaleBench, BetaMaleDeadlift);
+
+        // zeroPts: no attempts → Total=0, TeamPoints=null → excluded from standings (Gamma hidden)
+
+        // Record attempts for 2025 women (same weight category, 57.0m body weight)
+        // alphaFemale: Total=260 → Place 1 → TeamPoints=12
+        await RecordFullTotalAsync(tc2025MeetId, alphaFemalePid, AlphaFemaleSquat, AlphaFemaleBench, AlphaFemaleDeadlift);
+
+        // betaFemale: Total=220 → Place 2 → TeamPoints=9
+        await RecordFullTotalAsync(tc2025MeetId, betaFemalePid, BetaFemaleSquat, BetaFemaleBench, BetaFemaleDeadlift);
+
+        // Create 6 male athletes for 2026 meet with descending totals → places 1–6 → points 12,9,8,7,6,5
+        // Best 5 of 6 points = 12+9+8+7+6 = 42 (ExpectedBestN2026TotalPoints)
+        string alpha26M1Slug = await CreateAthleteAsync("Alpha26M1", "m");
+        int alpha26M1Pid = await AddParticipantAsync(tc2026MeetId, alpha26M1Slug, _alphaTeamId);
+        await RecordFullTotalAsync(tc2026MeetId, alpha26M1Pid, 200.0m, 150.0m, 250.0m); // Total=600 → Place 1 → 12pts
+
+        string alpha26M2Slug = await CreateAthleteAsync("Alpha26M2", "m");
+        int alpha26M2Pid = await AddParticipantAsync(tc2026MeetId, alpha26M2Slug, _alphaTeamId);
+        await RecordFullTotalAsync(tc2026MeetId, alpha26M2Pid, 190.0m, 140.0m, 220.0m); // Total=550 → Place 2 → 9pts
+
+        string alpha26M3Slug = await CreateAthleteAsync("Alpha26M3", "m");
+        int alpha26M3Pid = await AddParticipantAsync(tc2026MeetId, alpha26M3Slug, _alphaTeamId);
+        await RecordFullTotalAsync(tc2026MeetId, alpha26M3Pid, 170.0m, 130.0m, 200.0m); // Total=500 → Place 3 → 8pts
+
+        string alpha26M4Slug = await CreateAthleteAsync("Alpha26M4", "m");
+        int alpha26M4Pid = await AddParticipantAsync(tc2026MeetId, alpha26M4Slug, _alphaTeamId);
+        await RecordFullTotalAsync(tc2026MeetId, alpha26M4Pid, 150.0m, 120.0m, 180.0m); // Total=450 → Place 4 → 7pts
+
+        string alpha26M5Slug = await CreateAthleteAsync("Alpha26M5", "m");
+        int alpha26M5Pid = await AddParticipantAsync(tc2026MeetId, alpha26M5Slug, _alphaTeamId);
+        await RecordFullTotalAsync(tc2026MeetId, alpha26M5Pid, 135.0m, 110.0m, 155.0m); // Total=400 → Place 5 → 6pts
+
+        string alpha26M6Slug = await CreateAthleteAsync("Alpha26M6", "m");
+        int alpha26M6Pid = await AddParticipantAsync(tc2026MeetId, alpha26M6Slug, _alphaTeamId);
+        await RecordFullTotalAsync(tc2026MeetId, alpha26M6Pid, 120.0m, 100.0m, 130.0m); // Total=350 → Place 6 → 5pts
     }
 
     public async ValueTask DisposeAsync()
@@ -233,7 +277,7 @@ public sealed class GetMeetTeamPointsTests(CollectionFixture fixture) : IAsyncLi
     [Fact]
     public async Task AppliesBestNLimit_PerMeet()
     {
-        // Arrange — 6 male athletes all scoring 12 -> best 5 -> 5*12 = 60
+        // Arrange — 6 male athletes with places 1–6 → points 12,9,8,7,6,5; best 5 = 12+9+8+7+6 = 42
 
         // Act
         MeetTeamPointsResponse? response = await _httpClient.GetFromJsonAsync<MeetTeamPointsResponse>(
@@ -243,14 +287,14 @@ public sealed class GetMeetTeamPointsTests(CollectionFixture fixture) : IAsyncLi
         response.ShouldNotBeNull();
         response.Men.ShouldNotBeEmpty();
         TeamCompetitionStanding alpha = response.Men.First(s => s.TeamName == _alphaTeamName);
-        alpha.TotalPoints.ShouldBe(60);
+        alpha.TotalPoints.ShouldBe(ExpectedBestN2026TotalPoints);
     }
 
     [Fact]
     public async Task ExcludesDisqualifiedParticipations()
     {
-        // Arrange — DQ'd participation with TeamPoints=7 for Alpha
-        // Alpha men should have 12 (not 12+7=19)
+        // Arrange — DQ'd Alpha male has Place=0, TeamPoints=0
+        // Alpha men total should be 12 (from Place 1 only, not including DQ'd participant)
 
         // Act
         MeetTeamPointsResponse? response = await _httpClient.GetFromJsonAsync<MeetTeamPointsResponse>(
@@ -277,16 +321,28 @@ public sealed class GetMeetTeamPointsTests(CollectionFixture fixture) : IAsyncLi
     [Fact]
     public async Task ExcludesParticipationsWithZeroTeamPoints()
     {
-        // Arrange — Gamma has only a participation with TeamPoints=0
-        // If the TeamPoints > 0 filter were removed, Gamma would appear as a third team
+        // Arrange — Gamma has only a participation with no recorded attempts (TeamPoints=null)
+        // If the TeamPoints filter were removed, Gamma would appear as a third team
 
         // Act
         MeetTeamPointsResponse? response = await _httpClient.GetFromJsonAsync<MeetTeamPointsResponse>(
             $"{BasePath}/{_tc2025MeetSlug}/team-points", CancellationToken.None);
 
-        // Assert — only Alpha and Beta appear; Gamma (with zero points) is excluded
+        // Assert — only Alpha and Beta appear; Gamma (with no team points) is excluded
         response!.Men.Count.ShouldBe(2);
         response.Men.ShouldNotContain(s => s.TeamSlug == _gammaTeamSlug);
+    }
+
+    private async Task RecordFullTotalAsync(
+        int meetId,
+        int participationId,
+        decimal squat,
+        decimal bench,
+        decimal deadlift)
+    {
+        await RecordAttemptAsync(meetId, participationId, Discipline.Squat, 1, squat);
+        await RecordAttemptAsync(meetId, participationId, Discipline.Bench, 1, bench);
+        await RecordAttemptAsync(meetId, participationId, Discipline.Deadlift, 1, deadlift);
     }
 
     private async Task RecordAttemptAsync(int meetId, int participationId, Discipline discipline, int round, decimal weight, bool good = true)

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
@@ -373,8 +373,6 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
                 CancellationToken.None);
 
         // Assert — Place defaults to -1; with CalcPlaces=false it must not be modified
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
-
         participations.ShouldNotBeNull();
         MeetParticipation? p1 = participations.FirstOrDefault(p => p.ParticipationId == participation1Id);
         MeetParticipation? p2 = participations.FirstOrDefault(p => p.ParticipationId == participation2Id);
@@ -383,6 +381,8 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         p2.ShouldNotBeNull();
         p1.Rank.ShouldBe(-1);
         p2.Rank.ShouldBe(-1);
+
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
     }
 
     [Fact]
@@ -413,8 +413,6 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
                 CancellationToken.None);
 
         // Assert
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
-
         participations.ShouldNotBeNull();
         MeetParticipation? dq = participations.FirstOrDefault(p => p.ParticipationId == dqParticipationId);
         MeetParticipation? ranked = participations.FirstOrDefault(p => p.ParticipationId == rankedParticipationId);
@@ -423,6 +421,8 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         ranked.ShouldNotBeNull();
         dq.Rank.ShouldBe(0);
         ranked.Rank.ShouldBe(1);
+
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
     }
 
     [Fact]
@@ -454,8 +454,6 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
                 CancellationToken.None);
 
         // Assert
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
-
         participations.ShouldNotBeNull();
         MeetParticipation? lighter = participations.FirstOrDefault(p => p.ParticipationId == lighterParticipationId);
         MeetParticipation? heavier = participations.FirstOrDefault(p => p.ParticipationId == heavierParticipationId);
@@ -464,6 +462,8 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         heavier.ShouldNotBeNull();
         lighter.Rank.ShouldBe(1);
         heavier.Rank.ShouldBe(2);
+
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
     }
 
     [Fact]
@@ -494,8 +494,6 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
             .ToListAsync(CancellationToken.None);
 
         // Assert
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
-
         Participation? higher = participationEntities.FirstOrDefault(p => p.ParticipationId == higherTotalParticipationId);
         Participation? lower = participationEntities.FirstOrDefault(p => p.ParticipationId == lowerTotalParticipationId);
 
@@ -503,6 +501,8 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         lower.ShouldNotBeNull();
         higher.TeamPoints.ShouldBe(12);
         lower.TeamPoints.ShouldBe(9);
+
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
     }
 
     private static string Path(int meetId, int participationId, Discipline discipline, int round) =>

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
@@ -309,6 +309,40 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
     }
 
+    [Fact]
+    public async Task ComputesPlace_AfterAttemptRecorded()
+    {
+        // Arrange
+        int participation1Id = await AddParticipantAsync();
+        int participation2Id = await AddParticipantAsync();
+
+        // Participant 1 — higher total (300kg): should be rank 1
+        await RecordAttempt(participation1Id, Discipline.Squat, 1, 100.0m, true);
+        await RecordAttempt(participation1Id, Discipline.Bench, 1, 50.0m, true);
+        await RecordAttempt(participation1Id, Discipline.Deadlift, 1, 150.0m, true);
+
+        // Participant 2 — lower total (240kg): should be rank 2
+        await RecordAttempt(participation2Id, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttempt(participation2Id, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttempt(participation2Id, Discipline.Deadlift, 1, 120.0m, true);
+
+        // Act
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{_meetSlug}/participations",
+                CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        MeetParticipation? p1 = participations.FirstOrDefault(p => p.ParticipationId == participation1Id);
+        MeetParticipation? p2 = participations.FirstOrDefault(p => p.ParticipationId == participation2Id);
+
+        p1.ShouldNotBeNull();
+        p2.ShouldNotBeNull();
+        p1.Rank.ShouldBe(1);
+        p2.Rank.ShouldBe(2);
+    }
+
     private static string Path(int meetId, int participationId, Discipline discipline, int round) =>
         $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}";
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
@@ -4,9 +4,14 @@ using System.Net.Http.Json;
 using KRAFT.Results.Contracts;
 using KRAFT.Results.Contracts.Athletes;
 using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi;
+using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 using KRAFT.Results.WebApi.ValueObjects;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 using Shouldly;
 
@@ -343,8 +348,185 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         p2.Rank.ShouldBe(2);
     }
 
+    [Fact]
+    public async Task PlaceNotComputed_WhenCalcPlacesFalse()
+    {
+        // Arrange
+        (int meetId, string meetSlug) = await CreateMeetAsync(
+            new CreateMeetCommandBuilder().WithCalcPlaces(false));
+
+        int participation1Id = await AddParticipantToMeetAsync(meetId);
+        int participation2Id = await AddParticipantToMeetAsync(meetId);
+
+        await RecordAttemptForMeet(meetId, participation1Id, Discipline.Squat, 1, 100.0m, true);
+        await RecordAttemptForMeet(meetId, participation1Id, Discipline.Bench, 1, 50.0m, true);
+        await RecordAttemptForMeet(meetId, participation1Id, Discipline.Deadlift, 1, 150.0m, true);
+
+        await RecordAttemptForMeet(meetId, participation2Id, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, participation2Id, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, participation2Id, Discipline.Deadlift, 1, 120.0m, true);
+
+        // Act
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{meetSlug}/participations",
+                CancellationToken.None);
+
+        // Assert — Place defaults to -1; with CalcPlaces=false it must not be modified
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        MeetParticipation? p1 = participations.FirstOrDefault(p => p.ParticipationId == participation1Id);
+        MeetParticipation? p2 = participations.FirstOrDefault(p => p.ParticipationId == participation2Id);
+
+        p1.ShouldNotBeNull();
+        p2.ShouldNotBeNull();
+        p1.Rank.ShouldBe(-1);
+        p2.Rank.ShouldBe(-1);
+    }
+
+    [Fact]
+    public async Task DisqualifiedParticipantReceivesPlaceZero_AfterBombOut()
+    {
+        // Arrange
+        (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
+
+        int dqParticipationId = await AddParticipantToMeetAsync(meetId);
+        int rankedParticipationId = await AddParticipantToMeetAsync(meetId);
+
+        // DQ participant — all bench attempts fail
+        await RecordAttemptForMeet(meetId, dqParticipationId, Discipline.Squat, 1, 100.0m, true);
+        await RecordAttemptForMeet(meetId, dqParticipationId, Discipline.Bench, 1, 60.0m, false);
+        await RecordAttemptForMeet(meetId, dqParticipationId, Discipline.Bench, 2, 60.0m, false);
+        await RecordAttemptForMeet(meetId, dqParticipationId, Discipline.Bench, 3, 60.0m, false);
+        await RecordAttemptForMeet(meetId, dqParticipationId, Discipline.Deadlift, 1, 150.0m, true);
+
+        // Ranked participant — valid total
+        await RecordAttemptForMeet(meetId, rankedParticipationId, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, rankedParticipationId, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, rankedParticipationId, Discipline.Deadlift, 1, 120.0m, true);
+
+        // Act
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{meetSlug}/participations",
+                CancellationToken.None);
+
+        // Assert
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        MeetParticipation? dq = participations.FirstOrDefault(p => p.ParticipationId == dqParticipationId);
+        MeetParticipation? ranked = participations.FirstOrDefault(p => p.ParticipationId == rankedParticipationId);
+
+        dq.ShouldNotBeNull();
+        ranked.ShouldNotBeNull();
+        dq.Rank.ShouldBe(0);
+        ranked.Rank.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task LighterParticipantRanksHigher_WhenTotalsAreEqual()
+    {
+        // Arrange
+        (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
+
+        // Lighter participant (75.0 kg) — same total as heavier, should win tiebreaker
+        // Both use body weights above 74.01 to land in the same 83 kg weight category
+        int lighterParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 75.0m);
+
+        // Heavier participant (80.0 kg)
+        int heavierParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 80.0m);
+
+        // Both record the same total (240 kg)
+        await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Deadlift, 1, 120.0m, true);
+
+        await RecordAttemptForMeet(meetId, heavierParticipationId, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, heavierParticipationId, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, heavierParticipationId, Discipline.Deadlift, 1, 120.0m, true);
+
+        // Act
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{meetSlug}/participations",
+                CancellationToken.None);
+
+        // Assert
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        MeetParticipation? lighter = participations.FirstOrDefault(p => p.ParticipationId == lighterParticipationId);
+        MeetParticipation? heavier = participations.FirstOrDefault(p => p.ParticipationId == heavierParticipationId);
+
+        lighter.ShouldNotBeNull();
+        heavier.ShouldNotBeNull();
+        lighter.Rank.ShouldBe(1);
+        heavier.Rank.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task TeamPoints_MapToTiebreakerPointValues_ByPlace()
+    {
+        // Arrange
+        (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
+
+        int higherTotalParticipationId = await AddParticipantToMeetAsync(meetId);
+        int lowerTotalParticipationId = await AddParticipantToMeetAsync(meetId);
+
+        // Higher total → place 1 → 12 TeamPoints
+        await RecordAttemptForMeet(meetId, higherTotalParticipationId, Discipline.Squat, 1, 100.0m, true);
+        await RecordAttemptForMeet(meetId, higherTotalParticipationId, Discipline.Bench, 1, 50.0m, true);
+        await RecordAttemptForMeet(meetId, higherTotalParticipationId, Discipline.Deadlift, 1, 150.0m, true);
+
+        // Lower total → place 2 → 9 TeamPoints
+        await RecordAttemptForMeet(meetId, lowerTotalParticipationId, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, lowerTotalParticipationId, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, lowerTotalParticipationId, Discipline.Deadlift, 1, 120.0m, true);
+
+        // Act — read TeamPoints directly from the database (no read endpoint exposes per-participation TeamPoints)
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        List<Participation> participationEntities = await dbContext.Set<Participation>()
+            .Where(p => p.ParticipationId == higherTotalParticipationId || p.ParticipationId == lowerTotalParticipationId)
+            .ToListAsync(CancellationToken.None);
+
+        // Assert
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+
+        Participation? higher = participationEntities.FirstOrDefault(p => p.ParticipationId == higherTotalParticipationId);
+        Participation? lower = participationEntities.FirstOrDefault(p => p.ParticipationId == lowerTotalParticipationId);
+
+        higher.ShouldNotBeNull();
+        lower.ShouldNotBeNull();
+        higher.TeamPoints.ShouldBe(12);
+        lower.TeamPoints.ShouldBe(9);
+    }
+
     private static string Path(int meetId, int participationId, Discipline discipline, int round) =>
         $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}";
+
+    private async Task<(int MeetId, string MeetSlug)> CreateMeetAsync(CreateMeetCommandBuilder builder)
+    {
+        CreateMeetCommand command = builder.Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{slug}",
+            CancellationToken.None);
+
+        return (details!.MeetId, slug);
+    }
 
     private async Task RecordAttempt(int participationId, Discipline discipline, int round, decimal weight, bool good)
     {
@@ -355,6 +537,27 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
 
         HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
             Path(_meetId, participationId, discipline, round),
+            command,
+            CancellationToken.None);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    private async Task RecordAttemptForMeet(
+        int meetId,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight,
+        bool good)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .WithGood(good)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
+            Path(meetId, participationId, discipline, round),
             command,
             CancellationToken.None);
 
@@ -379,6 +582,36 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
 
         HttpResponseMessage participantResponse = await _authorizedHttpClient.PostAsJsonAsync(
             $"/meets/{_meetId}/participants",
+            participantCommand,
+            CancellationToken.None);
+
+        participantResponse.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await participantResponse.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        return result!.ParticipationId;
+    }
+
+    private async Task<int> AddParticipantToMeetAsync(int meetId, decimal bodyWeight = 80.5m)
+    {
+        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
+        HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes",
+            athleteCommand,
+            CancellationToken.None);
+
+        athleteResponse.EnsureSuccessStatusCode();
+
+        string athleteSlug = Slug.Create($"{athleteCommand.FirstName} {athleteCommand.LastName}");
+
+        AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(bodyWeight)
+            .Build();
+
+        HttpResponseMessage participantResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants",
             participantCommand,
             CancellationToken.None);
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RecordAttemptTests.cs
@@ -355,8 +355,8 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         (int meetId, string meetSlug) = await CreateMeetAsync(
             new CreateMeetCommandBuilder().WithCalcPlaces(false));
 
-        int participation1Id = await AddParticipantToMeetAsync(meetId);
-        int participation2Id = await AddParticipantToMeetAsync(meetId);
+        (int participation1Id, string athlete1Slug) = await AddParticipantToMeetAsync(meetId);
+        (int participation2Id, string athlete2Slug) = await AddParticipantToMeetAsync(meetId);
 
         await RecordAttemptForMeet(meetId, participation1Id, Discipline.Squat, 1, 100.0m, true);
         await RecordAttemptForMeet(meetId, participation1Id, Discipline.Bench, 1, 50.0m, true);
@@ -382,7 +382,12 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         p1.Rank.ShouldBe(-1);
         p2.Rank.ShouldBe(-1);
 
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+        // Cleanup — reverse FK order: participants → meet → athletes
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{participation1Id}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{participation2Id}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{athlete1Slug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{athlete2Slug}", CancellationToken.None)).EnsureSuccessStatusCode();
     }
 
     [Fact]
@@ -391,8 +396,8 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         // Arrange
         (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
 
-        int dqParticipationId = await AddParticipantToMeetAsync(meetId);
-        int rankedParticipationId = await AddParticipantToMeetAsync(meetId);
+        (int dqParticipationId, string dqAthleteSlug) = await AddParticipantToMeetAsync(meetId);
+        (int rankedParticipationId, string rankedAthleteSlug) = await AddParticipantToMeetAsync(meetId);
 
         // DQ participant — all bench attempts fail
         await RecordAttemptForMeet(meetId, dqParticipationId, Discipline.Squat, 1, 100.0m, true);
@@ -422,7 +427,12 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         dq.Rank.ShouldBe(0);
         ranked.Rank.ShouldBe(1);
 
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+        // Cleanup — reverse FK order: participants → meet → athletes
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{dqParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{rankedParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{dqAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{rankedAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
     }
 
     [Fact]
@@ -433,10 +443,10 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
 
         // Lighter participant (75.0 kg) — same total as heavier, should win tiebreaker
         // Both use body weights above 74.01 to land in the same 83 kg weight category
-        int lighterParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 75.0m);
+        (int lighterParticipationId, string lighterAthleteSlug) = await AddParticipantToMeetAsync(meetId, bodyWeight: 75.0m);
 
         // Heavier participant (80.0 kg)
-        int heavierParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 80.0m);
+        (int heavierParticipationId, string heavierAthleteSlug) = await AddParticipantToMeetAsync(meetId, bodyWeight: 80.0m);
 
         // Both record the same total (240 kg)
         await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Squat, 1, 80.0m, true);
@@ -463,7 +473,12 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         lighter.Rank.ShouldBe(1);
         heavier.Rank.ShouldBe(2);
 
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+        // Cleanup — reverse FK order: participants → meet → athletes
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{lighterParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{heavierParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{lighterAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{heavierAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
     }
 
     [Fact]
@@ -472,8 +487,8 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         // Arrange
         (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
 
-        int higherTotalParticipationId = await AddParticipantToMeetAsync(meetId);
-        int lowerTotalParticipationId = await AddParticipantToMeetAsync(meetId);
+        (int higherTotalParticipationId, string higherTotalAthleteSlug) = await AddParticipantToMeetAsync(meetId);
+        (int lowerTotalParticipationId, string lowerTotalAthleteSlug) = await AddParticipantToMeetAsync(meetId);
 
         // Higher total → place 1 → 12 TeamPoints
         await RecordAttemptForMeet(meetId, higherTotalParticipationId, Discipline.Squat, 1, 100.0m, true);
@@ -502,7 +517,12 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         higher.TeamPoints.ShouldBe(12);
         lower.TeamPoints.ShouldBe(9);
 
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+        // Cleanup — reverse FK order: participants → meet → athletes
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{higherTotalParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{lowerTotalParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{higherTotalAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{lowerTotalAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
     }
 
     private static string Path(int meetId, int participationId, Discipline discipline, int round) =>
@@ -593,7 +613,7 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         return result!.ParticipationId;
     }
 
-    private async Task<int> AddParticipantToMeetAsync(int meetId, decimal bodyWeight = 80.5m)
+    private async Task<(int ParticipationId, string AthleteSlug)> AddParticipantToMeetAsync(int meetId, decimal bodyWeight = 80.5m)
     {
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
         HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
@@ -620,6 +640,6 @@ public sealed class RecordAttemptTests(CollectionFixture fixture) : IAsyncLifeti
         AddParticipantResponse? result = await participantResponse.Content
             .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
 
-        return result!.ParticipationId;
+        return (result!.ParticipationId, athleteSlug);
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
@@ -2,9 +2,12 @@ using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
 using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.Features.Participations;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
 
 using Shouldly;
 
@@ -110,6 +113,57 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLi
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 
+    [Fact]
+    public async Task ReranksSurvivingParticipants_WhenSecondPlaceParticipantRemoved()
+    {
+        // Arrange
+        (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
+
+        int firstPlaceId = await AddParticipantToMeetAsync(meetId);
+        int secondPlaceId = await AddParticipantToMeetAsync(meetId);
+        int thirdPlaceId = await AddParticipantToMeetAsync(meetId);
+
+        // First place — highest total (300 kg)
+        await RecordAttemptForMeet(meetId, firstPlaceId, Discipline.Squat, 1, 100.0m, true);
+        await RecordAttemptForMeet(meetId, firstPlaceId, Discipline.Bench, 1, 50.0m, true);
+        await RecordAttemptForMeet(meetId, firstPlaceId, Discipline.Deadlift, 1, 150.0m, true);
+
+        // Second place — middle total (240 kg)
+        await RecordAttemptForMeet(meetId, secondPlaceId, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, secondPlaceId, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, secondPlaceId, Discipline.Deadlift, 1, 120.0m, true);
+
+        // Third place — lowest total (180 kg)
+        await RecordAttemptForMeet(meetId, thirdPlaceId, Discipline.Squat, 1, 60.0m, true);
+        await RecordAttemptForMeet(meetId, thirdPlaceId, Discipline.Bench, 1, 30.0m, true);
+        await RecordAttemptForMeet(meetId, thirdPlaceId, Discipline.Deadlift, 1, 90.0m, true);
+
+        // Act — remove the 2nd-place participant
+        HttpResponseMessage deleteResponse = await _authorizedHttpClient.DeleteAsync(
+            $"/meets/{meetId}/participants/{secondPlaceId}",
+            CancellationToken.None);
+        deleteResponse.EnsureSuccessStatusCode();
+
+        // Assert — former 3rd-place participant should now be ranked 2nd
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{meetSlug}/participations",
+                CancellationToken.None);
+
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        MeetParticipation? first = participations.FirstOrDefault(p => p.ParticipationId == firstPlaceId);
+        MeetParticipation? third = participations.FirstOrDefault(p => p.ParticipationId == thirdPlaceId);
+        MeetParticipation? removed = participations.FirstOrDefault(p => p.ParticipationId == secondPlaceId);
+
+        first.ShouldNotBeNull();
+        third.ShouldNotBeNull();
+        removed.ShouldBeNull();
+        first.Rank.ShouldBe(1);
+        third.Rank.ShouldBe(2);
+    }
+
     private async Task<int> AddParticipantAsync(int meetId)
     {
         AddParticipantCommand command = new AddParticipantCommandBuilder()
@@ -126,5 +180,75 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLi
         body.ShouldNotBeNull();
 
         return body.ParticipationId;
+    }
+
+    private async Task<(int MeetId, string MeetSlug)> CreateMeetAsync(CreateMeetCommandBuilder builder)
+    {
+        CreateMeetCommand command = builder.Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{slug}",
+            CancellationToken.None);
+
+        return (details!.MeetId, slug);
+    }
+
+    private async Task<int> AddParticipantToMeetAsync(int meetId)
+    {
+        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
+        HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes",
+            athleteCommand,
+            CancellationToken.None);
+
+        athleteResponse.EnsureSuccessStatusCode();
+
+        string athleteSlug = Slug.Create($"{athleteCommand.FirstName} {athleteCommand.LastName}");
+
+        AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .Build();
+
+        HttpResponseMessage participantResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants",
+            participantCommand,
+            CancellationToken.None);
+
+        participantResponse.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await participantResponse.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        return result!.ParticipationId;
+    }
+
+    private async Task RecordAttemptForMeet(
+        int meetId,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight,
+        bool good)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .WithGood(good)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/RemoveParticipantTests.cs
@@ -119,9 +119,9 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLi
         // Arrange
         (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
 
-        int firstPlaceId = await AddParticipantToMeetAsync(meetId);
-        int secondPlaceId = await AddParticipantToMeetAsync(meetId);
-        int thirdPlaceId = await AddParticipantToMeetAsync(meetId);
+        (int firstPlaceId, string firstAthleteSlug) = await AddParticipantToMeetAsync(meetId);
+        (int secondPlaceId, string secondAthleteSlug) = await AddParticipantToMeetAsync(meetId);
+        (int thirdPlaceId, string thirdAthleteSlug) = await AddParticipantToMeetAsync(meetId);
 
         // First place — highest total (300 kg)
         await RecordAttemptForMeet(meetId, firstPlaceId, Discipline.Squat, 1, 100.0m, true);
@@ -150,8 +150,6 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLi
                 $"/meets/{meetSlug}/participations",
                 CancellationToken.None);
 
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
-
         participations.ShouldNotBeNull();
         MeetParticipation? first = participations.FirstOrDefault(p => p.ParticipationId == firstPlaceId);
         MeetParticipation? third = participations.FirstOrDefault(p => p.ParticipationId == thirdPlaceId);
@@ -162,6 +160,14 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLi
         removed.ShouldBeNull();
         first.Rank.ShouldBe(1);
         third.Rank.ShouldBe(2);
+
+        // Cleanup — secondPlaceId already removed during Act; delete remaining participants first
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{firstPlaceId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{thirdPlaceId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{firstAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{secondAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{thirdAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
     }
 
     private async Task<int> AddParticipantAsync(int meetId)
@@ -202,7 +208,7 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLi
         return (details!.MeetId, slug);
     }
 
-    private async Task<int> AddParticipantToMeetAsync(int meetId)
+    private async Task<(int ParticipationId, string AthleteSlug)> AddParticipantToMeetAsync(int meetId)
     {
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
         HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
@@ -228,7 +234,7 @@ public sealed class RemoveParticipantTests(CollectionFixture fixture) : IAsyncLi
         AddParticipantResponse? result = await participantResponse.Content
             .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
 
-        return result!.ParticipationId;
+        return (result!.ParticipationId, athleteSlug);
     }
 
     private async Task RecordAttemptForMeet(

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateBodyWeightTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateBodyWeightTests.cs
@@ -247,8 +247,8 @@ public sealed class UpdateBodyWeightTests(CollectionFixture fixture) : IAsyncLif
         // Arrange — two participants with the same total; lighter (75.0kg) is initially rank 1
         (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
 
-        int lighterParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 75.0m);
-        int heavierParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 80.0m);
+        (int lighterParticipationId, string lighterAthleteSlug) = await AddParticipantToMeetAsync(meetId, bodyWeight: 75.0m);
+        (int heavierParticipationId, string heavierAthleteSlug) = await AddParticipantToMeetAsync(meetId, bodyWeight: 80.0m);
 
         // Both record the same total (240 kg)
         await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Squat, 1, 80.0m, true);
@@ -274,8 +274,6 @@ public sealed class UpdateBodyWeightTests(CollectionFixture fixture) : IAsyncLif
                 $"/meets/{meetSlug}/participations",
                 CancellationToken.None);
 
-        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
-
         participations.ShouldNotBeNull();
         MeetParticipation? formerlyLighter = participations.FirstOrDefault(p => p.ParticipationId == lighterParticipationId);
         MeetParticipation? formerlyHeavier = participations.FirstOrDefault(p => p.ParticipationId == heavierParticipationId);
@@ -284,6 +282,13 @@ public sealed class UpdateBodyWeightTests(CollectionFixture fixture) : IAsyncLif
         formerlyHeavier.ShouldNotBeNull();
         formerlyLighter.Rank.ShouldBe(2, "formerly lighter participant is now 85.0kg — should be rank 2");
         formerlyHeavier.Rank.ShouldBe(1, "formerly heavier participant is now the lightest — should be rank 1");
+
+        // Cleanup — reverse FK order: participants → meet → athletes
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{lighterParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{heavierParticipationId}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{lighterAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
+        (await _authorizedHttpClient.DeleteAsync($"/athletes/{heavierAthleteSlug}", CancellationToken.None)).EnsureSuccessStatusCode();
     }
 
     private static string Path(int meetId, int participationId) =>
@@ -309,7 +314,7 @@ public sealed class UpdateBodyWeightTests(CollectionFixture fixture) : IAsyncLif
         return (details!.MeetId, slug);
     }
 
-    private async Task<int> AddParticipantToMeetAsync(int meetId, decimal bodyWeight = 80.5m)
+    private async Task<(int ParticipationId, string AthleteSlug)> AddParticipantToMeetAsync(int meetId, decimal bodyWeight = 80.5m)
     {
         CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
         HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
@@ -336,7 +341,7 @@ public sealed class UpdateBodyWeightTests(CollectionFixture fixture) : IAsyncLif
         AddParticipantResponse? result = await participantResponse.Content
             .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
 
-        return result!.ParticipationId;
+        return (result!.ParticipationId, athleteSlug);
     }
 
     private async Task RecordAttemptForMeet(

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateBodyWeightTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/UpdateBodyWeightTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 
+using KRAFT.Results.Contracts;
 using KRAFT.Results.Contracts.Athletes;
 using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
@@ -240,6 +241,122 @@ public sealed class UpdateBodyWeightTests(CollectionFixture fixture) : IAsyncLif
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }
 
+    [Fact]
+    public async Task UpdateBodyWeight_SwapsTiebreaker_WhenLighterParticipantBecomesHeavier()
+    {
+        // Arrange — two participants with the same total; lighter (75.0kg) is initially rank 1
+        (int meetId, string meetSlug) = await CreateMeetAsync(new CreateMeetCommandBuilder());
+
+        int lighterParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 75.0m);
+        int heavierParticipationId = await AddParticipantToMeetAsync(meetId, bodyWeight: 80.0m);
+
+        // Both record the same total (240 kg)
+        await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, lighterParticipationId, Discipline.Deadlift, 1, 120.0m, true);
+
+        await RecordAttemptForMeet(meetId, heavierParticipationId, Discipline.Squat, 1, 80.0m, true);
+        await RecordAttemptForMeet(meetId, heavierParticipationId, Discipline.Bench, 1, 40.0m, true);
+        await RecordAttemptForMeet(meetId, heavierParticipationId, Discipline.Deadlift, 1, 120.0m, true);
+
+        // Act — update the lighter participant's body weight to 85.0kg (now heavier than the other)
+        UpdateBodyWeightCommand command = new(85.0m);
+        HttpResponseMessage updateResponse = await _authorizedHttpClient.PatchAsJsonAsync(
+            Path(meetId, lighterParticipationId),
+            command,
+            CancellationToken.None);
+
+        updateResponse.EnsureSuccessStatusCode();
+
+        // Assert — places must have swapped: heavier-at-registration (80.0kg) is now rank 1
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{meetSlug}/participations",
+                CancellationToken.None);
+
+        await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        MeetParticipation? formerlyLighter = participations.FirstOrDefault(p => p.ParticipationId == lighterParticipationId);
+        MeetParticipation? formerlyHeavier = participations.FirstOrDefault(p => p.ParticipationId == heavierParticipationId);
+
+        formerlyLighter.ShouldNotBeNull();
+        formerlyHeavier.ShouldNotBeNull();
+        formerlyLighter.Rank.ShouldBe(2, "formerly lighter participant is now 85.0kg — should be rank 2");
+        formerlyHeavier.Rank.ShouldBe(1, "formerly heavier participant is now the lightest — should be rank 1");
+    }
+
     private static string Path(int meetId, int participationId) =>
         $"/meets/{meetId}/participations/{participationId}";
+
+    private async Task<(int MeetId, string MeetSlug)> CreateMeetAsync(CreateMeetCommandBuilder builder)
+    {
+        CreateMeetCommand command = builder.Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{slug}",
+            CancellationToken.None);
+
+        return (details!.MeetId, slug);
+    }
+
+    private async Task<int> AddParticipantToMeetAsync(int meetId, decimal bodyWeight = 80.5m)
+    {
+        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder().WithCountryId(2).Build();
+        HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes",
+            athleteCommand,
+            CancellationToken.None);
+
+        athleteResponse.EnsureSuccessStatusCode();
+
+        string athleteSlug = Slug.Create($"{athleteCommand.FirstName} {athleteCommand.LastName}");
+
+        AddParticipantCommand participantCommand = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(bodyWeight)
+            .Build();
+
+        HttpResponseMessage participantResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants",
+            participantCommand,
+            CancellationToken.None);
+
+        participantResponse.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await participantResponse.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        return result!.ParticipationId;
+    }
+
+    private async Task RecordAttemptForMeet(
+        int meetId,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight,
+        bool good)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .WithGood(good)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Rankings/GetRankingsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Rankings/GetRankingsTests.cs
@@ -44,29 +44,23 @@ public sealed class GetRankingsTests(CollectionFixture fixture) : IAsyncLifetime
         int meet1Id = await CreateMeetAndGetIdAsync(new DateOnly(MeetYear, 6, 1));
         int meet2Id = await CreateMeetAndGetIdAsync(new DateOnly(MeetYear, 9, 1));
 
-        // P1: athlete A in meet1, place 1, best result
+        // P1: athlete A in meet1, place 1 (computed), best result
         int p1Id = await AddParticipantAsync(meet1Id, athleteASlug);
         await RecordAttemptAsync(meet1Id, p1Id, Discipline.Squat, 1, P1Squat);
         await RecordAttemptAsync(meet1Id, p1Id, Discipline.Bench, 1, P1Bench);
         await RecordAttemptAsync(meet1Id, p1Id, Discipline.Deadlift, 1, P1Deadlift);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET Place = 1 WHERE ParticipationId = {p1Id}");
 
-        // P2: athlete A in meet2, place 1, second-best result
+        // P2: athlete A in meet2, place 1 (computed), second-best result
         int p2Id = await AddParticipantAsync(meet2Id, athleteASlug);
         await RecordAttemptAsync(meet2Id, p2Id, Discipline.Squat, 1, P2Squat);
         await RecordAttemptAsync(meet2Id, p2Id, Discipline.Bench, 1, P2Bench);
         await RecordAttemptAsync(meet2Id, p2Id, Discipline.Deadlift, 1, P2Deadlift);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET Place = 1 WHERE ParticipationId = {p2Id}");
 
-        // P3: athlete B in meet1, disqualified (3 failed squats trigger automatic DQ via RecalculateTotals)
+        // P3: athlete B in meet1, disqualified (3 failed squats trigger automatic DQ via RecalculateTotals), place 0 (computed)
         int p3Id = await AddParticipantAsync(meet1Id, athleteBSlug);
         await RecordAttemptAsync(meet1Id, p3Id, Discipline.Squat, 1, 100.0m, good: false);
         await RecordAttemptAsync(meet1Id, p3Id, Discipline.Squat, 2, 100.0m, good: false);
         await RecordAttemptAsync(meet1Id, p3Id, Discipline.Squat, 3, 100.0m, good: false);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET Place = 3 WHERE ParticipationId = {p3Id}");
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/TeamCompetition/GetTeamCompetitionTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/TeamCompetition/GetTeamCompetitionTests.cs
@@ -19,25 +19,59 @@ public sealed class GetTeamCompetitionTests(CollectionFixture fixture) : IAsyncL
     private const string BasePath = "/team-competition";
     private const int Year2025 = 2025;
     private const int Year2026 = 2026;
+
+    // 2025 men — meet1: alphaMale=Place1→12pts, noTeam=Place2→9pts(excluded), betaMale=Place3→8pts
+    //            meet2: betaMale=Place1→12pts, alphaMale=Place2→9pts
+    // Totals: Alpha=12+9=21, Beta=8+12=20
     private const int AlphaMenMeet1Points = 12;
     private const int AlphaMenMeet2Points = 9;
     private const int AlphaMenTotalPoints = AlphaMenMeet1Points + AlphaMenMeet2Points; // 21
     private const int BetaMenMeet1Points = 8;
     private const int BetaMenMeet2Points = 12;
     private const int BetaMenTotalPoints = BetaMenMeet1Points + BetaMenMeet2Points; // 20
+
+    // 2025 women — meet1: alphaFemale=Place1→12pts, betaFemale=Place2→9pts
     private const int AlphaWomenPoints = 12;
     private const int BetaWomenPoints = 9;
-    private const int DqPoints = 7;
-    private const int NoTeamPoints = 5;
-    private const int ZeroTeamPoints = 0;
-    private const int BestNPointsPerAthlete = 12;
-    private const int BestNMeet2Athlete1Points = 12;
-    private const int BestNMeet2Athlete2Points = 9;
-    private const int BestNMeet2Athlete3Points = 8;
-    private const int BestNLimit = 5;
-    private const int BestNMeet1Total = BestNLimit * BestNPointsPerAthlete; // 60
-    private const int BestNMeet2Total = BestNMeet2Athlete1Points + BestNMeet2Athlete2Points + BestNMeet2Athlete3Points; // 29
-    private const int BestNExpectedTotal = BestNMeet1Total + BestNMeet2Total; // 89
+
+    // BestN 2026:
+    // Meet1: 6 athletes, totals descend → places 1–6 → points 12,9,8,7,6,5 → best 5 = 12+9+8+7+6 = 42
+    // Meet2: 3 athletes, totals descend → places 1–3 → points 12,9,8 → sum = 29
+    // Grand total: 42 + 29 = 71
+    private const int BestNMeet1Total = 42; // 12+9+8+7+6
+    private const int BestNMeet2Total = 29; // 12+9+8
+    private const int BestNExpectedTotal = BestNMeet1Total + BestNMeet2Total; // 71
+
+    // Meet1 2025 — men totals (same weight category, 82.0m body weight)
+    private const decimal AlphaMaleMeet1Squat = 100.0m;
+    private const decimal AlphaMaleMeet1Bench = 100.0m;
+    private const decimal AlphaMaleMeet1Deadlift = 100.0m; // Total=300 → Place 1
+
+    private const decimal NoTeamMaleMeet1Squat = 90.0m;
+    private const decimal NoTeamMaleMeet1Bench = 80.0m;
+    private const decimal NoTeamMaleMeet1Deadlift = 80.0m; // Total=250 → Place 2 (no team, excluded from standings)
+
+    private const decimal BetaMaleMeet1Squat = 70.0m;
+    private const decimal BetaMaleMeet1Bench = 60.0m;
+    private const decimal BetaMaleMeet1Deadlift = 70.0m; // Total=200 → Place 3
+
+    // Meet2 2025 — men totals (same weight category, 82.0m body weight)
+    private const decimal BetaMaleMeet2Squat = 100.0m;
+    private const decimal BetaMaleMeet2Bench = 100.0m;
+    private const decimal BetaMaleMeet2Deadlift = 100.0m; // Total=300 → Place 1
+
+    private const decimal AlphaMaleMeet2Squat = 90.0m;
+    private const decimal AlphaMaleMeet2Bench = 80.0m;
+    private const decimal AlphaMaleMeet2Deadlift = 80.0m; // Total=250 → Place 2
+
+    // Meet1 2025 — women totals (57.0m body weight)
+    private const decimal AlphaFemaleMeet1Squat = 90.0m;
+    private const decimal AlphaFemaleMeet1Bench = 70.0m;
+    private const decimal AlphaFemaleMeet1Deadlift = 100.0m; // Total=260 → Place 1
+
+    private const decimal BetaFemaleMeet1Squat = 80.0m;
+    private const decimal BetaFemaleMeet1Bench = 60.0m;
+    private const decimal BetaFemaleMeet1Deadlift = 80.0m; // Total=220 → Place 2
 
     private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
     private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
@@ -77,75 +111,89 @@ public sealed class GetTeamCompetitionTests(CollectionFixture fixture) : IAsyncL
         string noTeamSlug = await CreateAthleteAsync("NoTeam", "m");
         string zeroPtsSlug = await CreateAthleteAsync("ZeroPts", "m");
 
-        // Alpha male: meet1=12, meet2=9 → total=21
+        // Add participants for 2025 meet1 — men (82.0m body weight, same weight category)
         int alphaMalePid1 = await AddParticipantAsync(meet1In2025Id, alphaMaleSlug, _alphaTeamId);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {AlphaMenMeet1Points}, Place = 1 WHERE ParticipationId = {alphaMalePid1}");
-
-        int alphaMalePid2 = await AddParticipantAsync(meet2In2025Id, alphaMaleSlug, _alphaTeamId);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {AlphaMenMeet2Points}, Place = 2 WHERE ParticipationId = {alphaMalePid2}");
-
-        // Beta male: meet1=8, meet2=12 → total=20
         int betaMalePid1 = await AddParticipantAsync(meet1In2025Id, betaMaleSlug, _betaTeamId);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {BetaMenMeet1Points}, Place = 3 WHERE ParticipationId = {betaMalePid1}");
-
-        int betaMalePid2 = await AddParticipantAsync(meet2In2025Id, betaMaleSlug, _betaTeamId);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {BetaMenMeet2Points}, Place = 1 WHERE ParticipationId = {betaMalePid2}");
-
-        // Alpha female: meet1=12
-        int alphaFemalePid = await AddParticipantAsync(meet1In2025Id, alphaFemaleSlug, _alphaTeamId, 57.0m);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {AlphaWomenPoints}, Place = 1 WHERE ParticipationId = {alphaFemalePid}");
-
-        // Beta female: meet1=9
-        int betaFemalePid = await AddParticipantAsync(meet1In2025Id, betaFemaleSlug, _betaTeamId, 57.0m);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {BetaWomenPoints}, Place = 2 WHERE ParticipationId = {betaFemalePid}");
-
-        // DQ'd participation: Alpha male, meet1, TeamPoints=7 (should be excluded)
-        // 3 failed squat attempts trigger automatic DQ via RecalculateTotals
         int dqPid = await AddParticipantAsync(meet1In2025Id, dqAlphaMaleSlug, _alphaTeamId);
+        int noTeamPid = await AddParticipantAsync(meet1In2025Id, noTeamSlug, teamId: null);
+        await AddParticipantAsync(meet1In2025Id, zeroPtsSlug, _alphaTeamId);
+
+        // DQ the dqAlphaMale via 3 failed squat attempts → Disqualified=true, Total=0, Place=0, TeamPoints=0
         await RecordAttemptAsync(meet1In2025Id, dqPid, Discipline.Squat, 1, 100.0m, good: false);
         await RecordAttemptAsync(meet1In2025Id, dqPid, Discipline.Squat, 2, 100.0m, good: false);
         await RecordAttemptAsync(meet1In2025Id, dqPid, Discipline.Squat, 3, 100.0m, good: false);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {DqPoints} WHERE ParticipationId = {dqPid}");
 
-        // No team participation: meet1, TeamPoints=5 (should be excluded)
-        int noTeamPid = await AddParticipantAsync(meet1In2025Id, noTeamSlug, teamId: null);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {NoTeamPoints} WHERE ParticipationId = {noTeamPid}");
+        // Meet1 men totals determine places:
+        // alphaMale: Total=300 → Place 1 → TeamPoints=12
+        // noTeamMale: Total=250 → Place 2 → TeamPoints=9 (no team, excluded from standings)
+        // betaMale: Total=200 → Place 3 → TeamPoints=8
+        // zeroPts: no attempts → Total=0, not disqualified → Place=0, TeamPoints=null (excluded)
+        await RecordFullTotalAsync(meet1In2025Id, alphaMalePid1, AlphaMaleMeet1Squat, AlphaMaleMeet1Bench, AlphaMaleMeet1Deadlift);
+        await RecordFullTotalAsync(meet1In2025Id, noTeamPid, NoTeamMaleMeet1Squat, NoTeamMaleMeet1Bench, NoTeamMaleMeet1Deadlift);
+        await RecordFullTotalAsync(meet1In2025Id, betaMalePid1, BetaMaleMeet1Squat, BetaMaleMeet1Bench, BetaMaleMeet1Deadlift);
 
-        // Zero team points participation: meet1, TeamPoints=0 (should be excluded)
-        int zeroPtsPid = await AddParticipantAsync(meet1In2025Id, zeroPtsSlug, _alphaTeamId);
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Participations SET TeamPoints = {ZeroTeamPoints} WHERE ParticipationId = {zeroPtsPid}");
+        // Add participants for 2025 meet1 — women (57.0m body weight, separate weight category)
+        int alphaFemalePid = await AddParticipantAsync(meet1In2025Id, alphaFemaleSlug, _alphaTeamId, 57.0m);
+        int betaFemalePid = await AddParticipantAsync(meet1In2025Id, betaFemaleSlug, _betaTeamId, 57.0m);
+
+        // Meet1 women totals:
+        // alphaFemale: Total=260 → Place 1 → TeamPoints=12
+        // betaFemale: Total=220 → Place 2 → TeamPoints=9
+        await RecordFullTotalAsync(meet1In2025Id, alphaFemalePid, AlphaFemaleMeet1Squat, AlphaFemaleMeet1Bench, AlphaFemaleMeet1Deadlift);
+        await RecordFullTotalAsync(meet1In2025Id, betaFemalePid, BetaFemaleMeet1Squat, BetaFemaleMeet1Bench, BetaFemaleMeet1Deadlift);
+
+        // Add participants for 2025 meet2 — men (82.0m body weight)
+        int alphaMalePid2 = await AddParticipantAsync(meet2In2025Id, alphaMaleSlug, _alphaTeamId);
+        int betaMalePid2 = await AddParticipantAsync(meet2In2025Id, betaMaleSlug, _betaTeamId);
+
+        // Meet2 men totals:
+        // betaMale: Total=300 → Place 1 → TeamPoints=12
+        // alphaMale: Total=250 → Place 2 → TeamPoints=9
+        await RecordFullTotalAsync(meet2In2025Id, betaMalePid2, BetaMaleMeet2Squat, BetaMaleMeet2Bench, BetaMaleMeet2Deadlift);
+        await RecordFullTotalAsync(meet2In2025Id, alphaMalePid2, AlphaMaleMeet2Squat, AlphaMaleMeet2Bench, AlphaMaleMeet2Deadlift);
 
         // Create 2026 meets for BestN test
         int meet1In2026Id = await CreateMeetAndGetIdAsync(new DateOnly(Year2026, 6, 1));
         int meet2In2026Id = await CreateMeetAndGetIdAsync(new DateOnly(Year2026, 9, 1));
 
-        // Meet1 2026: 6 male athletes all scoring 12 → best 5 → 60
-        for (int i = 1; i <= 6; i++)
-        {
-            string slug = await CreateAthleteAsync($"Alpha26M{i}", "m");
-            int pid = await AddParticipantAsync(meet1In2026Id, slug, _alphaTeamId);
-            await fixture.ExecuteSqlAsync(
-                $"UPDATE Participations SET TeamPoints = {BestNPointsPerAthlete}, Place = {i} WHERE ParticipationId = {pid}");
-        }
+        // Meet1 2026: 6 male athletes with descending totals → places 1–6 → points 12,9,8,7,6,5
+        // Best 5 of those 6 = 12+9+8+7+6 = 42
+        string alpha26M1Slug = await CreateAthleteAsync("Alpha26M1", "m");
+        int alpha26M1Pid = await AddParticipantAsync(meet1In2026Id, alpha26M1Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet1In2026Id, alpha26M1Pid, 200.0m, 150.0m, 250.0m); // Total=600 → Place 1 → 12pts
 
-        // Meet2 2026: 3 male athletes scoring 12, 9, 8 → 29
-        int[] meet2Points = [BestNMeet2Athlete1Points, BestNMeet2Athlete2Points, BestNMeet2Athlete3Points];
-        for (int i = 0; i < meet2Points.Length; i++)
-        {
-            string slug = await CreateAthleteAsync($"Alpha26N{i}", "m");
-            int pid = await AddParticipantAsync(meet2In2026Id, slug, _alphaTeamId);
-            await fixture.ExecuteSqlAsync(
-                $"UPDATE Participations SET TeamPoints = {meet2Points[i]}, Place = {i + 1} WHERE ParticipationId = {pid}");
-        }
+        string alpha26M2Slug = await CreateAthleteAsync("Alpha26M2", "m");
+        int alpha26M2Pid = await AddParticipantAsync(meet1In2026Id, alpha26M2Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet1In2026Id, alpha26M2Pid, 190.0m, 140.0m, 220.0m); // Total=550 → Place 2 → 9pts
+
+        string alpha26M3Slug = await CreateAthleteAsync("Alpha26M3", "m");
+        int alpha26M3Pid = await AddParticipantAsync(meet1In2026Id, alpha26M3Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet1In2026Id, alpha26M3Pid, 170.0m, 130.0m, 200.0m); // Total=500 → Place 3 → 8pts
+
+        string alpha26M4Slug = await CreateAthleteAsync("Alpha26M4", "m");
+        int alpha26M4Pid = await AddParticipantAsync(meet1In2026Id, alpha26M4Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet1In2026Id, alpha26M4Pid, 150.0m, 120.0m, 180.0m); // Total=450 → Place 4 → 7pts
+
+        string alpha26M5Slug = await CreateAthleteAsync("Alpha26M5", "m");
+        int alpha26M5Pid = await AddParticipantAsync(meet1In2026Id, alpha26M5Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet1In2026Id, alpha26M5Pid, 135.0m, 110.0m, 155.0m); // Total=400 → Place 5 → 6pts
+
+        string alpha26M6Slug = await CreateAthleteAsync("Alpha26M6", "m");
+        int alpha26M6Pid = await AddParticipantAsync(meet1In2026Id, alpha26M6Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet1In2026Id, alpha26M6Pid, 120.0m, 100.0m, 130.0m); // Total=350 → Place 6 → 5pts (capped by BestN)
+
+        // Meet2 2026: 3 male athletes with descending totals → places 1–3 → points 12,9,8 → sum=29
+        string alpha26N0Slug = await CreateAthleteAsync("Alpha26N0", "m");
+        int alpha26N0Pid = await AddParticipantAsync(meet2In2026Id, alpha26N0Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet2In2026Id, alpha26N0Pid, 100.0m, 100.0m, 100.0m); // Total=300 → Place 1 → 12pts
+
+        string alpha26N1Slug = await CreateAthleteAsync("Alpha26N1", "m");
+        int alpha26N1Pid = await AddParticipantAsync(meet2In2026Id, alpha26N1Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet2In2026Id, alpha26N1Pid, 90.0m, 80.0m, 80.0m); // Total=250 → Place 2 → 9pts
+
+        string alpha26N2Slug = await CreateAthleteAsync("Alpha26N2", "m");
+        int alpha26N2Pid = await AddParticipantAsync(meet2In2026Id, alpha26N2Slug, _alphaTeamId);
+        await RecordFullTotalAsync(meet2In2026Id, alpha26N2Pid, 70.0m, 60.0m, 70.0m); // Total=200 → Place 3 → 8pts
     }
 
     public async ValueTask DisposeAsync()
@@ -269,8 +317,8 @@ public sealed class GetTeamCompetitionTests(CollectionFixture fixture) : IAsyncL
     [Fact]
     public async Task ExcludesDisqualifiedParticipations()
     {
-        // Arrange — DQ'd participation with TeamPoints=7 for Alpha should be excluded
-        // Alpha men: 12+9=21 (not 12+9+7=28)
+        // Arrange — DQ'd participation has Place=0, TeamPoints=0 for Alpha
+        // Alpha men: 12+9=21 (not 12+9+0=21+DQ contribution)
 
         // Act
         TeamCompetitionResponse? response = await _httpClient.GetFromJsonAsync<TeamCompetitionResponse>(
@@ -284,7 +332,7 @@ public sealed class GetTeamCompetitionTests(CollectionFixture fixture) : IAsyncL
     [Fact]
     public async Task ExcludesParticipationsWithNoTeam()
     {
-        // Arrange — participation without TeamId has TeamPoints=5, should be excluded
+        // Arrange — participation without TeamId should be excluded
 
         // Act
         TeamCompetitionResponse? response = await _httpClient.GetFromJsonAsync<TeamCompetitionResponse>(
@@ -297,7 +345,7 @@ public sealed class GetTeamCompetitionTests(CollectionFixture fixture) : IAsyncL
     [Fact]
     public async Task ExcludesParticipationsWithZeroTeamPoints()
     {
-        // Arrange — participation with TeamPoints=0 for Alpha should be excluded
+        // Arrange — zeroPts participant has no attempts → TeamPoints=null → excluded
         // If it were included, the zero-point entry would still appear in the team's breakdown
 
         // Act
@@ -341,9 +389,9 @@ public sealed class GetTeamCompetitionTests(CollectionFixture fixture) : IAsyncL
     public async Task AppliesBestNLimit_PerMeet()
     {
         // Arrange — Alpha Team 2026 men:
-        // Meet 1: 6 athletes all scoring 12 -> best 5 -> 5*12 = 60
-        // Meet 2: 3 athletes scoring 12, 9, 8 -> all 3 count -> 29
-        // Per-meet total: 60 + 29 = 89
+        // Meet1: 6 athletes, places 1–6 → points 12,9,8,7,6,5 → best 5 → 12+9+8+7+6 = 42
+        // Meet2: 3 athletes, places 1–3 → points 12,9,8 → sum = 29
+        // Grand total: 42 + 29 = 71
 
         // Act
         TeamCompetitionResponse? response = await _httpClient.GetFromJsonAsync<TeamCompetitionResponse>(
@@ -353,6 +401,18 @@ public sealed class GetTeamCompetitionTests(CollectionFixture fixture) : IAsyncL
         response!.Men.ShouldNotBeEmpty();
         TeamCompetitionStanding alpha = response.Men.First(s => s.TeamName == _alphaTeamName);
         alpha.TotalPoints.ShouldBe(BestNExpectedTotal);
+    }
+
+    private async Task RecordFullTotalAsync(
+        int meetId,
+        int participationId,
+        decimal squat,
+        decimal bench,
+        decimal deadlift)
+    {
+        await RecordAttemptAsync(meetId, participationId, Discipline.Squat, 1, squat);
+        await RecordAttemptAsync(meetId, participationId, Discipline.Bench, 1, bench);
+        await RecordAttemptAsync(meetId, participationId, Discipline.Deadlift, 1, deadlift);
     }
 
     private async Task RecordAttemptAsync(int meetId, int participationId, Discipline discipline, int round, decimal weight, bool good = true)

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateRanking/SetsPlaceTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateRanking/SetsPlaceTests.cs
@@ -1,0 +1,24 @@
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Participations.Participation.UpdateRanking;
+
+public sealed class SetsPlaceTests
+{
+    [Fact]
+    public void SetsPlace_WhenCalledWithPositivePlace()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        // Act
+        participation.UpdateRanking(1);
+
+        // Assert
+        participation.Place.ShouldBe(1);
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateRanking/SetsPlaceTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateRanking/SetsPlaceTests.cs
@@ -21,4 +21,19 @@ public sealed class SetsPlaceTests
         // Assert
         participation.Place.ShouldBe(1);
     }
+
+    [Fact]
+    public void SetsPlaceToZero_WhenCalledWithZero()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        // Act
+        participation.UpdateRanking(0);
+
+        // Assert
+        participation.Place.ShouldBe(0);
+    }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateRanking/SetsTeamPointsTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/UpdateRanking/SetsTeamPointsTests.cs
@@ -1,0 +1,53 @@
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Participations.Participation.UpdateRanking;
+
+public sealed class SetsTeamPointsTests
+{
+    [Theory]
+    [InlineData(1, 12)]
+    [InlineData(2, 9)]
+    [InlineData(3, 8)]
+    [InlineData(4, 7)]
+    [InlineData(5, 6)]
+    [InlineData(6, 5)]
+    [InlineData(7, 4)]
+    [InlineData(8, 3)]
+    [InlineData(9, 2)]
+    [InlineData(10, 1)]
+    [InlineData(11, 0)]
+    [InlineData(100, 0)]
+    public void SetsTeamPoints_BasedOnPlace(int place, int expectedTeamPoints)
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        // Act
+        participation.UpdateRanking(place);
+
+        // Assert
+        participation.TeamPoints.ShouldBe(expectedTeamPoints);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SetsTeamPoints_ToZero_WhenDqOrNotComputed(int place)
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        // Act
+        participation.UpdateRanking(place);
+
+        // Assert
+        participation.TeamPoints.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Compute and persist Place and TeamPoints automatically after recording attempts, deleting participations, or updating body weight when CalcPlaces is enabled
- Rank participants by total descending, body weight ascending, lot number ascending (IPF tiebreaker rules)
- Remove all raw SQL test setup for Place and TeamPoints across 4 test files

Closes #456

## Test plan

- [x] Place computed after recording full attempts (tracer bullet)
- [x] CalcPlaces=false short-circuits — Place stays at default
- [x] DQ'd participant gets Place=0, TeamPoints=0
- [x] Body weight tiebreaker resolves correctly
- [x] TeamPoints maps to TiebreakerPointValues (1st=12, 2nd=9, ..., 10th=1, >10th=0)
- [x] UpdateBodyWeight triggers reranking
- [x] RemoveParticipant promotes remaining participants
- [x] GetMeetParticipationsTests migrated — SQL removed
- [x] GetMeetTeamPointsTests migrated — SQL removed
- [x] GetTeamCompetitionTests migrated — SQL removed
- [x] GetRankingsTests migrated — SQL removed
- [x] 554 tests pass (118 unit + 405 integration + 31 client)