### PR TITLE
feat(webapi): recompute places when CalcPlaces is toggled

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEvent.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEvent.cs
@@ -1,0 +1,5 @@
+using KRAFT.Results.WebApi.Abstractions;
+
+namespace KRAFT.Results.WebApi.Features.Meets;
+
+internal sealed record class CalcPlacesChangedEvent(int MeetId, bool CalcPlaces) : IDomainEvent;

--- a/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEvent.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEvent.cs
@@ -2,4 +2,4 @@ using KRAFT.Results.WebApi.Abstractions;
 
 namespace KRAFT.Results.WebApi.Features.Meets;
 
-internal sealed record class CalcPlacesChangedEvent(int MeetId, bool CalcPlaces) : IDomainEvent;
+internal sealed record class CalcPlacesChangedEvent(string Slug, bool CalcPlaces) : IDomainEvent;

--- a/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEventHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEventHandler.cs
@@ -22,11 +22,6 @@ internal sealed class CalcPlacesChangedEventHandler(
 
     public Task HandleAsync(IDomainEvent domainEvent, CancellationToken cancellationToken)
     {
-        if (domainEvent is CalcPlacesChangedEvent calcPlacesChangedEvent)
-        {
-            return HandleAsync(calcPlacesChangedEvent, cancellationToken);
-        }
-
-        return Task.CompletedTask;
+        return HandleAsync((CalcPlacesChangedEvent)domainEvent, cancellationToken);
     }
 }

--- a/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEventHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEventHandler.cs
@@ -13,11 +13,11 @@ internal sealed class CalcPlacesChangedEventHandler(
     public async Task HandleAsync(CalcPlacesChangedEvent domainEvent, CancellationToken cancellationToken)
     {
         _logger.LogInformation(
-            "Processing CalcPlacesChangedEvent for meet {MeetId}, CalcPlaces={CalcPlaces}",
-            domainEvent.MeetId,
+            "Processing CalcPlacesChangedEvent for meet {Slug}, CalcPlaces={CalcPlaces}",
+            domainEvent.Slug,
             domainEvent.CalcPlaces);
 
-        await _placeComputationService.RecomputeMeetAsync(domainEvent.MeetId, domainEvent.CalcPlaces, cancellationToken);
+        await _placeComputationService.RecomputeMeetAsync(domainEvent.Slug, domainEvent.CalcPlaces, cancellationToken);
     }
 
     public Task HandleAsync(IDomainEvent domainEvent, CancellationToken cancellationToken)

--- a/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEventHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/CalcPlacesChangedEventHandler.cs
@@ -1,0 +1,32 @@
+using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Participations.ComputePlaces;
+
+namespace KRAFT.Results.WebApi.Features.Meets;
+
+internal sealed class CalcPlacesChangedEventHandler(
+    PlaceComputationService placeComputationService,
+    ILogger<CalcPlacesChangedEventHandler> logger) : IDomainEventHandler<CalcPlacesChangedEvent>
+{
+    private readonly PlaceComputationService _placeComputationService = placeComputationService;
+    private readonly ILogger<CalcPlacesChangedEventHandler> _logger = logger;
+
+    public async Task HandleAsync(CalcPlacesChangedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Processing CalcPlacesChangedEvent for meet {MeetId}, CalcPlaces={CalcPlaces}",
+            domainEvent.MeetId,
+            domainEvent.CalcPlaces);
+
+        await _placeComputationService.RecomputeMeetAsync(domainEvent.MeetId, domainEvent.CalcPlaces, cancellationToken);
+    }
+
+    public Task HandleAsync(IDomainEvent domainEvent, CancellationToken cancellationToken)
+    {
+        if (domainEvent is CalcPlacesChangedEvent calcPlacesChangedEvent)
+        {
+            return HandleAsync(calcPlacesChangedEvent, cancellationToken);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Meets/Meet.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Meet.cs
@@ -157,7 +157,6 @@ internal sealed class Meet : AggregateRoot
     }
 
     internal Result Update(
-        int meetId,
         User modifier,
         MeetCategory category,
         string title,
@@ -244,7 +243,7 @@ internal sealed class Meet : AggregateRoot
 
         if (calcPlacesChanged)
         {
-            Raise(new CalcPlacesChangedEvent(meetId, calcPlaces));
+            Raise(new CalcPlacesChangedEvent(Slug, calcPlaces));
         }
 
         return Result.Success();

--- a/src/KRAFT.Results.WebApi/Features/Meets/Meet.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Meet.cs
@@ -157,6 +157,7 @@ internal sealed class Meet : AggregateRoot
     }
 
     internal Result Update(
+        int meetId,
         User modifier,
         MeetCategory category,
         string title,
@@ -217,6 +218,8 @@ internal sealed class Meet : AggregateRoot
             return MeetErrors.TextTooLong;
         }
 
+        bool calcPlacesChanged = CalcPlaces != calcPlaces;
+
         DateTime startDateTime = startDate.ToDateTime(TimeOnly.MinValue);
 
         Title = title;
@@ -238,6 +241,11 @@ internal sealed class Meet : AggregateRoot
         IsRaw = isRaw;
         ModifiedOn = DateTime.UtcNow;
         ModifiedBy = modifier.Username;
+
+        if (calcPlacesChanged)
+        {
+            Raise(new CalcPlacesChangedEvent(meetId, calcPlaces));
+        }
 
         return Result.Success();
     }

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
@@ -1,4 +1,5 @@
-﻿using KRAFT.Results.WebApi.Features.Meets.AddParticipant;
+﻿using KRAFT.Results.WebApi.Abstractions;
+using KRAFT.Results.WebApi.Features.Meets.AddParticipant;
 using KRAFT.Results.WebApi.Features.Meets.Create;
 using KRAFT.Results.WebApi.Features.Meets.Delete;
 using KRAFT.Results.WebApi.Features.Meets.Get;
@@ -37,6 +38,7 @@ internal static class MeetServices
         services.AddScoped<UpdateAgeCategoryHandler>();
         services.AddScoped<UpdateBodyWeightHandler>();
         services.AddScoped<UpdateMeetHandler>();
+        services.AddScoped<IDomainEventHandler<CalcPlacesChangedEvent>, CalcPlacesChangedEventHandler>();
 
         return services;
     }

--- a/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
@@ -55,14 +55,7 @@ internal sealed class UpdateMeetHandler
             return Result.Failure(MeetErrors.MeetTypeNotFound);
         }
 
-        if (_dbContext.Entry(meet).Property("MeetId").CurrentValue is not int meetId)
-        {
-            _logger.LogError("MeetId shadow property missing or wrong type for slug {Slug}", slug);
-            return Result.Failure(MeetErrors.MeetNotFound);
-        }
-
         Result result = meet.Update(
-            meetId,
             modifier,
             category,
             command.Title,

--- a/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
@@ -55,7 +55,11 @@ internal sealed class UpdateMeetHandler
             return Result.Failure(MeetErrors.MeetTypeNotFound);
         }
 
-        int meetId = (int)_dbContext.Entry(meet).Property("MeetId").CurrentValue!;
+        if (_dbContext.Entry(meet).Property("MeetId").CurrentValue is not int meetId)
+        {
+            _logger.LogError("MeetId shadow property missing or wrong type for slug {Slug}", slug);
+            return Result.Failure(MeetErrors.MeetNotFound);
+        }
 
         Result result = meet.Update(
             meetId,

--- a/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/Update/UpdateMeetHandler.cs
@@ -55,7 +55,10 @@ internal sealed class UpdateMeetHandler
             return Result.Failure(MeetErrors.MeetTypeNotFound);
         }
 
+        int meetId = (int)_dbContext.Entry(meet).Property("MeetId").CurrentValue!;
+
         Result result = meet.Update(
+            meetId,
             modifier,
             category,
             command.Title,

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -22,7 +22,6 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
     internal async Task RecomputeMeetAsync(int meetId, bool calcPlaces, CancellationToken cancellationToken)
     {
         List<Participation> participations = await dbContext.Set<Participation>()
-            .Include(p => p.Attempts)
             .Where(p => p.MeetId == meetId)
             .ToListAsync(cancellationToken);
 

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -19,6 +19,26 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
             cancellationToken);
     }
 
+    internal async Task RecomputeMeetAsync(int meetId, bool calcPlaces, CancellationToken cancellationToken)
+    {
+        List<Participation> participations = await dbContext.Set<Participation>()
+            .Include(p => p.Attempts)
+            .Where(p => p.MeetId == meetId)
+            .ToListAsync(cancellationToken);
+
+        if (calcPlaces)
+        {
+            return;
+        }
+
+        foreach (Participation participation in participations)
+        {
+            participation.ClearRanking();
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
     internal async Task RecomputeGroupAsync(
         int meetId,
         int weightCategoryId,

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -19,10 +19,10 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
             cancellationToken);
     }
 
-    internal async Task RecomputeMeetAsync(int meetId, bool calcPlaces, CancellationToken cancellationToken)
+    internal async Task RecomputeMeetAsync(string slug, bool calcPlaces, CancellationToken cancellationToken)
     {
         List<Participation> participations = await dbContext.Set<Participation>()
-            .Where(p => p.MeetId == meetId)
+            .Where(p => p.Meet.Slug == slug)
             .ToListAsync(cancellationToken);
 
         if (calcPlaces)

--- a/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/ComputePlaces/PlaceComputationService.cs
@@ -28,12 +28,20 @@ internal sealed class PlaceComputationService(ResultsDbContext dbContext)
 
         if (calcPlaces)
         {
-            return;
-        }
+            IEnumerable<IGrouping<(int WeightCategoryId, int AgeCategoryId), Participation>> groups = participations
+                .GroupBy(p => (p.WeightCategoryId, p.AgeCategoryId));
 
-        foreach (Participation participation in participations)
+            foreach (IGrouping<(int WeightCategoryId, int AgeCategoryId), Participation> group in groups)
+            {
+                RankGroup(group.ToList());
+            }
+        }
+        else
         {
-            participation.ClearRanking();
+            foreach (Participation participation in participations)
+            {
+                participation.ClearRanking();
+            }
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
+++ b/src/KRAFT.Results.WebApi/Features/Participations/Participation.cs
@@ -155,6 +155,12 @@ internal sealed class Participation : AggregateRoot
         Raise(new AttemptRecordedEvent(this, attempt));
     }
 
+    internal void ClearRanking()
+    {
+        Place = 0;
+        TeamPoints = null;
+    }
+
     internal void UpdateRanking(int place)
     {
         Place = place;

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/CalcPlacesToggleTestsCollection.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/CalcPlacesToggleTestsCollection.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+[CollectionDefinition(nameof(CalcPlacesToggleTestsCollection))]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "xUnit collection definition")]
+public sealed class CalcPlacesToggleTestsCollection : ICollectionFixture<CollectionFixture>
+{
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/CalcPlacesToggleTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/CalcPlacesToggleTests.cs
@@ -1,0 +1,174 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
+
+[Collection(nameof(CalcPlacesToggleTestsCollection))]
+public sealed class CalcPlacesToggleTests(CollectionFixture fixture) : IAsyncLifetime
+{
+    private readonly HttpClient _authorizedHttpClient = fixture.CreateAuthorizedHttpClient();
+    private readonly List<string> _athleteSlugs = [];
+    private readonly List<(int MeetId, string MeetSlug)> _meets = [];
+    private readonly List<(int MeetId, int ParticipationId)> _participations = [];
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach ((int meetId, int participationId) in Enumerable.Reverse(_participations))
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{meetId}/participants/{participationId}", CancellationToken.None);
+        }
+
+        foreach ((int _, string meetSlug) in Enumerable.Reverse(_meets))
+        {
+            await _authorizedHttpClient.DeleteAsync($"/meets/{meetSlug}", CancellationToken.None);
+        }
+
+        foreach (string slug in _athleteSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+    }
+
+    [Fact]
+    public async Task RecomputesPlacesPerWeightCategoryGroup_WhenToggledFromFalseToTrue()
+    {
+        // Arrange — create a meet with CalcPlaces=false so attempts do not trigger place computation
+        (int meetId, string meetSlug) = await CreateMeetAsync(calcPlaces: false);
+
+        // Athlete 1 in 83kg group (body weight 80.5 kg) — higher total within own group
+        string athlete1Slug = await CreateAthleteAsync();
+        int participation1Id = await AddParticipantAsync(meetId, athlete1Slug, bodyWeight: 80.5m);
+        await RecordFullTotalAsync(meetId, participation1Id, squat: 200.0m, bench: 130.0m, deadlift: 250.0m);
+
+        // Athlete 2 in 93kg group (body weight 88.0 kg) — only lifter in this group
+        string athlete2Slug = await CreateAthleteAsync();
+        int participation2Id = await AddParticipantAsync(meetId, athlete2Slug, bodyWeight: 88.0m);
+        await RecordFullTotalAsync(meetId, participation2Id, squat: 180.0m, bench: 110.0m, deadlift: 210.0m);
+
+        // Act — toggle CalcPlaces to true; this triggers RecomputeMeetAsync(calcPlaces: true)
+        UpdateMeetCommand updateCommand = new UpdateMeetCommandBuilder()
+            .WithCalcPlaces(true)
+            .Build();
+
+        HttpResponseMessage updateResponse = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetSlug}",
+            updateCommand,
+            CancellationToken.None);
+
+        updateResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Assert — each athlete is ranked 1st within their own weight category group
+        List<MeetParticipation>? participations = await _authorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{meetSlug}/participations",
+            CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        MeetParticipation? p1 = participations.FirstOrDefault(p => p.ParticipationId == participation1Id);
+        MeetParticipation? p2 = participations.FirstOrDefault(p => p.ParticipationId == participation2Id);
+
+        p1.ShouldNotBeNull();
+        p2.ShouldNotBeNull();
+
+        // Both are ranked 1st because they are in separate weight category groups
+        p1.Rank.ShouldBe(1);
+        p2.Rank.ShouldBe(1);
+    }
+
+    private async Task<(int MeetId, string MeetSlug)> CreateMeetAsync(bool calcPlaces)
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder()
+            .WithCalcPlaces(calcPlaces)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/meets",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? details = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{slug}",
+            CancellationToken.None);
+
+        (int meetId, string meetSlug) = (details!.MeetId, slug);
+        _meets.Add((meetId, meetSlug));
+        return (meetId, meetSlug);
+    }
+
+    private async Task<string> CreateAthleteAsync()
+    {
+        CreateAthleteCommand command = new CreateAthleteCommandBuilder()
+            .WithCountryCode("NOR")
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
+
+        string slug = Slug.Create($"{command.FirstName} {command.LastName}");
+        _athleteSlugs.Add(slug);
+        return slug;
+    }
+
+    private async Task<int> AddParticipantAsync(int meetId, string athleteSlug, decimal bodyWeight)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(bodyWeight)
+            .WithAgeCategorySlug("open")
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            $"/meets/{meetId}/participants",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content.ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+        int participationId = result!.ParticipationId;
+        _participations.Add((meetId, participationId));
+        return participationId;
+    }
+
+    private async Task RecordFullTotalAsync(int meetId, int participationId, decimal squat, decimal bench, decimal deadlift)
+    {
+        await RecordAttemptAsync(meetId, participationId, Discipline.Squat, 1, squat, good: true);
+        await RecordAttemptAsync(meetId, participationId, Discipline.Bench, 1, bench, good: true);
+        await RecordAttemptAsync(meetId, participationId, Discipline.Deadlift, 1, deadlift, good: true);
+    }
+
+    private async Task RecordAttemptAsync(int meetId, int participationId, Discipline discipline, int round, decimal weight, bool good)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .WithGood(good)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/CalcPlacesToggleTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/CalcPlacesToggleTests.cs
@@ -43,6 +43,115 @@ public sealed class CalcPlacesToggleTests(CollectionFixture fixture) : IAsyncLif
     }
 
     [Fact]
+    public async Task ClearsPlacesAndTeamPoints_WhenToggledFromTrueToFalse()
+    {
+        // Arrange — create a meet with CalcPlaces=true so attempts trigger place computation
+        (int meetId, string meetSlug) = await CreateMeetAsync(calcPlaces: true);
+
+        string athlete1Slug = await CreateAthleteAsync();
+        int participation1Id = await AddParticipantAsync(meetId, athlete1Slug, bodyWeight: 80.5m);
+        await RecordFullTotalAsync(meetId, participation1Id, squat: 200.0m, bench: 130.0m, deadlift: 250.0m);
+
+        string athlete2Slug = await CreateAthleteAsync();
+        int participation2Id = await AddParticipantAsync(meetId, athlete2Slug, bodyWeight: 88.0m);
+        await RecordFullTotalAsync(meetId, participation2Id, squat: 180.0m, bench: 110.0m, deadlift: 210.0m);
+
+        // Verify places are computed before toggling
+        List<MeetParticipation>? before = await _authorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{meetSlug}/participations",
+            CancellationToken.None);
+
+        before.ShouldNotBeNull();
+        before.ShouldAllBe(p => p.Rank > 0);
+
+        // Act — toggle CalcPlaces to false; this triggers RecomputeMeetAsync(calcPlaces: false)
+        UpdateMeetCommand updateCommand = new UpdateMeetCommandBuilder()
+            .WithCalcPlaces(false)
+            .Build();
+
+        HttpResponseMessage updateResponse = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetSlug}",
+            updateCommand,
+            CancellationToken.None);
+
+        updateResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Assert — all participations have rank 0
+        List<MeetParticipation>? participations = await _authorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{meetSlug}/participations",
+            CancellationToken.None);
+
+        participations.ShouldNotBeNull();
+        participations.ShouldAllBe(p => p.Rank == 0);
+    }
+
+    [Fact]
+    public async Task PreservesExistingPlaces_WhenCalcPlacesUnchanged()
+    {
+        // Arrange — create a meet with CalcPlaces=true so attempts trigger place computation
+        (int meetId, string meetSlug) = await CreateMeetAsync(calcPlaces: true);
+
+        string athlete1Slug = await CreateAthleteAsync();
+        int participation1Id = await AddParticipantAsync(meetId, athlete1Slug, bodyWeight: 80.5m);
+        await RecordFullTotalAsync(meetId, participation1Id, squat: 200.0m, bench: 130.0m, deadlift: 250.0m);
+
+        string athlete2Slug = await CreateAthleteAsync();
+        int participation2Id = await AddParticipantAsync(meetId, athlete2Slug, bodyWeight: 80.5m);
+        await RecordFullTotalAsync(meetId, participation2Id, squat: 180.0m, bench: 110.0m, deadlift: 210.0m);
+
+        // Read ranks before the no-op update
+        List<MeetParticipation>? before = await _authorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{meetSlug}/participations",
+            CancellationToken.None);
+
+        before.ShouldNotBeNull();
+        int rankBefore1 = before.First(p => p.ParticipationId == participation1Id).Rank;
+        int rankBefore2 = before.First(p => p.ParticipationId == participation2Id).Rank;
+
+        // Act — update with a different title but same CalcPlaces=true
+        UpdateMeetCommand updateCommand = new UpdateMeetCommandBuilder()
+            .WithTitle(Guid.NewGuid().ToString())
+            .WithCalcPlaces(true)
+            .Build();
+
+        HttpResponseMessage updateResponse = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetSlug}",
+            updateCommand,
+            CancellationToken.None);
+
+        updateResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Assert — ranks remain unchanged
+        List<MeetParticipation>? after = await _authorizedHttpClient.GetFromJsonAsync<List<MeetParticipation>>(
+            $"/meets/{meetSlug}/participations",
+            CancellationToken.None);
+
+        after.ShouldNotBeNull();
+        after.First(p => p.ParticipationId == participation1Id).Rank.ShouldBe(rankBefore1);
+        after.First(p => p.ParticipationId == participation2Id).Rank.ShouldBe(rankBefore2);
+    }
+
+    [Fact]
+    public async Task Succeeds_WhenTogglingCalcPlacesOnMeetWithNoParticipations()
+    {
+        // Arrange — create a meet with no participations
+        (int _, string meetSlug) = await CreateMeetAsync(calcPlaces: true);
+
+        // Act — toggle CalcPlaces to false on an empty meet
+        UpdateMeetCommand updateCommand = new UpdateMeetCommandBuilder()
+            .WithCalcPlaces(false)
+            .Build();
+
+        // Assert — the update succeeds without error
+        HttpResponseMessage updateResponse = await _authorizedHttpClient.PutAsJsonAsync(
+            $"/meets/{meetSlug}",
+            updateCommand,
+            CancellationToken.None);
+
+        updateResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task RecomputesPlacesPerWeightCategoryGroup_WhenToggledFromFalseToTrue()
     {
         // Arrange — create a meet with CalcPlaces=false so attempts do not trigger place computation

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Meets/MeetTests/Update/RaisesCalcPlacesChangedEventTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Meets/MeetTests/Update/RaisesCalcPlacesChangedEventTests.cs
@@ -1,0 +1,97 @@
+using KRAFT.Results.WebApi.Features.Meets;
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Meets.MeetTests.Update;
+
+public sealed class RaisesCalcPlacesChangedEventTests
+{
+    [Fact]
+    public void RaisesCalcPlacesChangedEvent_WhenCalcPlacesChangesFromTrueToFalse()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        Meet meet = Meet.Create(
+            creator,
+            MeetCategory.Powerlifting,
+            title: "Test Meet",
+            startDate: new DateOnly(2025, 6, 1),
+            calcPlaces: true).FromResult();
+        int meetId = 42;
+
+        // Act
+        meet.Update(
+            meetId,
+            creator,
+            MeetCategory.Powerlifting,
+            title: "Test Meet",
+            startDate: new DateOnly(2025, 6, 1),
+            calcPlaces: false);
+
+        // Assert
+        CalcPlacesChangedEvent? raisedEvent = meet.DomainEvents
+            .OfType<CalcPlacesChangedEvent>()
+            .FirstOrDefault();
+        raisedEvent.ShouldNotBeNull();
+        raisedEvent.MeetId.ShouldBe(meetId);
+        raisedEvent.CalcPlaces.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DoesNotRaiseCalcPlacesChangedEvent_WhenCalcPlacesDoesNotChange()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        Meet meet = Meet.Create(
+            creator,
+            MeetCategory.Powerlifting,
+            title: "Test Meet",
+            startDate: new DateOnly(2025, 6, 1),
+            calcPlaces: true).FromResult();
+        int meetId = 42;
+
+        // Act
+        meet.Update(
+            meetId,
+            creator,
+            MeetCategory.Powerlifting,
+            title: "Test Meet",
+            startDate: new DateOnly(2025, 6, 1),
+            calcPlaces: true);
+
+        // Assert
+        meet.DomainEvents
+            .OfType<CalcPlacesChangedEvent>()
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void DoesNotRaiseCalcPlacesChangedEvent_WhenValidationFails()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        Meet meet = Meet.Create(
+            creator,
+            MeetCategory.Powerlifting,
+            title: "Test Meet",
+            startDate: new DateOnly(2025, 6, 1),
+            calcPlaces: true).FromResult();
+        int meetId = 42;
+
+        // Act — empty title fails validation
+        meet.Update(
+            meetId,
+            creator,
+            MeetCategory.Powerlifting,
+            title: string.Empty,
+            startDate: new DateOnly(2025, 6, 1),
+            calcPlaces: false);
+
+        // Assert
+        meet.DomainEvents
+            .OfType<CalcPlacesChangedEvent>()
+            .ShouldBeEmpty();
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Meets/MeetTests/Update/RaisesCalcPlacesChangedEventTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Meets/MeetTests/Update/RaisesCalcPlacesChangedEventTests.cs
@@ -19,11 +19,9 @@ public sealed class RaisesCalcPlacesChangedEventTests
             title: "Test Meet",
             startDate: new DateOnly(2025, 6, 1),
             calcPlaces: true).FromResult();
-        int meetId = 42;
 
         // Act
         meet.Update(
-            meetId,
             creator,
             MeetCategory.Powerlifting,
             title: "Test Meet",
@@ -35,7 +33,7 @@ public sealed class RaisesCalcPlacesChangedEventTests
             .OfType<CalcPlacesChangedEvent>()
             .FirstOrDefault();
         raisedEvent.ShouldNotBeNull();
-        raisedEvent.MeetId.ShouldBe(meetId);
+        raisedEvent.Slug.ShouldBe(meet.Slug);
         raisedEvent.CalcPlaces.ShouldBeFalse();
     }
 
@@ -50,11 +48,9 @@ public sealed class RaisesCalcPlacesChangedEventTests
             title: "Test Meet",
             startDate: new DateOnly(2025, 6, 1),
             calcPlaces: true).FromResult();
-        int meetId = 42;
 
         // Act
         meet.Update(
-            meetId,
             creator,
             MeetCategory.Powerlifting,
             title: "Test Meet",
@@ -78,11 +74,9 @@ public sealed class RaisesCalcPlacesChangedEventTests
             title: "Test Meet",
             startDate: new DateOnly(2025, 6, 1),
             calcPlaces: true).FromResult();
-        int meetId = 42;
 
         // Act — empty title fails validation
         meet.Update(
-            meetId,
             creator,
             MeetCategory.Powerlifting,
             title: string.Empty,

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/ClearRanking/SetsPlaceToZeroTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/ClearRanking/SetsPlaceToZeroTests.cs
@@ -1,0 +1,25 @@
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Participations.Participation.ClearRanking;
+
+public sealed class SetsPlaceToZeroTests
+{
+    [Fact]
+    public void SetsPlaceToZero()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+        participation.UpdateRanking(3);
+
+        // Act
+        participation.ClearRanking();
+
+        // Assert
+        participation.Place.ShouldBe(0);
+    }
+}

--- a/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/ClearRanking/SetsTeamPointsToNullTests.cs
+++ b/tests/KRAFT.Results.WebApi.UnitTests/Features/Participations/Participation/ClearRanking/SetsTeamPointsToNullTests.cs
@@ -1,0 +1,25 @@
+using KRAFT.Results.WebApi.Features.Users;
+using KRAFT.Results.WebApi.UnitTests.Builders;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.UnitTests.Features.Participations.Participation.ClearRanking;
+
+public sealed class SetsTeamPointsToNullTests
+{
+    [Fact]
+    public void SetsTeamPointsToNull_EvenWhenPreviouslySet()
+    {
+        // Arrange
+        User creator = new UserBuilder().Build();
+        WebApi.Features.Participations.Participation participation = WebApi.Features.Participations.Participation.Create(
+            creator, athleteId: 1, meetId: 1, weightCategoryId: 1, ageCategoryId: 1, bodyWeight: 83.5m).FromResult();
+        participation.UpdateRanking(1);
+
+        // Act
+        participation.ClearRanking();
+
+        // Assert
+        participation.TeamPoints.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- When `CalcPlaces` is toggled from `false` to `true`, places and team points are recomputed for all participations grouped by weight category and age category
- When toggled from `true` to `false`, places are reset to 0 and team points to null
- No recomputation occurs when `CalcPlaces` is unchanged during a meet update

## Implementation

- Domain event `CalcPlacesChangedEvent` raised by `Meet.Update()` only when `CalcPlaces` actually changes
- `CalcPlacesChangedEventHandler` delegates to `PlaceComputationService.RecomputeMeetAsync`
- `RecomputeMeetAsync` handles both directions: groups + ranks when enabling, clears via `Participation.ClearRanking()` when disabling
- Synchronous processing within the request (bounded participation count)

## Test plan

- [x] Unit tests: ClearRanking sets Place=0 and TeamPoints=null
- [x] Unit tests: Meet.Update raises event only on CalcPlaces change
- [x] Integration test: false→true computes places per group
- [x] Integration test: true→false clears all places and team points
- [x] Integration test: unchanged CalcPlaces preserves existing places
- [x] Integration test: empty meet toggle succeeds without error

Closes #475