### PR TITLE
refactor(webapi): derive Disqualified from active ban on meet date

### DIFF
--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -1,0 +1,86 @@
+# DOMAIN.md
+
+Domain concepts for KRAFT.Results — a powerlifting competition results management system for the Icelandic Powerlifting Federation (KRAFT). This document covers concepts that are non-obvious or have implementation trade-offs worth recording.
+
+---
+
+## Bans and Disqualification
+
+### Ban
+
+A **Ban** is a period during which an athlete is prohibited from competing. It is defined by `FromDate` and `ToDate`, both stored as `DateTime`. Comparisons are made at **date granularity** using `DateOnly.FromDateTime()`.
+
+### Active ban
+
+A ban is **active** on a given date when that date falls within `[FromDate, ToDate]` inclusive:
+
+```csharp
+// Athlete.cs
+internal bool HasActiveBan(DateOnly date)
+{
+    return Bans.Any(ban =>
+        date >= DateOnly.FromDateTime(ban.FromDate)
+        && date <= DateOnly.FromDateTime(ban.ToDate));
+}
+```
+
+`IsEligibleForRecord(DateOnly meetDate)` delegates to `!HasActiveBan(meetDate)`.
+
+### Meet date used for ban checks
+
+`Meet.StartDate` is used as the reference date when evaluating whether an athlete has an active ban. This is a pragmatic approximation (see WADA note below). The field is stored as `DateTime`; the ban check converts it via `DateOnly.FromDateTime(Meet.StartDate)`.
+
+### Disqualification derivation
+
+`Participation.Disqualified` is **derived**, never set manually. `RecalculateTotals()` computes it as:
+
+```
+Disqualified = bombedOut || HasActiveBan(meetDate)
+```
+
+where:
+
+- `bombedOut` — the athlete has zero good lifts in any required discipline (Squat, Bench, or Deadlift)
+- `HasActiveBan(meetDate)` — the athlete has at least one ban whose range covers `Meet.StartDate`
+
+`RecalculateTotals()` requires both `Participation.Meet` and `Participation.Athlete` (with `Athlete.Bans`) to be loaded; it throws `InvalidOperationException` if either navigation property is null.
+
+### Preserved values for banned athletes
+
+Banned athletes keep their computed `Total`, `Wilks`, and `IpfPoints` values. Only `Disqualified` is set to `true`. This distinguishes the two disqualification causes:
+
+| Condition | Disqualified | Total |
+|---|---|---|
+| Bomb-out | `true` | `0` |
+| Active ban | `true` | `> 0` |
+
+### Downstream effects
+
+All views — rankings, personal bests, team points, meet display — filter on `Disqualified`. Setting the flag at the source (in `RecalculateTotals`) propagates correctness everywhere without additional special-casing.
+
+### Retroactive cascade
+
+When a ban is added or removed, a domain event is raised on the `Athlete` aggregate root:
+
+- `BanAddedEvent` — raised by `Athlete.AddBan()`
+- `BanRemovedEvent` — raised when a ban is removed (future: `Athlete.RemoveBan()`)
+
+`BanEventHandler` handles both events and runs the retroactive cascade for all participations whose meet falls within the ban period:
+
+1. `RecalculateTotals()` — updates `Disqualified` (and lifts/Total)
+2. `PlaceComputationService.ComputePlacesAsync()` — recomputes meet placements, excluding disqualified athletes from ranked positions
+3. `RecordComputationService.RebuildSlotsAsync()` — rebuilds record slots for affected age/weight/discipline combinations
+
+The cascade runs within a single `SaveChangesAsync` call per event.
+
+---
+
+## WADA / IPF Reference
+
+KRAFT (Icelandic Powerlifting Federation) follows IPF rules, which implement the WADA Code. Anti-doping oversight for Icelandic athletes is handled by **Lyfjaeftirlit Íslands** (Icelandic Anti-Doping Authority). KRAFT does not maintain independent ban rules.
+
+### Competition vs. Event under WADA
+
+Under the WADA Code, a **Competition** is a single lifting session; an **Event** is the multi-day championship. Ban eligibility is evaluated per Competition (i.e., per lifting session), not per Event.
+
+The system approximates this by using `Meet.StartDate` for all participants, regardless of which session they lifted in. Icelandic meets are typically 1–2 days, making this edge case negligible in practice. If a per-session date is ever added to `Participation`, the ban check becomes a one-line change in `RecalculateTotals()`.

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -8,79 +8,56 @@ Domain concepts for KRAFT.Results — a powerlifting competition results managem
 
 ### Ban
 
-A **Ban** is a period during which an athlete is prohibited from competing. It is defined by `FromDate` and `ToDate`, both stored as `DateTime`. Comparisons are made at **date granularity** using `DateOnly.FromDateTime()`.
+A **Ban** is a period during which an athlete is prohibited from competing. It is defined by `FromDate` and `ToDate`. Comparisons are made at **date granularity** (time-of-day is ignored).
 
 ### Active ban
 
-A ban is **active** on a given date when that date falls within `[FromDate, ToDate]` inclusive:
-
-```csharp
-// Athlete.cs
-internal bool HasActiveBan(DateOnly date)
-{
-    return Bans.Any(ban =>
-        date >= DateOnly.FromDateTime(ban.FromDate)
-        && date <= DateOnly.FromDateTime(ban.ToDate));
-}
-```
-
-`IsEligibleForRecord(DateOnly meetDate)` delegates to `!HasActiveBan(meetDate)`.
+A ban is **active** on a given date when that date falls within `[FromDate, ToDate]` inclusive. Multiple bans may overlap — removing one does not clear the active status if another covers the same date.
 
 ### Meet date used for ban checks
 
-`Meet.StartDate` is used as the reference date when evaluating whether an athlete has an active ban. This is a pragmatic approximation (see WADA note below). The field is stored as `DateTime`; the ban check converts it via `DateOnly.FromDateTime(Meet.StartDate)`.
+The meet's start date is used as the reference date when evaluating whether an athlete has an active ban. This is a pragmatic approximation (see WADA note below).
 
 ### Disqualification derivation
 
-`Participation.Disqualified` is **derived**, never set manually. `RecalculateTotals()` computes it as:
+A participation's disqualification status is **derived**, never set manually. It is recomputed whenever attempts are recorded. The formula is:
 
-```
-Disqualified = bombedOut || HasActiveBan(meetDate)
-```
+> Disqualified = bombed out OR has active ban on meet date
 
 where:
 
-- `bombedOut` — the athlete has zero good lifts in any required discipline (Squat, Bench, or Deadlift)
-- `HasActiveBan(meetDate)` — the athlete has at least one ban whose range covers `Meet.StartDate`
-
-`RecalculateTotals()` requires both `Participation.Meet` and `Participation.Athlete` (with `Athlete.Bans`) to be loaded; it throws `InvalidOperationException` if either navigation property is null.
+- **Bombed out** — the athlete has zero good lifts in any required discipline (Squat, Bench, or Deadlift)
+- **Has active ban** — the athlete has at least one ban whose date range covers the meet's start date
 
 ### Preserved values for banned athletes
 
-Banned athletes keep their computed `Total`, `Wilks`, and `IpfPoints` values. Only `Disqualified` is set to `true`. This distinguishes the two disqualification causes:
+Banned athletes keep their computed Total, Wilks, and IpfPoints values. Only the disqualification flag is set. This distinguishes the two disqualification causes:
 
 | Condition | Disqualified | Total |
 |---|---|---|
-| Bomb-out | `true` | `0` |
-| Active ban | `true` | `> 0` |
+| Bomb-out | yes | 0 |
+| Active ban | yes | > 0 |
 
 ### Downstream effects
 
-All views — rankings, personal bests, team points, meet display — filter on `Disqualified`. Setting the flag at the source (in `RecalculateTotals`) propagates correctness everywhere without additional special-casing.
+All views — rankings, personal bests, team points, meet display — filter on the disqualification flag. Setting it at the source propagates correctness everywhere without additional special-casing.
 
 ### Retroactive cascade
 
-When a ban is added or removed, a domain event is raised on the `Athlete` aggregate root:
+When a ban is added or removed, a domain event is raised on the Athlete aggregate root. The event handler runs a retroactive cascade for all participations whose meet falls within the ban period:
 
-- `BanAddedEvent` — raised by `Athlete.AddBan()`
-- `BanRemovedEvent` — raised when a ban is removed (future: `Athlete.RemoveBan()`)
-
-`BanEventHandler` handles both events and runs the retroactive cascade for all participations whose meet falls within the ban period:
-
-1. `RecalculateTotals()` — updates `Disqualified` (and lifts/Total)
-2. `PlaceComputationService.ComputePlacesAsync()` — recomputes meet placements, excluding disqualified athletes from ranked positions
-3. `RecordComputationService.RebuildSlotsAsync()` — rebuilds record slots for affected age/weight/discipline combinations
-
-The cascade runs with one `SaveChangesAsync` call per participation iteration (to persist `Disqualified` before place computation queries) plus a trailing `SaveChangesAsync` for place and rank updates.
+1. Recompute totals and disqualification status
+2. Recompute meet placements, excluding disqualified athletes from ranked positions
+3. Rebuild record slots for affected age/weight/discipline combinations
 
 ---
 
 ## WADA / IPF Reference
 
-KRAFT (Icelandic Powerlifting Federation) follows IPF rules, which implement the WADA Code. Anti-doping oversight for Icelandic athletes is handled by **Lyfjaeftirlit Íslands** (Icelandic Anti-Doping Authority). KRAFT does not maintain independent ban rules.
+KRAFT (Icelandic Powerlifting Federation) follows IPF rules, which implement the WADA Code. Anti-doping oversight for Icelandic athletes is handled by **Lyfjaeftirlit Islands** (Icelandic Anti-Doping Authority). KRAFT does not maintain independent ban rules.
 
 ### Competition vs. Event under WADA
 
 Under the WADA Code, a **Competition** is a single lifting session; an **Event** is the multi-day championship. Ban eligibility is evaluated per Competition (i.e., per lifting session), not per Event.
 
-The system approximates this by using `Meet.StartDate` for all participants, regardless of which session they lifted in. Icelandic meets are typically 1–2 days, making this edge case negligible in practice. If a per-session date is ever added to `Participation`, the ban check becomes a one-line change in `RecalculateTotals()`.
+The system approximates this by using the meet's start date for all participants, regardless of which session they lifted in. Icelandic meets are typically 1-2 days, making this edge case negligible in practice. If a per-session date is ever added to participations, the ban check is a one-line change.

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -71,7 +71,7 @@ When a ban is added or removed, a domain event is raised on the `Athlete` aggreg
 2. `PlaceComputationService.ComputePlacesAsync()` — recomputes meet placements, excluding disqualified athletes from ranked positions
 3. `RecordComputationService.RebuildSlotsAsync()` — rebuilds record slots for affected age/weight/discipline combinations
 
-The cascade runs within a single `SaveChangesAsync` call per event.
+The cascade runs with one `SaveChangesAsync` call per participation iteration (to persist `Disqualified` before place computation queries) plus a trailing `SaveChangesAsync` for place and rank updates.
 
 ---
 

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Athlete.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Athlete.cs
@@ -88,6 +88,12 @@ internal sealed class Athlete : AggregateRoot
         return athlete;
     }
 
+    internal void AddBan(Ban ban)
+    {
+        Bans.Add(ban);
+        Raise(new BanAddedEvent(AthleteId, ban.FromDate, ban.ToDate));
+    }
+
     internal bool HasActiveBan(DateOnly date)
     {
         return Bans.Any(ban =>

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Athlete.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Athlete.cs
@@ -88,11 +88,16 @@ internal sealed class Athlete : AggregateRoot
         return athlete;
     }
 
+    internal bool HasActiveBan(DateOnly date)
+    {
+        return Bans.Any(ban =>
+            date >= DateOnly.FromDateTime(ban.FromDate)
+            && date <= DateOnly.FromDateTime(ban.ToDate));
+    }
+
     internal bool IsEligibleForRecord(DateOnly meetDate)
     {
-        return !Bans.Any(ban =>
-            meetDate >= DateOnly.FromDateTime(ban.FromDate)
-            && meetDate <= DateOnly.FromDateTime(ban.ToDate));
+        return !HasActiveBan(meetDate);
     }
 
     internal Result Update(User modifier, string firstName, string lastName, string gender, Country country, DateOnly? dateOfBirth, Team? team)

--- a/src/KRAFT.Results.WebApi/Features/Athletes/AthleteServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/AthleteServices.cs
@@ -1,4 +1,5 @@
-﻿using KRAFT.Results.WebApi.Features.Athletes.Create;
+﻿using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Athletes.Create;
 using KRAFT.Results.WebApi.Features.Athletes.Delete;
 using KRAFT.Results.WebApi.Features.Athletes.Get;
 using KRAFT.Results.WebApi.Features.Athletes.GetDetails;
@@ -23,6 +24,8 @@ internal static class AthleteServices
         services.AddScoped<GetAthleteRecordsHandler>();
         services.AddScoped<GetAthleteParticipationsHandler>();
         services.AddScoped<UpdateAthleteHandler>();
+        services.AddScoped<IDomainEventHandler<BanAddedEvent>, BanEventHandler>();
+        services.AddScoped<IDomainEventHandler<BanRemovedEvent>, BanEventHandler>();
 
         return services;
     }

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanAddedEvent.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanAddedEvent.cs
@@ -1,0 +1,5 @@
+using KRAFT.Results.WebApi.Abstractions;
+
+namespace KRAFT.Results.WebApi.Features.Athletes;
+
+internal sealed record class BanAddedEvent(int AthleteId, DateTime FromDate, DateTime ToDate) : IDomainEvent;

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanEventHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanEventHandler.cs
@@ -55,12 +55,17 @@ internal sealed class BanEventHandler(
 
     public Task HandleAsync(IDomainEvent domainEvent, CancellationToken cancellationToken)
     {
-        return domainEvent switch
+        if (domainEvent is BanAddedEvent banAddedEvent)
         {
-            BanAddedEvent addedEvent => HandleAsync(addedEvent, cancellationToken),
-            BanRemovedEvent removedEvent => HandleAsync(removedEvent, cancellationToken),
-            _ => Task.CompletedTask,
-        };
+            return HandleAsync(banAddedEvent, cancellationToken);
+        }
+
+        if (domainEvent is BanRemovedEvent banRemovedEvent)
+        {
+            return HandleAsync(banRemovedEvent, cancellationToken);
+        }
+
+        return Task.CompletedTask;
     }
 
     private static List<SlotKey> DetermineAffectedSlots(
@@ -177,6 +182,8 @@ internal sealed class BanEventHandler(
         foreach (Participation participation in affectedParticipations)
         {
             participation.RecalculateTotals();
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
 
             await _placeComputationService.ComputePlacesAsync(participation, cancellationToken);
 

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanEventHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanEventHandler.cs
@@ -150,6 +150,7 @@ internal sealed class BanEventHandler(
                 .ThenInclude(a => a.Bans)
             .Include(p => p.Attempts)
             .Include(p => p.AgeCategory)
+            .AsSingleQuery()
             .Where(p => p.AthleteId == athleteId)
             .Where(p => p.Meet.StartDate >= fromDate)
             .Where(p => p.Meet.StartDate <= toDate)

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanEventHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanEventHandler.cs
@@ -1,0 +1,216 @@
+using KRAFT.Results.Contracts;
+using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Enums;
+using KRAFT.Results.WebApi.Features.AgeCategories;
+using KRAFT.Results.WebApi.Features.Eras;
+using KRAFT.Results.WebApi.Features.Meets;
+using KRAFT.Results.WebApi.Features.Participations;
+using KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
+using KRAFT.Results.WebApi.Features.Records.ComputeRecords;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace KRAFT.Results.WebApi.Features.Athletes;
+
+internal sealed class BanEventHandler(
+    ResultsDbContext dbContext,
+    PlaceComputationService placeComputationService,
+    RecordComputationService recordComputationService,
+    ILogger<BanEventHandler> logger) : IDomainEventHandler<BanAddedEvent>, IDomainEventHandler<BanRemovedEvent>
+{
+    private readonly ResultsDbContext _dbContext = dbContext;
+    private readonly PlaceComputationService _placeComputationService = placeComputationService;
+    private readonly RecordComputationService _recordComputationService = recordComputationService;
+    private readonly ILogger<BanEventHandler> _logger = logger;
+
+    public async Task HandleAsync(BanAddedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Processing BanAddedEvent for athlete {AthleteId}, ban period {FromDate} to {ToDate}",
+            domainEvent.AthleteId,
+            domainEvent.FromDate,
+            domainEvent.ToDate);
+
+        await HandleBanEventAsync(
+            domainEvent.AthleteId,
+            domainEvent.FromDate,
+            domainEvent.ToDate,
+            cancellationToken);
+    }
+
+    public async Task HandleAsync(BanRemovedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Processing BanRemovedEvent for athlete {AthleteId}, ban period {FromDate} to {ToDate}",
+            domainEvent.AthleteId,
+            domainEvent.FromDate,
+            domainEvent.ToDate);
+
+        await HandleBanEventAsync(
+            domainEvent.AthleteId,
+            domainEvent.FromDate,
+            domainEvent.ToDate,
+            cancellationToken);
+    }
+
+    public Task HandleAsync(IDomainEvent domainEvent, CancellationToken cancellationToken)
+    {
+        return domainEvent switch
+        {
+            BanAddedEvent addedEvent => HandleAsync(addedEvent, cancellationToken),
+            BanRemovedEvent removedEvent => HandleAsync(removedEvent, cancellationToken),
+            _ => Task.CompletedTask,
+        };
+    }
+
+    private static List<SlotKey> DetermineAffectedSlots(
+        Participation participation,
+        Meet meet,
+        Era era,
+        Dictionary<string, int> slugToIdMap)
+    {
+        Athlete athlete = participation.Athlete;
+        DateOnly meetDate = DateOnly.FromDateTime(meet.StartDate);
+        string biologicalSlug = AgeCategory.ResolveSlug(athlete.DateOfBirth, meetDate);
+        IReadOnlyList<string> cascadeSlugs = AgeCategory.GetCascadeSlugs(biologicalSlug);
+
+        List<int> cascadeAgeCategoryIds = [];
+
+        foreach (string cascadeSlug in cascadeSlugs)
+        {
+            if (slugToIdMap.TryGetValue(cascadeSlug, out int ageCategoryId))
+            {
+                cascadeAgeCategoryIds.Add(ageCategoryId);
+            }
+        }
+
+        IReadOnlyList<Discipline> requiredDisciplines = meet.Category.GetDisciplines();
+
+        List<RecordCategory> applicableCategories = [];
+
+        foreach (Discipline discipline in requiredDisciplines)
+        {
+            RecordCategory category = meet.Category.MapDisciplineToRecordCategory(discipline);
+
+            if (category != RecordCategory.None)
+            {
+                applicableCategories.Add(category);
+
+                RecordCategory? singleLiftCategory = category switch
+                {
+                    RecordCategory.Bench => RecordCategory.BenchSingle,
+                    RecordCategory.Deadlift => RecordCategory.DeadliftSingle,
+                    _ => null,
+                };
+
+                if (singleLiftCategory is not null)
+                {
+                    applicableCategories.Add(singleLiftCategory.Value);
+                }
+            }
+        }
+
+        if (requiredDisciplines.Count > 1 && participation.Total > 0)
+        {
+            applicableCategories.Add(RecordCategory.Total);
+        }
+
+        List<SlotKey> affectedSlots = [];
+
+        foreach (RecordCategory category in applicableCategories)
+        {
+            foreach (int ageCategoryId in cascadeAgeCategoryIds)
+            {
+                affectedSlots.Add(new SlotKey(
+                    era.EraId,
+                    ageCategoryId,
+                    participation.WeightCategoryId,
+                    category,
+                    meet.IsRaw));
+            }
+        }
+
+        return affectedSlots;
+    }
+
+    private async Task HandleBanEventAsync(
+        int athleteId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken)
+    {
+        List<Participation> affectedParticipations = await _dbContext.Set<Participation>()
+            .Include(p => p.Meet)
+            .Include(p => p.Athlete)
+                .ThenInclude(a => a.Bans)
+            .Include(p => p.Attempts)
+            .Include(p => p.AgeCategory)
+            .Where(p => p.AthleteId == athleteId)
+            .Where(p => p.Meet.StartDate >= fromDate)
+            .Where(p => p.Meet.StartDate <= toDate)
+            .Where(p => p.Attempts.Any())
+            .ToListAsync(cancellationToken);
+
+        if (affectedParticipations.Count == 0)
+        {
+            _logger.LogInformation(
+                "No affected participations found for athlete {AthleteId} in ban period {FromDate} to {ToDate}",
+                athleteId,
+                fromDate,
+                toDate);
+            return;
+        }
+
+        List<Era> eras = await _dbContext.Set<Era>()
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        Dictionary<string, int> slugToIdMap = await _dbContext.Set<AgeCategory>()
+            .Where(ac => ac.Slug != null)
+            .ToDictionaryAsync(
+                ac => ac.Slug!,
+                ac => ac.AgeCategoryId,
+                cancellationToken);
+
+        List<SlotKey> allAffectedSlots = [];
+
+        foreach (Participation participation in affectedParticipations)
+        {
+            participation.RecalculateTotals();
+
+            await _placeComputationService.ComputePlacesAsync(participation, cancellationToken);
+
+            Meet meet = participation.Meet;
+            DateOnly meetDate = DateOnly.FromDateTime(meet.StartDate);
+
+            Era? era = eras.FirstOrDefault(
+                e => e.StartDate <= meetDate && e.EndDate >= meetDate);
+
+            if (era is null)
+            {
+                _logger.LogWarning(
+                    "No era found for meet date {MeetDate} (ParticipationId: {ParticipationId})",
+                    meetDate,
+                    participation.ParticipationId);
+                continue;
+            }
+
+            List<SlotKey> participationSlots = DetermineAffectedSlots(
+                participation,
+                meet,
+                era,
+                slugToIdMap);
+
+            allAffectedSlots.AddRange(participationSlots);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        List<SlotKey> distinctSlots = allAffectedSlots.Distinct().ToList();
+
+        if (distinctSlots.Count > 0)
+        {
+            await _recordComputationService.RebuildSlotsAsync(distinctSlots, cancellationToken);
+        }
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Athletes/BanRemovedEvent.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/BanRemovedEvent.cs
@@ -1,0 +1,5 @@
+using KRAFT.Results.WebApi.Abstractions;
+
+namespace KRAFT.Results.WebApi.Features.Athletes;
+
+internal sealed record class BanRemovedEvent(int AthleteId, DateTime FromDate, DateTime ToDate) : IDomainEvent;

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetParticipations/GetMeetParticipationsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetParticipations/GetMeetParticipationsHandler.cs
@@ -87,7 +87,7 @@ internal sealed class GetMeetParticipationsHandler(ResultsDbContext dbContext)
                     });
 
                 IReadOnlyList<Discipline> disciplines = r.Category.GetDisciplines();
-                decimal displayTotal = r.Disqualified ? 0m : ComputeDisplayTotal(disciplines, attempts);
+                decimal displayTotal = r.Total == 0 ? 0m : ComputeDisplayTotal(disciplines, attempts);
 
                 return new MeetParticipation(
                     r.ParticipationId,

--- a/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
@@ -50,6 +50,8 @@ internal sealed class RecordAttemptHandler
         Participation? participation = await _dbContext.Set<Participation>()
             .Include(p => p.Attempts)
             .Include(p => p.Meet)
+            .Include(p => p.Athlete)
+            .ThenInclude(a => a.Bans)
             .Where(p => p.ParticipationId == participationId)
             .FirstOrDefaultAsync(
                 p => p.MeetId == meetId,

--- a/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/RecordAttempt/RecordAttemptHandler.cs
@@ -51,7 +51,8 @@ internal sealed class RecordAttemptHandler
             .Include(p => p.Attempts)
             .Include(p => p.Meet)
             .Include(p => p.Athlete)
-            .ThenInclude(a => a.Bans)
+                .ThenInclude(a => a.Bans)
+            .AsSingleQuery()
             .Where(p => p.ParticipationId == participationId)
             .FirstOrDefaultAsync(
                 p => p.MeetId == meetId,

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -45,6 +45,7 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
     {
         List<Participation> ranked = groupParticipations
             .Where(p => p.Total > 0)
+            .Where(p => !p.Disqualified)
             .OrderByDescending(p => p.Total)
             .ThenBy(p => p.Weight.Value)
             .ThenBy(p => p.LotNo)
@@ -58,7 +59,7 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
             rank++;
         }
 
-        foreach (Participation p in groupParticipations.Where(p => p.Total == 0))
+        foreach (Participation p in groupParticipations.Where(p => p.Total == 0 || p.Disqualified))
         {
             p.UpdateRanking(0);
         }

--- a/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
@@ -173,6 +173,16 @@ internal sealed class Participation : AggregateRoot
 
     internal void RecalculateTotals()
     {
+        if (Athlete is null)
+        {
+            throw new InvalidOperationException("Athlete navigation property must be loaded before calling RecalculateTotals.");
+        }
+
+        if (Meet is null)
+        {
+            throw new InvalidOperationException("Meet navigation property must be loaded before calling RecalculateTotals.");
+        }
+
         decimal bestSquat = BestGoodLift(Discipline.Squat);
         decimal bestBench = BestGoodLift(Discipline.Bench);
         decimal bestDeadlift = BestGoodLift(Discipline.Deadlift);
@@ -183,7 +193,7 @@ internal sealed class Participation : AggregateRoot
 
         bool bombedOut = bestSquat == 0 || bestBench == 0 || bestDeadlift == 0;
         Total = bombedOut ? 0 : bestSquat + bestBench + bestDeadlift;
-        Disqualified = bombedOut;
+        Disqualified = bombedOut || Athlete.HasActiveBan(DateOnly.FromDateTime(Meet.StartDate));
     }
 
     private decimal BestGoodLift(Discipline discipline)

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/BanDisqualificationTestsCollection.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/BanDisqualificationTestsCollection.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+[CollectionDefinition(nameof(BanDisqualificationTestsCollection))]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "xUnit collection definition")]
+public sealed class BanDisqualificationTestsCollection : ICollectionFixture<CollectionFixture>
+{
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/BanDisqualificationTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/BanDisqualificationTests.cs
@@ -64,8 +64,9 @@ public sealed class BanDisqualificationTests(CollectionFixture fixture) : IAsync
     public async Task BannedAthlete_IsDisqualified_WithPreservedTotal()
     {
         // Arrange
-        (HttpClient recordClient, RecordComputationChannel channel) =
+        (HttpClient recordClientRaw, RecordComputationChannel channel) =
             fixture.CreateAuthorizedHttpClientWithRecordComputation();
+        using HttpClient recordClient = recordClientRaw;
 
         string athleteSlug = await CreateAthleteAsync("BanDq", "m", new DateOnly(1990, 6, 15));
         _banAthleteSlugsToClear.Add(athleteSlug);
@@ -93,17 +94,15 @@ public sealed class BanDisqualificationTests(CollectionFixture fixture) : IAsync
         banned.ShouldNotBeNull();
         banned.Disqualified.ShouldBeTrue();
         banned.Total.ShouldBeGreaterThan(0m);
-
-        // Cleanup
-        recordClient.Dispose();
     }
 
     [Fact]
     public async Task BannedAthlete_IsExcludedFromRankings_WhileUnbannedAthleteIsRanked()
     {
         // Arrange
-        (HttpClient recordClient, RecordComputationChannel channel) =
+        (HttpClient recordClientRaw, RecordComputationChannel channel) =
             fixture.CreateAuthorizedHttpClientWithRecordComputation();
+        using HttpClient recordClient = recordClientRaw;
 
         string bannedSlug = await CreateAthleteAsync("BanEx1", "m", new DateOnly(1988, 3, 10));
         string unbannedSlug = await CreateAthleteAsync("BanEx2", "m", new DateOnly(1985, 5, 20));
@@ -143,9 +142,6 @@ public sealed class BanDisqualificationTests(CollectionFixture fixture) : IAsync
         unbanned.ShouldNotBeNull();
         banned.Rank.ShouldBe(0);
         unbanned.Rank.ShouldBe(1);
-
-        // Cleanup
-        recordClient.Dispose();
     }
 
     private static async Task RecordAttemptAsync(

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/BanDisqualificationTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/BanDisqualificationTests.cs
@@ -1,0 +1,243 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.Features.Records.ComputeRecords;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
+
+[Collection(nameof(BanDisqualificationTestsCollection))]
+[SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "SQL is composed from compile-time constants and GUID-derived slugs containing only URL-safe characters")]
+[SuppressMessage("Security", "EF1002:Risk of vulnerability to SQL injection", Justification = "SQL is composed from compile-time constants and GUID-derived slugs containing only URL-safe characters")]
+public sealed class BanDisqualificationTests(CollectionFixture fixture) : IAsyncLifetime
+{
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly List<string> _athleteSlugs = [];
+    private readonly List<string> _meetSlugs = [];
+    private readonly List<(int MeetId, int ParticipationId)> _participations = [];
+    private readonly List<string> _banAthleteSlugsToClear = [];
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (string slug in _banAthleteSlugsToClear)
+        {
+            await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+            ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+            await dbContext.Database.ExecuteSqlRawAsync(
+                $"DELETE FROM Bans WHERE AthleteId = (SELECT AthleteId FROM Athletes WHERE Slug = '{slug}')",
+                CancellationToken.None);
+        }
+
+        foreach ((int meetId, int participationId) in _participations)
+        {
+            await _authorizedHttpClient.DeleteAsync(
+                $"/meets/{meetId}/participants/{participationId}", CancellationToken.None);
+        }
+
+        foreach (string slug in _meetSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{slug}", CancellationToken.None);
+        }
+
+        foreach (string slug in _athleteSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+    }
+
+    [Fact]
+    public async Task BannedAthlete_IsDisqualified_WithPreservedTotal()
+    {
+        // Arrange
+        (HttpClient recordClient, RecordComputationChannel channel) =
+            fixture.CreateAuthorizedHttpClientWithRecordComputation();
+
+        string athleteSlug = await CreateAthleteAsync("BanDq", "m", new DateOnly(1990, 6, 15));
+        _banAthleteSlugsToClear.Add(athleteSlug);
+
+        (int meetId, string meetSlug) = await CreateMeetAndGetIdAsync(new DateOnly(2025, 3, 15));
+
+        int participationId = await AddParticipantAsync(meetId, athleteSlug, 80.5m);
+
+        await InsertBanCoveringDateAsync(athleteSlug, new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31));
+
+        await RecordAttemptAsync(recordClient, meetId, participationId, Discipline.Squat, 1, 100.0m);
+        await RecordAttemptAsync(recordClient, meetId, participationId, Discipline.Bench, 1, 60.0m);
+        await RecordAttemptAsync(recordClient, meetId, participationId, Discipline.Deadlift, 1, 150.0m);
+        await channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{meetSlug}/participations",
+                CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        MeetParticipation? banned = participations.FirstOrDefault(p => p.ParticipationId == participationId);
+        banned.ShouldNotBeNull();
+        banned.Disqualified.ShouldBeTrue();
+        banned.Total.ShouldBeGreaterThan(0m);
+
+        // Cleanup
+        recordClient.Dispose();
+    }
+
+    [Fact]
+    public async Task BannedAthlete_IsExcludedFromRankings_WhileUnbannedAthleteIsRanked()
+    {
+        // Arrange
+        (HttpClient recordClient, RecordComputationChannel channel) =
+            fixture.CreateAuthorizedHttpClientWithRecordComputation();
+
+        string bannedSlug = await CreateAthleteAsync("BanEx1", "m", new DateOnly(1988, 3, 10));
+        string unbannedSlug = await CreateAthleteAsync("BanEx2", "m", new DateOnly(1985, 5, 20));
+        _banAthleteSlugsToClear.Add(bannedSlug);
+
+        (int meetId, string meetSlug) = await CreateMeetAndGetIdAsync(new DateOnly(2025, 5, 1));
+
+        int bannedParticipationId = await AddParticipantAsync(meetId, bannedSlug, 80.5m);
+        int unbannedParticipationId = await AddParticipantAsync(meetId, unbannedSlug, 82.0m);
+
+        await InsertBanCoveringDateAsync(bannedSlug, new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31));
+
+        // Banned athlete — valid lifts, but ban covers the meet date
+        await RecordAttemptAsync(recordClient, meetId, bannedParticipationId, Discipline.Squat, 1, 120.0m);
+        await RecordAttemptAsync(recordClient, meetId, bannedParticipationId, Discipline.Bench, 1, 70.0m);
+        await RecordAttemptAsync(recordClient, meetId, bannedParticipationId, Discipline.Deadlift, 1, 160.0m);
+        await channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Unbanned athlete — valid lifts, should rank 1
+        await RecordAttemptAsync(recordClient, meetId, unbannedParticipationId, Discipline.Squat, 1, 80.0m);
+        await RecordAttemptAsync(recordClient, meetId, unbannedParticipationId, Discipline.Bench, 1, 40.0m);
+        await RecordAttemptAsync(recordClient, meetId, unbannedParticipationId, Discipline.Deadlift, 1, 120.0m);
+        await channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        IReadOnlyList<MeetParticipation>? participations = await _authorizedHttpClient
+            .GetFromJsonAsync<IReadOnlyList<MeetParticipation>>(
+                $"/meets/{meetSlug}/participations",
+                CancellationToken.None);
+
+        // Assert
+        participations.ShouldNotBeNull();
+        MeetParticipation? banned = participations.FirstOrDefault(p => p.ParticipationId == bannedParticipationId);
+        MeetParticipation? unbanned = participations.FirstOrDefault(p => p.ParticipationId == unbannedParticipationId);
+
+        banned.ShouldNotBeNull();
+        unbanned.ShouldNotBeNull();
+        banned.Rank.ShouldBe(0);
+        unbanned.Rank.ShouldBe(1);
+
+        // Cleanup
+        recordClient.Dispose();
+    }
+
+    private static async Task RecordAttemptAsync(
+        HttpClient client,
+        int meetId,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .Build();
+
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    private async Task<string> CreateAthleteAsync(string prefix, string gender, DateOnly dateOfBirth)
+    {
+        string suffix = UniqueShortCode.Next();
+        string firstName = $"{prefix}{suffix}";
+        string lastName = "Bd";
+
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
+            .WithFirstName(firstName)
+            .WithLastName(lastName)
+            .WithGender(gender)
+            .WithDateOfBirth(dateOfBirth)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = Slug.Create($"{firstName} {lastName}");
+        _athleteSlugs.Add(slug);
+        return slug;
+    }
+
+    private async Task<(int MeetId, string MeetSlug)> CreateMeetAndGetIdAsync(DateOnly startDate)
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder()
+            .WithStartDate(startDate)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+        _meetSlugs.Add(slug);
+
+        MeetDetails? meetDetails = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{slug}", CancellationToken.None);
+
+        return (meetDetails!.MeetId, slug);
+    }
+
+    private async Task<int> AddParticipantAsync(int meetId, string athleteSlug, decimal bodyWeight)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(bodyWeight)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        int participationId = result!.ParticipationId;
+        _participations.Add((meetId, participationId));
+        return participationId;
+    }
+
+    private async Task InsertBanCoveringDateAsync(string athleteSlug, DateOnly fromDate, DateOnly toDate)
+    {
+        await using AsyncServiceScope scope = fixture.Factory!.Services.CreateAsyncScope();
+        ResultsDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResultsDbContext>();
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            $"""
+            DECLARE @aid INT = (SELECT AthleteId FROM Athletes WHERE Slug = '{athleteSlug}');
+            INSERT INTO Bans (AthleteId, FromDate, ToDate) VALUES (@aid, '{fromDate:yyyy-MM-dd}', '{toDate:yyyy-MM-dd}');
+            """,
+            CancellationToken.None);
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/AddBan/AddBanTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/AddBan/AddBanTests.cs
@@ -1,0 +1,57 @@
+using KRAFT.Results.WebApi.Features.Athletes;
+using KRAFT.Results.WebApi.Features.Countries;
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Athletes.Athlete.AddBan;
+
+public sealed class AddBanTests
+{
+    [Fact]
+    public void WhenBanAdded_AddsBanToBansCollection()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+        Ban ban = new BanBuilder().Build();
+
+        // Act
+        athlete.AddBan(ban);
+
+        // Assert
+        athlete.Bans.ShouldContain(ban);
+    }
+
+    [Fact]
+    public void WhenBanAdded_RaisesBanAddedEvent()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
+
+        // Act
+        athlete.AddBan(ban);
+
+        // Assert
+        BanAddedEvent? domainEvent = athlete.DomainEvents
+            .OfType<BanAddedEvent>()
+            .FirstOrDefault();
+
+        domainEvent.ShouldNotBeNull();
+        domainEvent.AthleteId.ShouldBe(athlete.AthleteId);
+        domainEvent.FromDate.ShouldBe(ban.FromDate);
+        domainEvent.ToDate.ShouldBe(ban.ToDate);
+    }
+
+    private static WebApi.Features.Athletes.Athlete CreateAthlete()
+    {
+        User creator = new UserBuilder().Build();
+        Country country = new();
+        return WebApi.Features.Athletes.Athlete.Create(
+            creator, "John", "Doe", "m", country, null, null).FromResult();
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/HasActiveBan/HasActiveBanTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Athletes/Athlete/HasActiveBan/HasActiveBanTests.cs
@@ -1,0 +1,122 @@
+using KRAFT.Results.WebApi.Features.Athletes;
+using KRAFT.Results.WebApi.Features.Countries;
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Athletes.Athlete.HasActiveBan;
+
+public sealed class HasActiveBanTests
+{
+    [Fact]
+    public void WhenNoBans_ReturnsFalse()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+
+        // Act
+        bool result = athlete.HasActiveBan(new DateOnly(2025, 6, 15));
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WhenDateEqualsBanToDate_ReturnsTrue()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
+        athlete.Bans.Add(ban);
+
+        // Act
+        bool result = athlete.HasActiveBan(new DateOnly(2025, 6, 15));
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WhenDateEqualsBanFromDate_ReturnsTrue()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
+        athlete.Bans.Add(ban);
+
+        // Act
+        bool result = athlete.HasActiveBan(new DateOnly(2025, 6, 15));
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WhenBanStartsAfterMeetDate_ReturnsFalse()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
+        athlete.Bans.Add(ban);
+
+        // Act
+        bool result = athlete.HasActiveBan(new DateOnly(2025, 6, 15));
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WhenBanEndsBeforeMeetDate_ReturnsFalse()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2024, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
+        athlete.Bans.Add(ban);
+
+        // Act
+        bool result = athlete.HasActiveBan(new DateOnly(2025, 6, 15));
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WhenBanCoversMeetDate_ReturnsTrue()
+    {
+        // Arrange
+        WebApi.Features.Athletes.Athlete athlete = CreateAthlete();
+        Ban ban = new BanBuilder()
+            .WithFromDate(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithToDate(new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
+        athlete.Bans.Add(ban);
+
+        // Act
+        bool result = athlete.HasActiveBan(new DateOnly(2025, 6, 15));
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    private static WebApi.Features.Athletes.Athlete CreateAthlete()
+    {
+        User creator = new UserBuilder().Build();
+        Country country = new();
+        return WebApi.Features.Athletes.Athlete.Create(
+            creator, "John", "Doe", "m", country, null, null).FromResult();
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedTests.cs
@@ -1,12 +1,8 @@
-using System.Reflection;
-
 using KRAFT.Results.Contracts;
-using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Attempts;
-using KRAFT.Results.WebApi.Features.Countries;
-using KRAFT.Results.WebApi.Features.Meets;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.UnitTests.Builders;
+using KRAFT.Results.WebApi.UnitTests.Helpers;
 
 using Shouldly;
 
@@ -80,34 +76,6 @@ public sealed class SetsDisqualifiedTests
         DateTime meetStartDate = default,
         WebApi.Features.Athletes.Athlete? athlete = null)
     {
-        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
-            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
-
-        if (athlete is null)
-        {
-            athlete = WebApi.Features.Athletes.Athlete.Create(
-                creator, "John", "Doe", "m", new Country(), null, null).FromResult();
-        }
-
-        DateTime resolvedStartDate = meetStartDate == default
-            ? new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc)
-            : meetStartDate;
-
-        WebApi.Features.Meets.Meet meet = WebApi.Features.Meets.Meet.Create(
-            creator,
-            WebApi.Features.Meets.MeetCategory.Powerlifting,
-            "Test Meet",
-            DateOnly.FromDateTime(resolvedStartDate)).FromResult();
-
-        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Athlete), athlete);
-        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Meet), meet);
-
-        return participation;
-    }
-
-    private static void SetProperty<T>(object target, string propertyName, T value)
-    {
-        PropertyInfo property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
-        property.SetValue(target, value);
+        return ParticipationTestHelper.CreateParticipationWithNavigations(creator, meetStartDate, athlete);
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedTests.cs
@@ -1,6 +1,10 @@
+using System.Reflection;
+
 using KRAFT.Results.Contracts;
 using KRAFT.Results.WebApi.Abstractions;
 using KRAFT.Results.WebApi.Features.Attempts;
+using KRAFT.Results.WebApi.Features.Countries;
+using KRAFT.Results.WebApi.Features.Meets;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.UnitTests.Builders;
 
@@ -15,8 +19,7 @@ public sealed class SetsDisqualifiedTests
     {
         // Arrange
         User creator = new UserBuilder().Build();
-        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
-            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+        WebApi.Features.Participations.Participation participation = CreateParticipationWithNavigations(creator);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: false, createdBy: "test");
         participation.RecordAttempt(Discipline.Squat, round: 2, weight: 100m, good: false, createdBy: "test");
@@ -34,8 +37,7 @@ public sealed class SetsDisqualifiedTests
     {
         // Arrange
         User creator = new UserBuilder().Build();
-        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
-            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+        WebApi.Features.Participations.Participation participation = CreateParticipationWithNavigations(creator);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: true, createdBy: "test");
         participation.RecordAttempt(Discipline.Bench, round: 1, weight: 60m, good: true, createdBy: "test");
@@ -53,8 +55,7 @@ public sealed class SetsDisqualifiedTests
     {
         // Arrange
         User creator = new UserBuilder().Build();
-        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
-            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+        WebApi.Features.Participations.Participation participation = CreateParticipationWithNavigations(creator);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: false, createdBy: "test");
         participation.RecordAttempt(Discipline.Squat, round: 2, weight: 100m, good: false, createdBy: "test");
@@ -72,5 +73,41 @@ public sealed class SetsDisqualifiedTests
 
         // Assert
         participation.Disqualified.ShouldBeFalse();
+    }
+
+    internal static WebApi.Features.Participations.Participation CreateParticipationWithNavigations(
+        User creator,
+        DateTime meetStartDate = default,
+        WebApi.Features.Athletes.Athlete? athlete = null)
+    {
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        if (athlete is null)
+        {
+            athlete = WebApi.Features.Athletes.Athlete.Create(
+                creator, "John", "Doe", "m", new Country(), null, null).FromResult();
+        }
+
+        DateTime resolvedStartDate = meetStartDate == default
+            ? new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc)
+            : meetStartDate;
+
+        WebApi.Features.Meets.Meet meet = WebApi.Features.Meets.Meet.Create(
+            creator,
+            WebApi.Features.Meets.MeetCategory.Powerlifting,
+            "Test Meet",
+            DateOnly.FromDateTime(resolvedStartDate)).FromResult();
+
+        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Athlete), athlete);
+        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Meet), meet);
+
+        return participation;
+    }
+
+    private static void SetProperty<T>(object target, string propertyName, T value)
+    {
+        PropertyInfo property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
+        property.SetValue(target, value);
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedTests.cs
@@ -15,7 +15,7 @@ public sealed class SetsDisqualifiedTests
     {
         // Arrange
         User creator = new UserBuilder().Build();
-        WebApi.Features.Participations.Participation participation = CreateParticipationWithNavigations(creator);
+        WebApi.Features.Participations.Participation participation = ParticipationTestHelper.CreateParticipationWithNavigations(creator);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: false, createdBy: "test");
         participation.RecordAttempt(Discipline.Squat, round: 2, weight: 100m, good: false, createdBy: "test");
@@ -33,7 +33,7 @@ public sealed class SetsDisqualifiedTests
     {
         // Arrange
         User creator = new UserBuilder().Build();
-        WebApi.Features.Participations.Participation participation = CreateParticipationWithNavigations(creator);
+        WebApi.Features.Participations.Participation participation = ParticipationTestHelper.CreateParticipationWithNavigations(creator);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: true, createdBy: "test");
         participation.RecordAttempt(Discipline.Bench, round: 1, weight: 60m, good: true, createdBy: "test");
@@ -51,7 +51,7 @@ public sealed class SetsDisqualifiedTests
     {
         // Arrange
         User creator = new UserBuilder().Build();
-        WebApi.Features.Participations.Participation participation = CreateParticipationWithNavigations(creator);
+        WebApi.Features.Participations.Participation participation = ParticipationTestHelper.CreateParticipationWithNavigations(creator);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: false, createdBy: "test");
         participation.RecordAttempt(Discipline.Squat, round: 2, weight: 100m, good: false, createdBy: "test");
@@ -69,13 +69,5 @@ public sealed class SetsDisqualifiedTests
 
         // Assert
         participation.Disqualified.ShouldBeFalse();
-    }
-
-    internal static WebApi.Features.Participations.Participation CreateParticipationWithNavigations(
-        User creator,
-        DateTime meetStartDate = default,
-        WebApi.Features.Athletes.Athlete? athlete = null)
-    {
-        return ParticipationTestHelper.CreateParticipationWithNavigations(creator, meetStartDate, athlete);
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedWhenBannedTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedWhenBannedTests.cs
@@ -2,6 +2,7 @@ using KRAFT.Results.Contracts;
 using KRAFT.Results.WebApi.Features.Countries;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.UnitTests.Builders;
+using KRAFT.Results.WebApi.UnitTests.Helpers;
 
 using Shouldly;
 
@@ -22,7 +23,7 @@ public sealed class SetsDisqualifiedWhenBannedTests
             banTo: new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc));
 
         DateTime meetDate = new(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
-        WebApi.Features.Participations.Participation participation = SetsDisqualifiedTests.CreateParticipationWithNavigations(
+        WebApi.Features.Participations.Participation participation = ParticipationTestHelper.CreateParticipationWithNavigations(
             creator, meetDate, athlete);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: true, createdBy: "test");
@@ -50,7 +51,7 @@ public sealed class SetsDisqualifiedWhenBannedTests
             banTo: new DateTime(2024, 12, 31, 0, 0, 0, DateTimeKind.Utc));
 
         DateTime meetDate = new(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
-        WebApi.Features.Participations.Participation participation = SetsDisqualifiedTests.CreateParticipationWithNavigations(
+        WebApi.Features.Participations.Participation participation = ParticipationTestHelper.CreateParticipationWithNavigations(
             creator, meetDate, athlete);
 
         participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: true, createdBy: "test");
@@ -77,7 +78,7 @@ public sealed class SetsDisqualifiedWhenBannedTests
             banTo: new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc));
 
         DateTime meetDate = new(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
-        WebApi.Features.Participations.Participation participation = SetsDisqualifiedTests.CreateParticipationWithNavigations(
+        WebApi.Features.Participations.Participation participation = ParticipationTestHelper.CreateParticipationWithNavigations(
             creator, meetDate, athlete);
 
         // All squat attempts failed — bomb-out

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedWhenBannedTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/SetsDisqualifiedWhenBannedTests.cs
@@ -1,0 +1,115 @@
+using KRAFT.Results.Contracts;
+using KRAFT.Results.WebApi.Features.Countries;
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Participations.Participation.RecalculateTotals;
+
+public sealed class SetsDisqualifiedWhenBannedTests
+{
+    [Fact]
+    public void SetsDisqualifiedTrue_WhenAthleteHasActiveBanOnMeetDate()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+
+        // Ban covers 2025-01-01 to 2025-12-31; meet is on 2025-06-15
+        WebApi.Features.Athletes.Athlete athlete = CreateAthleteWithBan(
+            creator,
+            banFrom: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            banTo: new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+
+        DateTime meetDate = new(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        WebApi.Features.Participations.Participation participation = SetsDisqualifiedTests.CreateParticipationWithNavigations(
+            creator, meetDate, athlete);
+
+        participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: true, createdBy: "test");
+        participation.RecordAttempt(Discipline.Bench, round: 1, weight: 60m, good: true, createdBy: "test");
+        participation.RecordAttempt(Discipline.Deadlift, round: 1, weight: 120m, good: true, createdBy: "test");
+
+        // Act
+        participation.RecalculateTotals();
+
+        // Assert
+        participation.Disqualified.ShouldBeTrue();
+        participation.Total.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void SetsDisqualifiedFalse_WhenAthletesBanDoesNotCoverMeetDate()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+
+        // Ban ended before meet date: ban is 2024-01-01 to 2024-12-31; meet is on 2025-06-15
+        WebApi.Features.Athletes.Athlete athlete = CreateAthleteWithBan(
+            creator,
+            banFrom: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            banTo: new DateTime(2024, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+
+        DateTime meetDate = new(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        WebApi.Features.Participations.Participation participation = SetsDisqualifiedTests.CreateParticipationWithNavigations(
+            creator, meetDate, athlete);
+
+        participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: true, createdBy: "test");
+        participation.RecordAttempt(Discipline.Bench, round: 1, weight: 60m, good: true, createdBy: "test");
+        participation.RecordAttempt(Discipline.Deadlift, round: 1, weight: 120m, good: true, createdBy: "test");
+
+        // Act
+        participation.RecalculateTotals();
+
+        // Assert
+        participation.Disqualified.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetsDisqualifiedTrue_WhenAthleteHasActiveBanAndBombedOut()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+
+        // Ban covers meet date
+        WebApi.Features.Athletes.Athlete athlete = CreateAthleteWithBan(
+            creator,
+            banFrom: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            banTo: new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+
+        DateTime meetDate = new(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        WebApi.Features.Participations.Participation participation = SetsDisqualifiedTests.CreateParticipationWithNavigations(
+            creator, meetDate, athlete);
+
+        // All squat attempts failed — bomb-out
+        participation.RecordAttempt(Discipline.Squat, round: 1, weight: 100m, good: false, createdBy: "test");
+        participation.RecordAttempt(Discipline.Squat, round: 2, weight: 100m, good: false, createdBy: "test");
+        participation.RecordAttempt(Discipline.Squat, round: 3, weight: 100m, good: false, createdBy: "test");
+        participation.RecordAttempt(Discipline.Bench, round: 1, weight: 60m, good: true, createdBy: "test");
+        participation.RecordAttempt(Discipline.Deadlift, round: 1, weight: 120m, good: true, createdBy: "test");
+
+        // Act
+        participation.RecalculateTotals();
+
+        // Assert
+        participation.Disqualified.ShouldBeTrue();
+        participation.Total.ShouldBe(0);
+    }
+
+    private static WebApi.Features.Athletes.Athlete CreateAthleteWithBan(
+        User creator,
+        DateTime banFrom,
+        DateTime banTo)
+    {
+        WebApi.Features.Athletes.Athlete athlete = WebApi.Features.Athletes.Athlete.Create(
+            creator, "Jane", "Doe", "f", new Country(), null, null).FromResult();
+
+        WebApi.Features.Athletes.Ban ban = new BanBuilder()
+            .WithFromDate(banFrom)
+            .WithToDate(banTo)
+            .Build();
+
+        athlete.Bans.Add(ban);
+
+        return athlete;
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/ThrowsWhenNavigationNotLoadedTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/ThrowsWhenNavigationNotLoadedTests.cs
@@ -1,9 +1,8 @@
-using System.Reflection;
-
 using KRAFT.Results.WebApi.Features.Athletes;
 using KRAFT.Results.WebApi.Features.Countries;
 using KRAFT.Results.WebApi.Features.Users;
 using KRAFT.Results.WebApi.UnitTests.Builders;
+using KRAFT.Results.WebApi.UnitTests.Helpers;
 
 using Shouldly;
 
@@ -36,18 +35,12 @@ public sealed class ThrowsWhenNavigationNotLoadedTests
 
         WebApi.Features.Athletes.Athlete athlete = WebApi.Features.Athletes.Athlete.Create(
             creator, "John", "Doe", "m", new Country(), null, null).FromResult();
-        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Athlete), athlete);
+        ParticipationTestHelper.SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Athlete), athlete);
 
         // Act
         Action act = () => participation.RecalculateTotals();
 
         // Assert
         Should.Throw<InvalidOperationException>(act);
-    }
-
-    private static void SetProperty<T>(object target, string propertyName, T value)
-    {
-        PropertyInfo property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
-        property.SetValue(target, value);
     }
 }

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/ThrowsWhenNavigationNotLoadedTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/RecalculateTotals/ThrowsWhenNavigationNotLoadedTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+
+using KRAFT.Results.WebApi.Features.Athletes;
+using KRAFT.Results.WebApi.Features.Countries;
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Participations.Participation.RecalculateTotals;
+
+public sealed class ThrowsWhenNavigationNotLoadedTests
+{
+    [Fact]
+    public void WhenAthleteNotLoaded_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        // Act
+        Action act = () => participation.RecalculateTotals();
+
+        // Assert
+        Should.Throw<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void WhenMeetNotLoaded_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        WebApi.Features.Athletes.Athlete athlete = WebApi.Features.Athletes.Athlete.Create(
+            creator, "John", "Doe", "m", new Country(), null, null).FromResult();
+        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Athlete), athlete);
+
+        // Act
+        Action act = () => participation.RecalculateTotals();
+
+        // Assert
+        Should.Throw<InvalidOperationException>(act);
+    }
+
+    private static void SetProperty<T>(object target, string propertyName, T value)
+    {
+        PropertyInfo property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
+        property.SetValue(target, value);
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Helpers/ParticipationTestHelper.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Helpers/ParticipationTestHelper.cs
@@ -10,7 +10,7 @@ internal static class ParticipationTestHelper
 {
     internal static WebApi.Features.Participations.Participation CreateParticipationWithNavigations(
         User creator,
-        DateTime meetStartDate = default,
+        DateTime? meetStartDate = null,
         WebApi.Features.Athletes.Athlete? athlete = null)
     {
         WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
@@ -22,9 +22,7 @@ internal static class ParticipationTestHelper
                 creator, "John", "Doe", "m", new Country(), null, null).FromResult();
         }
 
-        DateTime resolvedStartDate = meetStartDate == default
-            ? new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc)
-            : meetStartDate;
+        DateTime resolvedStartDate = meetStartDate ?? new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc);
 
         WebApi.Features.Meets.Meet meet = WebApi.Features.Meets.Meet.Create(
             creator,

--- a/tests/KRAFT.Results.WebApi.UnitTests/Helpers/ParticipationTestHelper.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Helpers/ParticipationTestHelper.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+
+using KRAFT.Results.WebApi.Features.Countries;
+using KRAFT.Results.WebApi.Features.Meets;
+using KRAFT.Results.WebApi.Features.Users;
+
+namespace KRAFT.Results.WebApi.UnitTests.Helpers;
+
+internal static class ParticipationTestHelper
+{
+    internal static WebApi.Features.Participations.Participation CreateParticipationWithNavigations(
+        User creator,
+        DateTime meetStartDate = default,
+        WebApi.Features.Athletes.Athlete? athlete = null)
+    {
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+
+        if (athlete is null)
+        {
+            athlete = WebApi.Features.Athletes.Athlete.Create(
+                creator, "John", "Doe", "m", new Country(), null, null).FromResult();
+        }
+
+        DateTime resolvedStartDate = meetStartDate == default
+            ? new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc)
+            : meetStartDate;
+
+        WebApi.Features.Meets.Meet meet = WebApi.Features.Meets.Meet.Create(
+            creator,
+            MeetCategory.Powerlifting,
+            "Test Meet",
+            DateOnly.FromDateTime(resolvedStartDate)).FromResult();
+
+        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Athlete), athlete);
+        SetProperty(participation, nameof(WebApi.Features.Participations.Participation.Meet), meet);
+
+        return participation;
+    }
+
+    internal static void SetProperty<T>(object target, string propertyName, T value)
+    {
+        PropertyInfo property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
+        property.SetValue(target, value);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `HasActiveBan(DateOnly)` on `Athlete` and refactor `IsEligibleForRecord()` to delegate
- Modify `RecalculateTotals()` to set `Disqualified = bombedOut || hasBanOnMeetDate` using navigation properties with fail-fast guards
- Fix `PlaceComputationService.RankGroup()` to exclude disqualified athletes with non-zero totals from rankings
- Add `BanAddedEvent`/`BanRemovedEvent` domain events on `Athlete` aggregate root with `BanEventHandler` for retroactive cascade (totals → places → records)
- Add `DOMAIN.md` documenting ban-date semantics, WADA/IPF rationale, and disqualification derivation rules

Closes #473

## Test plan

- [x] 11 new unit tests covering `HasActiveBan`, `AddBan`, navigation guards, and ban-based disqualification
- [x] 2 new integration tests: banned athlete disqualified with preserved Total, banned athlete excluded from rankings
- [x] All 131 unit tests pass
- [x] All 407 integration tests pass
- [x] Build passes with 0 warnings