### PR TITLE
fix(web): lift toast stack from ParticipationCard to MeetDetailsPage

### DIFF
--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -218,7 +218,7 @@ else
 }
 }
 
-<div class="toast-stack" aria-live="assertive">
+<div class="toast-stack" aria-live="polite">
     @foreach (ToastItem toast in _toasts)
     {
         <div class="toast-item @(toast.IsExiting ? "toast-item-exiting" : null)" @key="toast.Id">

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -218,12 +218,12 @@ else
 }
 }
 
-<div class="toast-stack" aria-live="polite">
+<div class="toast-stack" aria-live="assertive">
     @foreach (ToastItem toast in _toasts)
     {
-        <div class="toast-item @(toast.IsExiting ? "toast-item-exiting" : null)" role="alert">
+        <div class="toast-item @(toast.IsExiting ? "toast-item-exiting" : null)" @key="toast.Id">
             <span>@toast.Message</span>
-            <button class="toast-close" @onclick="() => DismissToast(toast.Id)" aria-label="Loka">×</button>
+            <button class="toast-close" @onclick="() => DismissToast(toast.Id)" aria-label="Loka"><span aria-hidden="true">×</span></button>
         </div>
     }
 </div>
@@ -238,8 +238,10 @@ else
                IsLoading="_isDeleting" />
 
 @code {
-    private sealed record ToastItem(Guid Id, string Message)
+    private sealed class ToastItem(Guid Id, string Message)
     {
+        public Guid Id { get; } = Id;
+        public string Message { get; } = Message;
         public bool IsExiting { get; set; }
     }
 
@@ -249,6 +251,7 @@ else
 
     private readonly List<ToastItem> _toasts = [];
     private readonly Dictionary<Guid, CancellationTokenSource> _toastTimers = [];
+    private readonly CancellationTokenSource _disposeCts = new();
 
     private ConfirmDialog _deleteDialog = null!;
     private bool _isDeleting;
@@ -291,7 +294,14 @@ else
         if (_toasts.Count >= MaxToasts)
         {
             ToastItem oldest = _toasts[0];
-            await RemoveToast(oldest.Id);
+            if (_toastTimers.TryGetValue(oldest.Id, out CancellationTokenSource? oldestCts))
+            {
+                await oldestCts.CancelAsync();
+                oldestCts.Dispose();
+                _toastTimers.Remove(oldest.Id);
+            }
+
+            _toasts.Remove(oldest);
         }
 
         Guid id = Guid.NewGuid();
@@ -324,7 +334,7 @@ else
     private async Task RemoveToast(Guid id)
     {
         ToastItem? toast = _toasts.FirstOrDefault(t => t.Id == id);
-        if (toast is null)
+        if (toast is null || toast.IsExiting)
         {
             return;
         }
@@ -332,7 +342,15 @@ else
         toast.IsExiting = true;
         StateHasChanged();
 
-        await Task.Delay(ToastExitDurationMs);
+        try
+        {
+            await Task.Delay(ToastExitDurationMs, _disposeCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Page disposed — stop without further UI updates
+            return;
+        }
 
         _toasts.Remove(toast);
 
@@ -347,6 +365,8 @@ else
 
     public async ValueTask DisposeAsync()
     {
+        await _disposeCts.CancelAsync();
+
         foreach (CancellationTokenSource cts in _toastTimers.Values)
         {
             await cts.CancelAsync();
@@ -354,6 +374,8 @@ else
         }
 
         _toastTimers.Clear();
+        _toasts.Clear();
+        _disposeCts.Dispose();
     }
 
     private async Task ReloadMeetRecords()

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -6,6 +6,8 @@
 @using KRAFT.Results.Web.Client.Features.TeamCompetition
 @using Microsoft.AspNetCore.Components.Authorization
 
+@implements IAsyncDisposable
+
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
 @inject AuthenticationStateProvider AuthenticationStateProvider
@@ -149,7 +151,8 @@ else
                                        DesktopGridTemplate="@ResultsGridTemplate"
                                        IsAdmin="_isAdmin"
                                        OnParticipantRemoved="ReloadParticipations"
-                                       OnBodyWeightUpdated="ReloadParticipations" />
+                                       OnBodyWeightUpdated="ReloadParticipations"
+                                       OnSaveError="AddToast" />
                 }
             }
         </section>
@@ -215,6 +218,16 @@ else
 }
 }
 
+<div class="toast-stack" aria-live="polite">
+    @foreach (ToastItem toast in _toasts)
+    {
+        <div class="toast-item @(toast.IsExiting ? "toast-item-exiting" : null)" role="alert">
+            <span>@toast.Message</span>
+            <button class="toast-close" @onclick="() => DismissToast(toast.Id)" aria-label="Loka">×</button>
+        </div>
+    }
+</div>
+
 <ConfirmDialog @ref="_deleteDialog"
                Id="delete-meet-dialog"
                Title="Eyða móti"
@@ -225,6 +238,18 @@ else
                IsLoading="_isDeleting" />
 
 @code {
+    private sealed record ToastItem(Guid Id, string Message)
+    {
+        public bool IsExiting { get; set; }
+    }
+
+    private const int MaxToasts = 5;
+    private const int ToastDurationMs = 4000;
+    private const int ToastExitDurationMs = 300;
+
+    private readonly List<ToastItem> _toasts = [];
+    private readonly Dictionary<Guid, CancellationTokenSource> _toastTimers = [];
+
     private ConfirmDialog _deleteDialog = null!;
     private bool _isDeleting;
     private bool _isLoading = true;
@@ -259,6 +284,76 @@ else
                 ? $"22px 280px {clubPart}{discPart} 63px 68px"
                 : $"22px 280px {clubPart}{discPart} 63px";
         }
+    }
+
+    private async Task AddToast(string message)
+    {
+        if (_toasts.Count >= MaxToasts)
+        {
+            ToastItem oldest = _toasts[0];
+            await RemoveToast(oldest.Id);
+        }
+
+        Guid id = Guid.NewGuid();
+        CancellationTokenSource cts = new();
+        _toastTimers[id] = cts;
+        _toasts.Add(new ToastItem(id, message));
+        StateHasChanged();
+
+        try
+        {
+            await Task.Delay(ToastDurationMs, cts.Token);
+            await RemoveToast(id);
+        }
+        catch (OperationCanceledException)
+        {
+            // Dismissed manually or page disposed
+        }
+    }
+
+    private async Task DismissToast(Guid id)
+    {
+        if (_toastTimers.TryGetValue(id, out CancellationTokenSource? cts))
+        {
+            await cts.CancelAsync();
+        }
+
+        await RemoveToast(id);
+    }
+
+    private async Task RemoveToast(Guid id)
+    {
+        ToastItem? toast = _toasts.FirstOrDefault(t => t.Id == id);
+        if (toast is null)
+        {
+            return;
+        }
+
+        toast.IsExiting = true;
+        StateHasChanged();
+
+        await Task.Delay(ToastExitDurationMs);
+
+        _toasts.Remove(toast);
+
+        if (_toastTimers.TryGetValue(id, out CancellationTokenSource? cts))
+        {
+            cts.Dispose();
+            _toastTimers.Remove(id);
+        }
+
+        StateHasChanged();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (CancellationTokenSource cts in _toastTimers.Values)
+        {
+            await cts.CancelAsync();
+            cts.Dispose();
+        }
+
+        _toastTimers.Clear();
     }
 
     private async Task ReloadMeetRecords()

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -144,6 +144,8 @@
     gap: 0.5rem;
     pointer-events: none;
     max-width: 24rem;
+    max-height: calc(100dvh - 2.5rem);
+    overflow-y: auto;
 }
 
 .toast-item {
@@ -158,6 +160,7 @@
     font-weight: 500;
     box-shadow: 0 4px 12px rgb(0 0 0 / 0.2);
     pointer-events: auto;
+    animation: toast-slide-in 0.2s ease;
     transition: opacity var(--transition-base) ease,
                 transform var(--transition-base) ease;
 }
@@ -197,5 +200,22 @@
     .toast-stack {
         inset-inline-start: 1.25rem;
         max-width: none;
+    }
+}
+
+@keyframes toast-slide-in {
+    from {
+        opacity: 0;
+        transform: translateY(0.375rem);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .toast-item-exiting {
+        transform: none;
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -131,3 +131,71 @@
 .card-section {
     margin-block-end: 1.5rem;
 }
+
+/* ===== Toast stack ===== */
+
+.toast-stack {
+    position: fixed;
+    inset-block-end: 1.25rem;
+    inset-inline-end: 1.25rem;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    pointer-events: none;
+    max-width: 24rem;
+}
+
+.toast-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--color-danger);
+    color: var(--color-white);
+    border-radius: var(--radius-md);
+    font-size: 14px;
+    font-weight: 500;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 0.2);
+    pointer-events: auto;
+    transition: opacity var(--transition-base) ease,
+                transform var(--transition-base) ease;
+}
+
+.toast-item-exiting {
+    opacity: 0;
+    transform: translateX(100%);
+}
+
+.toast-close {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    padding: 0;
+    opacity: 0.75;
+    flex-shrink: 0;
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.toast-close:hover {
+    opacity: 1;
+}
+
+.toast-close:focus-visible {
+    outline: 2px solid var(--color-white);
+    outline-offset: 2px;
+}
+
+@media (max-width: 30rem) {
+    .toast-stack {
+        inset-inline-start: 1.25rem;
+        max-width: none;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -145,7 +145,6 @@
     pointer-events: none;
     max-width: 24rem;
     max-height: calc(100dvh - 2.5rem);
-    overflow-y: auto;
 }
 
 .toast-item {
@@ -168,6 +167,11 @@
 .toast-item-exiting {
     opacity: 0;
     transform: translateX(100%);
+}
+
+.toast-item > span:first-child {
+    flex: 1;
+    min-width: 0;
 }
 
 .toast-close {
@@ -215,6 +219,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+    .toast-item {
+        animation: none;
+    }
+
     .toast-item-exiting {
         transform: none;
     }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
@@ -4,8 +4,6 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Globalization
 
-@implements IAsyncDisposable
-
 @inject HttpClient HttpClient
 @inject IJSRuntime JS
 
@@ -186,14 +184,6 @@
                ErrorMessage="@_removeErrorMessage"
                IsLoading="_isRemoving" />
 
-@if (_saveErrorMessage is not null)
-{
-    <div class="attempt-save-toast" role="alert">
-        <span>@_saveErrorMessage</span>
-        <button class="attempt-save-toast-close" @onclick="DismissSaveError" aria-label="Loka">×</button>
-    </div>
-}
-
 @code {
     private EditBodyWeightDialog _editDialog = null!;
     private ConfirmDialog _removeDialog = null!;
@@ -208,8 +198,6 @@
     private readonly Dictionary<(Discipline, short), string> _attemptErrors = [];
     private MeetParticipation? _lastParticipation;
     private MeetParticipation? _freshParticipation;
-    private string? _saveErrorMessage;
-    private CancellationTokenSource? _errorDismissCtx;
 
     [Parameter, EditorRequired]
     public MeetParticipation Participation { get; init; } = null!;
@@ -234,6 +222,9 @@
 
     [Parameter]
     public EventCallback OnBodyWeightUpdated { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnSaveError { get; set; }
 
     private string _metaLine = string.Empty;
     private string _rankDisplay = string.Empty;
@@ -463,7 +454,7 @@
             if (!response.IsSuccessStatusCode)
             {
                 _savedAttempts.Remove((discipline, round));
-                await ShowSaveErrorToast();
+                await OnSaveError.InvokeAsync("Villa kom upp. Reyndu aftur.");
                 return;
             }
 
@@ -473,37 +464,8 @@
         catch (HttpRequestException)
         {
             _savedAttempts.Remove((discipline, round));
-            await ShowSaveErrorToast();
+            await OnSaveError.InvokeAsync("Villa kom upp. Reyndu aftur.");
         }
-    }
-
-    private async Task ShowSaveErrorToast()
-    {
-        if (_errorDismissCtx is not null)
-        {
-            await _errorDismissCtx.CancelAsync();
-            _errorDismissCtx.Dispose();
-        }
-        _errorDismissCtx = new CancellationTokenSource();
-        _saveErrorMessage = "Villa kom upp. Reyndu aftur.";
-        StateHasChanged();
-
-        try
-        {
-            await Task.Delay(4000, _errorDismissCtx.Token);
-            _saveErrorMessage = null;
-            StateHasChanged();
-        }
-        catch (OperationCanceledException)
-        {
-            // Dismissed manually or component disposed
-        }
-    }
-
-    private void DismissSaveError()
-    {
-        _errorDismissCtx?.Cancel();
-        _saveErrorMessage = null;
     }
 
     private decimal GetEffectiveAttemptWeight(Discipline discipline, short round)
@@ -627,14 +589,5 @@
 
     private string GetInputId(Discipline discipline, short round) =>
         $"attempt-input-{Participation.ParticipationId}-{(int)discipline}-{round}";
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_errorDismissCtx is not null)
-        {
-            await _errorDismissCtx.CancelAsync();
-            _errorDismissCtx.Dispose();
-        }
-    }
 
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
@@ -251,63 +251,6 @@
 }
 
 
-/* Attempt save error toast */
-.attempt-save-toast {
-    position: fixed;
-    bottom: 1.25rem;
-    right: 1.25rem;
-    z-index: 9999;
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    background: var(--color-danger);
-    color: var(--color-white);
-    border-radius: var(--radius-md);
-    font-size: 14px;
-    font-weight: 500;
-    box-shadow: 0 4px 12px rgb(0 0 0 / 0.2);
-    animation: toast-slide-in 0.2s ease;
-}
-
-.attempt-save-toast-close {
-    background: none;
-    border: none;
-    color: inherit;
-    cursor: pointer;
-    font-size: 18px;
-    line-height: 1;
-    padding: 0;
-    opacity: 0.75;
-    flex-shrink: 0;
-    min-width: 44px;
-    min-height: 44px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.attempt-save-toast-close:hover {
-    opacity: 1;
-}
-
-@keyframes toast-slide-in {
-    from {
-        opacity: 0;
-        transform: translateY(6px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .attempt-save-toast {
-        animation: none;
-    }
-}
-
 /* ===== Mobile: always show edit button ===== */
 @container (max-width: 959px) {
     .btn-edit-weight {


### PR DESCRIPTION
## Summary

- Lift error toast out of individual `ParticipationCard` components into a shared stacked notification area in `MeetDetailsPage`
- Each card emits errors via `EventCallback<string> OnSaveError`; the page manages a capped stack of up to 5 toasts with individual auto-dismiss timers, smooth exit animations, and proper accessibility semantics

Closes #383

## Test plan

- [ ] Trigger a save error on a single ParticipationCard — toast appears at bottom-right
- [ ] Trigger save errors on multiple cards simultaneously — toasts stack vertically, newest at bottom
- [ ] Trigger 6+ errors rapidly — oldest toast is evicted before new one appears
- [ ] Click dismiss button — only that toast is dismissed, others remain
- [ ] Wait 4 seconds — toast auto-dismisses
- [ ] Dismiss a toast from the middle of the stack — remaining toasts reposition smoothly
- [ ] Test with screen reader — toasts announced politely without interrupting current speech
- [ ] Test with `prefers-reduced-motion: reduce` — no slide animations, instant appearance/removal
- [ ] Test on mobile viewport — toasts span full width below 480px
- [ ] Navigate away while toasts are showing — no console errors from disposed timers