### PR TITLE
refactor(web): consolidate data-loading lifecycle into DataLoader<T> component

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
+++ b/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
@@ -2,15 +2,21 @@
 
 @if (_state == State.Loading)
 {
-    <LoadingSpinner Label="@($"Sæki {Noun}...")" />
+    <div class="data-loader-status">
+        <LoadingSpinner Label="@($"Sæki {Noun}...")" />
+    </div>
 }
 else if (_state == State.Error)
 {
-    <ErrorMessage Message="@($"Villa kom upp við að sækja {Noun}. Reyndu aftur síðar.")" OnRetry="RetryAsync" />
+    <div class="data-loader-status">
+        <ErrorMessage Message="@($"Villa kom upp við að sækja {Noun}. Reyndu aftur síðar.")" OnRetry="RetryAsync" />
+    </div>
 }
 else if (_state == State.NotFound)
 {
-    <ErrorMessage Message="@($"{CapitalizedNoun} fannst ekki.")" />
+    <div class="data-loader-status">
+        <ErrorMessage Message="@($"{CapitalizedNoun} fannst ekki.")" />
+    </div>
 }
 else if (_state == State.Loaded && _data is not null)
 {

--- a/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
+++ b/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
@@ -1,0 +1,61 @@
+@typeparam T where T : class
+
+@if (_state == State.Loading)
+{
+    <LoadingSpinner Label="@($"Sæki {Noun}...")" />
+}
+else if (_state == State.Error)
+{
+    <ErrorMessage Message="@($"Villa kom upp við að sækja {Noun}. Reyndu aftur síðar.")" OnRetry="RetryAsync" />
+}
+else if (_state == State.NotFound)
+{
+    <ErrorMessage Message="@($"{CapitalizedNoun} fannst ekki.")" />
+}
+else if (_state == State.Loaded && _data is not null)
+{
+    @ChildContent(_data)
+}
+
+@code {
+    private enum State { Loading, Loaded, Error, NotFound }
+
+    private State _state = State.Loading;
+    private T? _data;
+
+    [Parameter, EditorRequired]
+    public Func<Task<T?>> Loader { get; set; } = null!;
+
+    [Parameter, EditorRequired]
+    public string Noun { get; set; } = string.Empty;
+
+    [Parameter, EditorRequired]
+    public RenderFragment<T> ChildContent { get; set; } = null!;
+
+    private string CapitalizedNoun =>
+        Noun.Length == 0 ? Noun : char.ToUpper(Noun[0]) + Noun[1..];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task RetryAsync()
+    {
+        _state = State.Loading;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            _data = await Loader();
+            _state = _data is null ? State.NotFound : State.Loaded;
+        }
+        catch (HttpRequestException)
+        {
+            _state = State.Error;
+        }
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
+++ b/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
@@ -43,6 +43,7 @@ else if (_state == State.Loaded && _data is not null)
     private async Task RetryAsync()
     {
         _state = State.Loading;
+        StateHasChanged();
         await LoadAsync();
     }
 
@@ -53,7 +54,7 @@ else if (_state == State.Loaded && _data is not null)
             _data = await Loader();
             _state = _data is null ? State.NotFound : State.Loaded;
         }
-        catch (HttpRequestException)
+        catch (Exception)
         {
             _state = State.Error;
         }

--- a/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
+++ b/src/KRAFT.Results.Web.Client/Components/DataLoader.razor
@@ -38,6 +38,9 @@ else if (_state == State.Loaded && _data is not null)
     [Parameter, EditorRequired]
     public RenderFragment<T> ChildContent { get; set; } = null!;
 
+    [Parameter]
+    public EventCallback OnLoaded { get; set; }
+
     private string CapitalizedNoun =>
         Noun.Length == 0 ? Noun : char.ToUpper(Noun[0]) + Noun[1..];
 
@@ -59,6 +62,11 @@ else if (_state == State.Loaded && _data is not null)
         {
             _data = await Loader();
             _state = _data is null ? State.NotFound : State.Loaded;
+
+            if (_state == State.Loaded)
+            {
+                await OnLoaded.InvokeAsync();
+            }
         }
         catch (Exception)
         {

--- a/src/KRAFT.Results.Web.Client/Components/DataLoader.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/DataLoader.razor.css
@@ -1,0 +1,6 @@
+.data-loader-status {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 200px;
+}

--- a/src/KRAFT.Results.Web.Client/Components/LoadingSpinner.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/LoadingSpinner.razor.css
@@ -11,7 +11,7 @@
     width: 32px;
     height: 32px;
     border: 3px solid var(--color-border);
-    border-top-color: var(--color-accent);
+    border-top-color: var(--color-primary);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
 }

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
@@ -8,153 +8,168 @@
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki keppanda..." />
-}
-else if (_errorMessage is not null)
-{
-    <div role="alert" class="error-message">
-        <p>@_errorMessage</p>
-        <a href="/athletes">Til baka í keppendur</a>
-    </div>
-}
-else
-{
-<div class="page-header">
-    <h1>@Athlete?.Name</h1>
-    <AuthorizeView Roles="Admin">
-        <div class="admin-actions">
-            <a href="/athletes/@Slug/edit" class="btn-action" aria-label="Breyta keppanda">
-                <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
-                    <path d="m15 5 4 4"/>
-                </svg>
-                Breyta
-            </a>
-            <button class="btn-action btn-danger" aria-label="Eyða keppanda" @onclick="ShowDeleteDialog">
-                <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M3 6h18"/>
-                    <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
-                    <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
-                    <line x1="10" x2="10" y1="11" y2="17"/>
-                    <line x1="14" x2="14" y1="11" y2="17"/>
-                </svg>
-                Eyða
-            </button>
+<DataLoader T="AthletePageData" Loader="LoadAsync" Noun="keppanda">
+    <ChildContent Context="pageData">
+        <div class="page-header">
+            <h1>@pageData.Athlete.Name</h1>
+            <AuthorizeView Roles="Admin">
+                <div class="admin-actions">
+                    <a href="/athletes/@Slug/edit" class="btn-action" aria-label="Breyta keppanda">
+                        <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+                            <path d="m15 5 4 4"/>
+                        </svg>
+                        Breyta
+                    </a>
+                    <button class="btn-action btn-danger" aria-label="Eyða keppanda" @onclick="ShowDeleteDialog">
+                        <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 6h18"/>
+                            <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
+                            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
+                            <line x1="10" x2="10" y1="11" y2="17"/>
+                            <line x1="14" x2="14" y1="11" y2="17"/>
+                        </svg>
+                        Eyða
+                    </button>
+                </div>
+            </AuthorizeView>
         </div>
-    </AuthorizeView>
-</div>
-<div class="athlete-meta">
-    <span>Fæðingarár: @Athlete?.YearOfBirth</span>
-    @if (ShowClubs)
-    {
-        <span class="meta-separator">&middot;</span>
-        <NavLink class="nav-link" href="@SlugSanitizer.SlugHref("/teams/", Athlete?.ClubSlug ?? string.Empty)">
-            @Athlete?.Club
-        </NavLink>
-    }
-</div>
+        <div class="athlete-meta">
+            <span>Fæðingarár: @pageData.Athlete.YearOfBirth</span>
+            @if (pageData.ShowClubs)
+            {
+                <span class="meta-separator">&middot;</span>
+                <NavLink class="nav-link" href="@SlugSanitizer.SlugHref("/teams/", pageData.Athlete.ClubSlug ?? string.Empty)">
+                    @pageData.Athlete.Club
+                </NavLink>
+            }
+        </div>
 
-@if (PersonalBests.Count > 0 || Records.Count > 0 || Participations.Count > 0)
-{
-    <SectionNav Links="@_navLinks" />
-}
-
-@if (PersonalBests.Count > 0)
-{
-    <h3 id="bestaragangur">Besti árangur</h3>
-    <div class="pb-group-container">
-        @foreach (IGrouping<bool, AthletePersonalBest> group in PersonalBests.GroupBy(x => x.IsClassic).OrderByDescending(g => g.Key))
+        @if (pageData.PersonalBests.Count > 0 || pageData.Records.Count > 0 || pageData.Participations.Count > 0)
         {
-            <AthletePersonalBestGroupCard
-                Title="@($"Besti árangur {DisplayNames.EquipmentType(group.Key).ToLowerInvariant()}")"
-                PersonalBests="@group.ToList()"
-                Records="@Records" />
+            <SectionNav Links="@pageData.NavLinks" />
         }
-    </div>
-}
 
-@if (Records.Count > 0)
-{
-    <h3 id="islandsmet">Núverandi íslandsmet (@Records.Count)</h3>
-    <div class="pb-group-container">
-        @foreach (IGrouping<bool, AthleteRecord> group in Records.GroupBy(x => x.IsClassic).OrderByDescending(g => g.Key))
+        @if (pageData.PersonalBests.Count > 0)
         {
-            <AthleteRecordGroupCard
-                Title="@($"Íslandsmet {DisplayNames.EquipmentType(group.Key).ToLowerInvariant()} ({group.Count()})")"
-                Records="@group.ToList()" />
+            <h3 id="bestaragangur">Besti árangur</h3>
+            <div class="pb-group-container">
+                @foreach (IGrouping<bool, AthletePersonalBest> group in pageData.PersonalBests.GroupBy(x => x.IsClassic).OrderByDescending(g => g.Key))
+                {
+                    <AthletePersonalBestGroupCard
+                        Title="@($"Besti árangur {DisplayNames.EquipmentType(group.Key).ToLowerInvariant()}")"
+                        PersonalBests="@group.ToList()"
+                        Records="@pageData.Records" />
+                }
+            </div>
         }
-    </div>
-}
 
-@if (Participations.Count > 0)
-{
-    <h3 id="ferill">Ferill (@Participations.Count)</h3>
-
-    int groupIndex = 0;
-    @foreach (IGrouping<string, AthleteParticipation> meetType in Participations.GroupBy(x => x.MeetType))
-    {
-        if (groupIndex == 0)
+        @if (pageData.Records.Count > 0)
         {
-            <details class="career-group" open>
-                <summary class="career-group-summary">@meetType.Key</summary>
-                <div class="card-list">
-                    @foreach (AthleteParticipation p in meetType)
-                    {
-                        <AthleteParticipationCard
-                            Participation="p"
-                            MeetType="@meetType.Key"
-                            ShowIpfPoints="@true" />
-                    }
-                </div>
-            </details>
+            <h3 id="islandsmet">Núverandi íslandsmet (@pageData.Records.Count)</h3>
+            <div class="pb-group-container">
+                @foreach (IGrouping<bool, AthleteRecord> group in pageData.Records.GroupBy(x => x.IsClassic).OrderByDescending(g => g.Key))
+                {
+                    <AthleteRecordGroupCard
+                        Title="@($"Íslandsmet {DisplayNames.EquipmentType(group.Key).ToLowerInvariant()} ({group.Count()})")"
+                        Records="@group.ToList()" />
+                }
+            </div>
         }
-        else
-        {
-            <details class="career-group">
-                <summary class="career-group-summary">@meetType.Key</summary>
-                <div class="card-list">
-                    @foreach (AthleteParticipation p in meetType)
-                    {
-                        <AthleteParticipationCard
-                            Participation="p"
-                            MeetType="@meetType.Key"
-                            ShowIpfPoints="@true" />
-                    }
-                </div>
-            </details>
-        }
-        groupIndex++;
-    }
-}
 
-<ConfirmDialog @ref="_deleteDialog"
-               Id="delete-athlete-dialog"
-               Title="Eyða keppanda"
-               Message="Ertu viss um að þú viljir eyða þessum keppanda?"
-               ConfirmLabel="Eyða keppanda"
-               OnConfirm="HandleDelete"
-               ErrorMessage="@_deleteErrorMessage"
-               IsLoading="_isDeleting" />
-}
+        @if (pageData.Participations.Count > 0)
+        {
+            <h3 id="ferill">Ferill (@pageData.Participations.Count)</h3>
+
+            int groupIndex = 0;
+            @foreach (IGrouping<string, AthleteParticipation> meetType in pageData.Participations.GroupBy(x => x.MeetType))
+            {
+                if (groupIndex == 0)
+                {
+                    <details class="career-group" open>
+                        <summary class="career-group-summary">@meetType.Key</summary>
+                        <div class="card-list">
+                            @foreach (AthleteParticipation p in meetType)
+                            {
+                                <AthleteParticipationCard
+                                    Participation="p"
+                                    MeetType="@meetType.Key"
+                                    ShowIpfPoints="@true" />
+                            }
+                        </div>
+                    </details>
+                }
+                else
+                {
+                    <details class="career-group">
+                        <summary class="career-group-summary">@meetType.Key</summary>
+                        <div class="card-list">
+                            @foreach (AthleteParticipation p in meetType)
+                            {
+                                <AthleteParticipationCard
+                                    Participation="p"
+                                    MeetType="@meetType.Key"
+                                    ShowIpfPoints="@true" />
+                            }
+                        </div>
+                    </details>
+                }
+                groupIndex++;
+            }
+        }
+
+        <ConfirmDialog @ref="_deleteDialog"
+                       Id="delete-athlete-dialog"
+                       Title="Eyða keppanda"
+                       Message="Ertu viss um að þú viljir eyða þessum keppanda?"
+                       ConfirmLabel="Eyða keppanda"
+                       OnConfirm="HandleDelete"
+                       ErrorMessage="@_deleteErrorMessage"
+                       IsLoading="_isDeleting" />
+    </ChildContent>
+</DataLoader>
 
 @code {
+    private sealed record AthletePageData(
+        AthleteDetails Athlete,
+        IReadOnlyList<AthletePersonalBest> PersonalBests,
+        IReadOnlyList<AthleteRecord> Records,
+        IReadOnlyList<AthleteParticipation> Participations,
+        List<SectionNav.SectionNavLink> NavLinks,
+        bool ShowClubs);
+
     private ConfirmDialog _deleteDialog = null!;
     private bool _isDeleting;
-    private bool _isLoading = true;
     private string? _deleteErrorMessage;
-    private string? _errorMessage;
 
     [Parameter]
     public string Slug { get; set; } = string.Empty;
 
-    private AthleteDetails? Athlete;
-    private bool ShowClubs;
-    private IReadOnlyList<AthletePersonalBest> PersonalBests = [];
-    private IReadOnlyList<AthleteRecord> Records = [];
-    private IReadOnlyList<AthleteParticipation> Participations = [];
-    private IReadOnlyList<SectionNav.SectionNavLink> _navLinks = [];
+    private async Task<AthletePageData?> LoadAsync()
+    {
+        AthleteDetails? athlete = await HttpClient.GetFromJsonAsync<AthleteDetails>($"/athletes/{Slug}");
+
+        if (athlete is null)
+        {
+            return null;
+        }
+
+        IReadOnlyList<AthletePersonalBest> personalBests =
+            await HttpClient.GetFromJsonAsync<IReadOnlyList<AthletePersonalBest>>($"/athletes/{Slug}/personalbests") ?? [];
+        IReadOnlyList<AthleteRecord> records =
+            await HttpClient.GetFromJsonAsync<IReadOnlyList<AthleteRecord>>($"/athletes/{Slug}/records") ?? [];
+        IReadOnlyList<AthleteParticipation> participations =
+            await HttpClient.GetFromJsonAsync<IReadOnlyList<AthleteParticipation>>($"/athletes/{Slug}/participations") ?? [];
+
+        bool showClubs = !string.IsNullOrWhiteSpace(athlete.Club);
+
+        List<SectionNav.SectionNavLink> navLinks = [];
+        if (personalBests.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Besti árangur", $"/athletes/{Slug}#bestaragangur")); }
+        if (records.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Íslandsmet", $"/athletes/{Slug}#islandsmet")); }
+        if (participations.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Ferill", $"/athletes/{Slug}#ferill")); }
+
+        return new AthletePageData(athlete, personalBests, records, participations, navLinks, showClubs);
+    }
 
     private async Task ShowDeleteDialog()
     {
@@ -196,32 +211,6 @@ else
         finally
         {
             _isDeleting = false;
-        }
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        try
-        {
-            Athlete = await HttpClient.GetFromJsonAsync<AthleteDetails>($"/athletes/{Slug}");
-            PersonalBests = await HttpClient.GetFromJsonAsync<IReadOnlyList<AthletePersonalBest>>($"/athletes/{Slug}/personalbests") ?? [];
-            Records = await HttpClient.GetFromJsonAsync<IReadOnlyList<AthleteRecord>>($"/athletes/{Slug}/records") ?? [];
-            Participations = await HttpClient.GetFromJsonAsync<IReadOnlyList<AthleteParticipation>>($"/athletes/{Slug}/participations") ?? [];
-            ShowClubs = !string.IsNullOrWhiteSpace(Athlete?.Club);
-
-            List<SectionNav.SectionNavLink> navLinks = [];
-            if (PersonalBests.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Besti árangur", $"/athletes/{Slug}#bestaragangur")); }
-            if (Records.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Íslandsmet", $"/athletes/{Slug}#islandsmet")); }
-            if (Participations.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Ferill", $"/athletes/{Slug}#ferill")); }
-            _navLinks = navLinks;
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp við að sækja keppanda. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isLoading = false;
         }
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
@@ -1,6 +1,7 @@
 @page "/athletes"
 
 @using KRAFT.Results.Contracts.Athletes
+@using KRAFT.Results.Web.Client.Components
 @using Microsoft.AspNetCore.Components.Routing
 
 @implements IAsyncDisposable
@@ -9,69 +10,73 @@
 
 <PageHeader Title="Keppendur" ActionHref="/athletes/create" ActionLabel="Stofna keppanda" />
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki keppendur..." />
-}
-else if (_errorMessage is not null)
-{
-    <ErrorMessage Message="@_errorMessage" />
-}
-else
-{
-    <div class="search-container">
-        <input @ref="_searchInput"
-               type="search"
-               class="search-input"
-               placeholder="Finna keppanda..."
-               aria-label="Finna keppanda"
-               @bind="_searchTerm"
-               @bind:event="oninput"
-               @bind:after="OnSearchInputAsync" />
-    </div>
+<DataLoader T="IReadOnlyCollection<AthleteSummary>" Loader="LoadAsync" Noun="keppendur">
+    <ChildContent Context="context">
+        @{ InitializeAthletes(context); }
+        <div class="search-container">
+            <input @ref="_searchInput"
+                   type="search"
+                   class="search-input"
+                   placeholder="Finna keppanda..."
+                   aria-label="Finna keppanda"
+                   @bind="_searchTerm"
+                   @bind:event="oninput"
+                   @bind:after="OnSearchInputAsync" />
+        </div>
 
-    @if (_filteredAthletes.Count > 0)
-    {
-        <table>
-            <thead>
-                <tr>
-                    <th>Nafn</th>
-                </tr>
-            </thead>
-
-            <tbody>
-                @foreach (AthleteSummary athlete in _filteredAthletes)
-                {
+        @if (_filteredAthletes.Count > 0)
+        {
+            <table>
+                <thead>
                     <tr>
-                        <td>
-                            <NavLink class="nav-link" href="@($"/athletes/{athlete.Slug}")">
-                                @(athlete.YearOfBirth is null ? athlete.Name : $"{athlete.Name} ({athlete.YearOfBirth})")
-                            </NavLink>
-                        </td>
+                        <th>Nafn</th>
                     </tr>
-                }
-            </tbody>
-        </table>
-    }
+                </thead>
 
-    @if (_filteredAthletes.Count == 0 && _athletes.Count > 0)
-    {
-        <EmptyState Message="Enginn keppandi fannst." />
-    }
-}
+                <tbody>
+                    @foreach (AthleteSummary athlete in _filteredAthletes)
+                    {
+                        <tr>
+                            <td>
+                                <NavLink class="nav-link" href="@($"/athletes/{athlete.Slug}")">
+                                    @(athlete.YearOfBirth is null ? athlete.Name : $"{athlete.Name} ({athlete.YearOfBirth})")
+                                </NavLink>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+
+        @if (_filteredAthletes.Count == 0 && _athletes.Count > 0)
+        {
+            <EmptyState Message="Enginn keppandi fannst." />
+        }
+    </ChildContent>
+</DataLoader>
 
 @code {
 
     private IReadOnlyCollection<AthleteSummary> _athletes = [];
     private string _searchTerm = string.Empty;
-    private bool _isLoading = true;
-    private string? _errorMessage;
     private bool _shouldFocusSearch;
     private ElementReference _searchInput;
 
     private IReadOnlyCollection<AthleteSummary> _filteredAthletes = [];
 
     private CancellationTokenSource _debounceCts = new();
+
+    private void InitializeAthletes(IReadOnlyCollection<AthleteSummary> context)
+    {
+        if (_athletes == context)
+        {
+            return;
+        }
+
+        _athletes = context;
+        _filteredAthletes = context;
+        _shouldFocusSearch = true;
+    }
 
     private void ApplyFilter()
     {
@@ -82,23 +87,9 @@ else
                 .ToList();
     }
 
-    protected override async Task OnInitializedAsync()
+    private async Task<IReadOnlyCollection<AthleteSummary>?> LoadAsync()
     {
-        try
-        {
-            await base.OnInitializedAsync();
-            _athletes = await HttpClient.GetFromJsonAsync<IReadOnlyCollection<AthleteSummary>>("/athletes") ?? [];
-            ApplyFilter();
-            _shouldFocusSearch = true;
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp við að sækja keppendur. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        return await HttpClient.GetFromJsonAsync<IReadOnlyCollection<AthleteSummary>>("/athletes");
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
@@ -10,7 +10,7 @@
 
 <PageHeader Title="Keppendur" ActionHref="/athletes/create" ActionLabel="Stofna keppanda" />
 
-<DataLoader T="IReadOnlyCollection<AthleteSummary>" Loader="LoadAsync" Noun="keppendur">
+<DataLoader T="IReadOnlyCollection<AthleteSummary>" Loader="LoadAsync" Noun="keppendur" OnLoaded="HandleDataLoaded">
     <ChildContent Context="context">
         @{ InitializeAthletes(context); }
         <div class="search-container">
@@ -66,6 +66,11 @@
 
     private CancellationTokenSource _debounceCts = new();
 
+    private void HandleDataLoaded()
+    {
+        _shouldFocusSearch = true;
+    }
+
     private void InitializeAthletes(IReadOnlyCollection<AthleteSummary> context)
     {
         if (_athletes == context)
@@ -75,7 +80,6 @@
 
         _athletes = context;
         _filteredAthletes = context;
-        _shouldFocusSearch = true;
     }
 
     private void ApplyFilter()

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/CreateAthletePage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/CreateAthletePage.razor
@@ -50,6 +50,11 @@
         IReadOnlyCollection<CountrySummary> countries = await countriesTask ?? [];
         IReadOnlyCollection<TeamOption> teams = await teamsTask ?? [];
 
+        if (countries.Count == 0)
+        {
+            throw new HttpRequestException("Required reference data is unavailable.");
+        }
+
         return new CreateAthleteData(countries, teams);
     }
 

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/CreateAthletePage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/CreateAthletePage.razor
@@ -10,6 +10,7 @@
 @using KRAFT.Results.Contracts.Athletes
 @using KRAFT.Results.Contracts.Countries
 @using KRAFT.Results.Contracts.Teams
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
@@ -17,50 +18,39 @@
 <PageTitle>Nýr keppandi</PageTitle>
 <h3>Nýr keppandi</h3>
 
-@if (_isInitializing)
-{
-    <LoadingSpinner Label="Sæki gögn..." />
-}
-else
-{
-    <AthleteForm Countries="_countries"
-                 Teams="_teams"
-                 OnSubmit="HandleSubmit"
-                 IsLoading="_isLoading"
-                 ErrorMessage="@_errorMessage"
-                 SubmitLabel="Stofna keppanda"
-                 BackUrl="/athletes" />
-}
+<DataLoader T="CreateAthleteData" Loader="LoadAsync" Noun="gögn">
+    <ChildContent Context="data">
+        <AthleteForm Countries="data.Countries"
+                     Teams="data.Teams"
+                     OnSubmit="HandleSubmit"
+                     IsLoading="_isLoading"
+                     ErrorMessage="@_errorMessage"
+                     SubmitLabel="Stofna keppanda"
+                     BackUrl="/athletes" />
+    </ChildContent>
+</DataLoader>
 
 @code {
-    private IReadOnlyCollection<CountrySummary> _countries = [];
-    private IReadOnlyCollection<TeamOption> _teams = [];
-    private bool _isInitializing = true;
+    private sealed record CreateAthleteData(
+        IReadOnlyCollection<CountrySummary> Countries,
+        IReadOnlyCollection<TeamOption> Teams);
+
     private bool _isLoading;
     private string? _errorMessage;
 
-    protected override async Task OnInitializedAsync()
+    private async Task<CreateAthleteData?> LoadAsync()
     {
-        try
-        {
-            Task<IReadOnlyCollection<CountrySummary>?> countriesTask =
-                HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries");
-            Task<IReadOnlyCollection<TeamOption>?> teamsTask =
-                HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamOption>>("/teams/options");
+        Task<IReadOnlyCollection<CountrySummary>?> countriesTask =
+            HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries");
+        Task<IReadOnlyCollection<TeamOption>?> teamsTask =
+            HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamOption>>("/teams/options");
 
-            await Task.WhenAll(countriesTask, teamsTask);
+        await Task.WhenAll(countriesTask, teamsTask);
 
-            _countries = await countriesTask ?? [];
-            _teams = await teamsTask ?? [];
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Gat ekki sótt gögn. Reyndu að endurhlaða síðuna.";
-        }
-        finally
-        {
-            _isInitializing = false;
-        }
+        IReadOnlyCollection<CountrySummary> countries = await countriesTask ?? [];
+        IReadOnlyCollection<TeamOption> teams = await teamsTask ?? [];
+
+        return new CreateAthleteData(countries, teams);
     }
 
     private async Task HandleSubmit(AthleteFormValues values)

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/EditAthletePage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/EditAthletePage.razor
@@ -8,6 +8,7 @@
 @using KRAFT.Results.Contracts.Athletes
 @using KRAFT.Results.Contracts.Countries
 @using KRAFT.Results.Contracts.Teams
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
@@ -15,79 +16,61 @@
 <PageTitle>Breyta keppanda</PageTitle>
 <h3>Breyta keppanda</h3>
 
-@if (_isInitializing)
-{
-    <LoadingSpinner Label="Sæki gögn..." />
-}
-else if (_initialValues is not null)
-{
-    <AthleteForm Countries="_countries"
-                 Teams="_teams"
-                 OnSubmit="HandleSubmit"
-                 IsLoading="_isLoading"
-                 ErrorMessage="@_errorMessage"
-                 SubmitLabel="Vista breytingar"
-                 BackUrl="@($"/athletes/{Slug}")"
-                 InitialValues="_initialValues" />
-}
-else if (_errorMessage is not null)
-{
-    <div role="alert" class="error-message">
-        <p>@_errorMessage</p>
-        <a href="/athletes">Til baka í keppandalista</a>
-    </div>
-}
+<DataLoader T="EditAthleteData" Loader="LoadAsync" Noun="gögn">
+    <ChildContent Context="data">
+        <AthleteForm Countries="data.Countries"
+                     Teams="data.Teams"
+                     OnSubmit="HandleSubmit"
+                     IsLoading="_isLoading"
+                     ErrorMessage="@_errorMessage"
+                     SubmitLabel="Vista breytingar"
+                     BackUrl="@($"/athletes/{Slug}")"
+                     InitialValues="data.InitialValues" />
+    </ChildContent>
+</DataLoader>
 
 @code {
+    private sealed record EditAthleteData(
+        AthleteFormInitialValues InitialValues,
+        IReadOnlyCollection<CountrySummary> Countries,
+        IReadOnlyCollection<TeamOption> Teams);
+
     [Parameter]
     public string Slug { get; set; } = string.Empty;
 
-    private IReadOnlyCollection<CountrySummary> _countries = [];
-    private IReadOnlyCollection<TeamOption> _teams = [];
-    private AthleteFormInitialValues? _initialValues;
-    private bool _isInitializing = true;
     private bool _isLoading;
     private string? _errorMessage;
 
-    protected override async Task OnInitializedAsync()
+    private async Task<EditAthleteData?> LoadAsync()
     {
-        try
+        Task<AthleteEditDetails?> athleteTask =
+            HttpClient.GetFromJsonAsync<AthleteEditDetails>($"/athletes/{Slug}/edit");
+        Task<IReadOnlyCollection<CountrySummary>?> countriesTask =
+            HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries");
+        Task<IReadOnlyCollection<TeamOption>?> teamsTask =
+            HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamOption>>("/teams/options");
+
+        await Task.WhenAll(athleteTask, countriesTask, teamsTask);
+
+        AthleteEditDetails? athlete = await athleteTask;
+
+        if (athlete is null)
         {
-            Task<AthleteEditDetails?> athleteTask =
-                HttpClient.GetFromJsonAsync<AthleteEditDetails>($"/athletes/{Slug}/edit");
-            Task<IReadOnlyCollection<CountrySummary>?> countriesTask =
-                HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries");
-            Task<IReadOnlyCollection<TeamOption>?> teamsTask =
-                HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamOption>>("/teams/options");
-
-            await Task.WhenAll(athleteTask, countriesTask, teamsTask);
-
-            AthleteEditDetails? athlete = await athleteTask;
-            _countries = await countriesTask ?? [];
-            _teams = await teamsTask ?? [];
-
-            if (athlete is null)
-            {
-                _errorMessage = "Keppandi fannst ekki.";
-                return;
-            }
-
-            _initialValues = new AthleteFormInitialValues(
-                athlete.FirstName,
-                athlete.LastName,
-                athlete.DateOfBirth,
-                athlete.Gender,
-                athlete.CountryCode,
-                athlete.TeamId ?? 0);
+            return null;
         }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isInitializing = false;
-        }
+
+        IReadOnlyCollection<CountrySummary> countries = await countriesTask ?? [];
+        IReadOnlyCollection<TeamOption> teams = await teamsTask ?? [];
+
+        AthleteFormInitialValues initialValues = new(
+            athlete.FirstName,
+            athlete.LastName,
+            athlete.DateOfBirth,
+            athlete.Gender,
+            athlete.CountryCode,
+            athlete.TeamId ?? 0);
+
+        return new EditAthleteData(initialValues, countries, teams);
     }
 
     private async Task HandleSubmit(AthleteFormValues values)

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -12,215 +12,193 @@
 
 <PageTitle>Forsíða — KRAFT Results</PageTitle>
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki forsíðu..." />
-}
-else if (_hasError)
-{
-    <ErrorMessage Message="Villa kom upp við að sækja gögn. Reyndu aftur síðar." />
-}
-else if (_dashboard is not null)
-{
-    <section class="season-stats" aria-label="Tölur ársins @_year">
-        <h2 class="section-label">Tölur ársins @_year</h2>
-        <div class="stat-bar">
-            <div class="stat-card">
-                <span class="stat-number">@_dashboard.SeasonStats.Meets</span>
-                <span class="stat-label">Mót</span>
+<DataLoader T="DashboardSummary" Loader="LoadAsync" Noun="forsíðu">
+    <ChildContent Context="context">
+        <section class="season-stats" aria-label="Tölur ársins @_year">
+            <h2 class="section-label">Tölur ársins @_year</h2>
+            <div class="stat-bar">
+                <div class="stat-card">
+                    <span class="stat-number">@context.SeasonStats.Meets</span>
+                    <span class="stat-label">Mót</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-number">@context.SeasonStats.Athletes</span>
+                    <span class="stat-label">Keppendur</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-number">@context.SeasonStats.Records</span>
+                    <span class="stat-label">Met</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-number">@context.SeasonStats.Clubs</span>
+                    <span class="stat-label">Félög</span>
+                </div>
             </div>
-            <div class="stat-card">
-                <span class="stat-number">@_dashboard.SeasonStats.Athletes</span>
-                <span class="stat-label">Keppendur</span>
-            </div>
-            <div class="stat-card">
-                <span class="stat-number">@_dashboard.SeasonStats.Records</span>
-                <span class="stat-label">Met</span>
-            </div>
-            <div class="stat-card">
-                <span class="stat-number">@_dashboard.SeasonStats.Clubs</span>
-                <span class="stat-label">Félög</span>
-            </div>
-        </div>
-    </section>
+        </section>
 
-    <div class="widget-grid">
-    <div class="widget">
-        <div class="widget-header">
-            <h2 class="widget-title">Mót</h2>
-            <NavLink class="widget-link" href="/meets">Mótaskrá →</NavLink>
-        </div>
-        <div class="split-columns">
-            <div class="split-col">
-                <div class="split-col-header">Síðustu mót</div>
-                @foreach (MeetSummary meet in _dashboard.RecentMeets)
-                {
-                    <article class="meet-item">
-                        <div class="date-box date-box--recent">@meet.StartDate.Day.ToString("D2")</div>
-                        <div>
-                            <NavLink class="meet-title" href="@($"/meets/{meet.Slug}")">@meet.Title</NavLink>
-                            <div class="meet-meta">@meet.StartDate.ToString("MMM", System.Globalization.CultureInfo.CurrentCulture) · @meet.Location</div>
-                        </div>
-                    </article>
-                }
+        <div class="widget-grid">
+        <div class="widget">
+            <div class="widget-header">
+                <h2 class="widget-title">Mót</h2>
+                <NavLink class="widget-link" href="/meets">Mótaskrá →</NavLink>
             </div>
-            <div class="split-col">
-                <div class="split-col-header">Næstu mót</div>
-                @if (_dashboard.UpcomingMeets.Count == 0)
-                {
-                    <p class="empty-col">Engin mót skráð í dagatal</p>
-                }
-                else
-                {
-                    @foreach (MeetSummary meet in _dashboard.UpcomingMeets)
+            <div class="split-columns">
+                <div class="split-col">
+                    <div class="split-col-header">Síðustu mót</div>
+                    @foreach (MeetSummary meet in context.RecentMeets)
                     {
                         <article class="meet-item">
-                            <div class="date-box date-box--upcoming">@meet.StartDate.Day.ToString("D2")</div>
+                            <div class="date-box date-box--recent">@meet.StartDate.Day.ToString("D2")</div>
                             <div>
                                 <NavLink class="meet-title" href="@($"/meets/{meet.Slug}")">@meet.Title</NavLink>
                                 <div class="meet-meta">@meet.StartDate.ToString("MMM", System.Globalization.CultureInfo.CurrentCulture) · @meet.Location</div>
                             </div>
                         </article>
                     }
-                }
-            </div>
-        </div>
-    </div>
-
-    <div class="widget">
-        <div class="widget-header">
-            <h2 class="widget-title">Stigatafla @_year — Klassík</h2>
-            <NavLink class="widget-link" href="/rankings">Allt →</NavLink>
-        </div>
-        <div class="split-columns">
-            <div class="split-col">
-                <div class="split-col-header">Karlar</div>
-                <div class="ranking-list">
-                    @foreach (RankingEntry entry in _dashboard.TopRankingsMen)
-                    {
-                        <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
-                    }
                 </div>
-            </div>
-            <div class="split-col">
-                <div class="split-col-header">Konur</div>
-                <div class="ranking-list">
-                    @foreach (RankingEntry entry in _dashboard.TopRankingsWomen)
+                <div class="split-col">
+                    <div class="split-col-header">Næstu mót</div>
+                    @if (context.UpcomingMeets.Count == 0)
                     {
-                        <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
+                        <p class="empty-col">Engin mót skráð í dagatal</p>
+                    }
+                    else
+                    {
+                        @foreach (MeetSummary meet in context.UpcomingMeets)
+                        {
+                            <article class="meet-item">
+                                <div class="date-box date-box--upcoming">@meet.StartDate.Day.ToString("D2")</div>
+                                <div>
+                                    <NavLink class="meet-title" href="@($"/meets/{meet.Slug}")">@meet.Title</NavLink>
+                                    <div class="meet-meta">@meet.StartDate.ToString("MMM", System.Globalization.CultureInfo.CurrentCulture) · @meet.Location</div>
+                                </div>
+                            </article>
+                        }
                     }
                 </div>
             </div>
         </div>
-    </div>
 
-    <div class="widget">
-        <div class="widget-header">
-            <h2 class="widget-title">Ný met</h2>
-            <NavLink class="widget-link" href="/records">Allt →</NavLink>
-        </div>
-        <div class="split-columns">
-            <div class="split-col">
-                <div class="split-col-header">Karlar</div>
-                @foreach (DashboardRecordEntry record in _dashboard.RecentRecordsMen)
-                {
-                    <div class="record-item">
-                        <div class="record-left">
-                            <div class="record-top">
-                                <span class="record-lift">@record.Lift</span>
-                                <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
-                            </div>
-                            <div class="record-meta">
-                                <span class="badge">@record.WeightCategory</span>
-                                <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
-                                <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
-                            </div>
-                        </div>
-                        <div class="record-right">
-                            <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")">@record.Weight kg</NavLink>
-                            <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
-                        </div>
-                    </div>
-                }
-            </div>
-            <div class="split-col">
-                <div class="split-col-header">Konur</div>
-                @foreach (DashboardRecordEntry record in _dashboard.RecentRecordsWomen)
-                {
-                    <div class="record-item">
-                        <div class="record-left">
-                            <div class="record-top">
-                                <span class="record-lift">@record.Lift</span>
-                                <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
-                            </div>
-                            <div class="record-meta">
-                                <span class="badge">@record.WeightCategory</span>
-                                <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
-                                <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
-                            </div>
-                        </div>
-                        <div class="record-right">
-                            <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")">@record.Weight kg</NavLink>
-                            <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
-                        </div>
-                    </div>
-                }
-            </div>
-        </div>
-    </div>
-
-    @if (_dashboard.TeamStandingsMen.Count > 0 || _dashboard.TeamStandingsWomen.Count > 0)
-    {
         <div class="widget">
             <div class="widget-header">
-                <h2 class="widget-title">Liðakeppni @_year</h2>
-                <NavLink class="widget-link" href="/team-competition">Allt →</NavLink>
+                <h2 class="widget-title">Stigatafla @_year — Klassík</h2>
+                <NavLink class="widget-link" href="/rankings">Allt →</NavLink>
             </div>
             <div class="split-columns">
                 <div class="split-col">
                     <div class="split-col-header">Karlar</div>
-                    <div class="team-list">
-                        @foreach (TeamCompetitionStanding team in _dashboard.TeamStandingsMen)
+                    <div class="ranking-list">
+                        @foreach (RankingEntry entry in context.TopRankingsMen)
                         {
-                            <StandingsCard Standing="team" />
+                            <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
                         }
                     </div>
                 </div>
                 <div class="split-col">
                     <div class="split-col-header">Konur</div>
-                    <div class="team-list">
-                        @foreach (TeamCompetitionStanding team in _dashboard.TeamStandingsWomen)
+                    <div class="ranking-list">
+                        @foreach (RankingEntry entry in context.TopRankingsWomen)
                         {
-                            <StandingsCard Standing="team" />
+                            <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
                         }
                     </div>
                 </div>
             </div>
         </div>
-    }
-    </div>
-}
+
+        <div class="widget">
+            <div class="widget-header">
+                <h2 class="widget-title">Ný met</h2>
+                <NavLink class="widget-link" href="/records">Allt →</NavLink>
+            </div>
+            <div class="split-columns">
+                <div class="split-col">
+                    <div class="split-col-header">Karlar</div>
+                    @foreach (DashboardRecordEntry record in context.RecentRecordsMen)
+                    {
+                        <div class="record-item">
+                            <div class="record-left">
+                                <div class="record-top">
+                                    <span class="record-lift">@record.Lift</span>
+                                    <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
+                                </div>
+                                <div class="record-meta">
+                                    <span class="badge">@record.WeightCategory</span>
+                                    <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
+                                    <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
+                                </div>
+                            </div>
+                            <div class="record-right">
+                                <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")">@record.Weight kg</NavLink>
+                                <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
+                            </div>
+                        </div>
+                    }
+                </div>
+                <div class="split-col">
+                    <div class="split-col-header">Konur</div>
+                    @foreach (DashboardRecordEntry record in context.RecentRecordsWomen)
+                    {
+                        <div class="record-item">
+                            <div class="record-left">
+                                <div class="record-top">
+                                    <span class="record-lift">@record.Lift</span>
+                                    <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
+                                </div>
+                                <div class="record-meta">
+                                    <span class="badge">@record.WeightCategory</span>
+                                    <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
+                                    <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
+                                </div>
+                            </div>
+                            <div class="record-right">
+                                <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")">@record.Weight kg</NavLink>
+                                <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+
+        @if (context.TeamStandingsMen.Count > 0 || context.TeamStandingsWomen.Count > 0)
+        {
+            <div class="widget">
+                <div class="widget-header">
+                    <h2 class="widget-title">Liðakeppni @_year</h2>
+                    <NavLink class="widget-link" href="/team-competition">Allt →</NavLink>
+                </div>
+                <div class="split-columns">
+                    <div class="split-col">
+                        <div class="split-col-header">Karlar</div>
+                        <div class="team-list">
+                            @foreach (TeamCompetitionStanding team in context.TeamStandingsMen)
+                            {
+                                <StandingsCard Standing="team" />
+                            }
+                        </div>
+                    </div>
+                    <div class="split-col">
+                        <div class="split-col-header">Konur</div>
+                        <div class="team-list">
+                            @foreach (TeamCompetitionStanding team in context.TeamStandingsWomen)
+                            {
+                                <StandingsCard Standing="team" />
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+        </div>
+    </ChildContent>
+</DataLoader>
 
 @code {
-    private bool _isLoading = true;
-    private bool _hasError;
-    private DashboardSummary? _dashboard;
     private readonly int _year = DateTime.Now.Year;
 
-    protected override async Task OnInitializedAsync()
+    private async Task<DashboardSummary?> LoadAsync()
     {
-        try
-        {
-            _dashboard = await HttpClient.GetFromJsonAsync<DashboardSummary>("/dashboard");
-        }
-        catch (HttpRequestException)
-        {
-            _hasError = true;
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        return await HttpClient.GetFromJsonAsync<DashboardSummary>("/dashboard");
     }
-
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/EditMeetPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/EditMeetPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/meets/{slug}/edit"
+@page "/meets/{slug}/edit"
 
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 
@@ -6,6 +6,7 @@
 
 @using System.Net
 @using KRAFT.Results.Contracts.Meets
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
@@ -13,81 +14,63 @@
 <PageTitle>Breyta móti</PageTitle>
 <h3>Breyta móti</h3>
 
-@if (_isInitializing)
-{
-    <LoadingSpinner Label="Sæki mót..." />
-}
-else if (_initialValues is not null)
-{
-    <MeetForm MeetTypes="_meetTypes"
-              OnSubmit="HandleSubmit"
-              IsLoading="_isLoading"
-              ErrorMessage="@_errorMessage"
-              SubmitLabel="Vista breytingar"
-              BackUrl="@($"/meets/{Slug}")"
-              InitialValues="_initialValues" />
-}
-else if (_errorMessage is not null)
-{
-    <div role="alert" class="error-message">
-        <p>@_errorMessage</p>
-        <a href="/meets">Til baka í mótslista</a>
-    </div>
-}
+<DataLoader T="EditMeetData" Loader="LoadAsync" Noun="gögn">
+    <ChildContent Context="data">
+        <MeetForm MeetTypes="data.MeetTypes"
+                  OnSubmit="HandleSubmit"
+                  IsLoading="_isLoading"
+                  ErrorMessage="@_errorMessage"
+                  SubmitLabel="Vista breytingar"
+                  BackUrl="@($"/meets/{Slug}")"
+                  InitialValues="data.InitialValues" />
+    </ChildContent>
+</DataLoader>
 
 @code {
+    private sealed record EditMeetData(
+        MeetFormInitialValues InitialValues,
+        IReadOnlyList<MeetTypeSummary> MeetTypes);
+
     [Parameter]
     public string Slug { get; set; } = string.Empty;
 
-    private IReadOnlyList<MeetTypeSummary> _meetTypes = [];
-    private MeetFormInitialValues? _initialValues;
-    private bool _isInitializing = true;
     private bool _isLoading;
     private string? _errorMessage;
 
-    protected override async Task OnInitializedAsync()
+    private async Task<EditMeetData?> LoadAsync()
     {
-        try
-        {
-            MeetDetails? meet = await HttpClient.GetFromJsonAsync<MeetDetails>($"/meets/{Slug}");
-            _meetTypes = await HttpClient.GetFromJsonAsync<IReadOnlyList<MeetTypeSummary>>("/meets/types") ?? [];
+        MeetDetails? meet = await HttpClient.GetFromJsonAsync<MeetDetails>($"/meets/{Slug}");
+        IReadOnlyList<MeetTypeSummary> meetTypes =
+            await HttpClient.GetFromJsonAsync<IReadOnlyList<MeetTypeSummary>>("/meets/types") ?? [];
 
-            if (meet is null)
-            {
-                _errorMessage = "Mót fannst ekki.";
-                return;
-            }
-
-            DateOnly? endDate = meet.EndDate == new DateOnly(1, 1, 1) ? null : meet.EndDate;
-
-            _initialValues = new MeetFormInitialValues(
-                meet.Title,
-                meet.StartDate,
-                meet.MeetTypeId,
-                endDate,
-                meet.Location,
-                meet.Text,
-                meet.CalculatePlaces,
-                MapResultModeToId(meet.ResultMode),
-                meet.PublishedResults,
-                meet.PublishedInCalendar,
-                meet.IsInTeamCompetition,
-                meet.ShowWilks,
-                meet.ShowTeamPoints,
-                meet.ShowBodyWeight,
-                meet.ShowTeams,
-                meet.RecordsPossible,
-                // IsClassic carries the IsRaw value (naming mismatch in MeetDetails — see issue tracker)
-                meet.IsClassic);
-        }
-        catch (HttpRequestException)
+        if (meet is null)
         {
-            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
+            return null;
         }
-        finally
-        {
-            _isInitializing = false;
-        }
+
+        DateOnly? endDate = meet.EndDate == new DateOnly(1, 1, 1) ? null : meet.EndDate;
+
+        MeetFormInitialValues initialValues = new(
+            meet.Title,
+            meet.StartDate,
+            meet.MeetTypeId,
+            endDate,
+            meet.Location,
+            meet.Text,
+            meet.CalculatePlaces,
+            MapResultModeToId(meet.ResultMode),
+            meet.PublishedResults,
+            meet.PublishedInCalendar,
+            meet.IsInTeamCompetition,
+            meet.ShowWilks,
+            meet.ShowTeamPoints,
+            meet.ShowBodyWeight,
+            meet.ShowTeams,
+            meet.RecordsPossible,
+            // IsClassic carries the IsRaw value (naming mismatch in MeetDetails — see issue tracker)
+            meet.IsClassic);
+
+        return new EditMeetData(initialValues, meetTypes);
     }
 
     private static int MapResultModeToId(string resultMode)

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -12,211 +12,229 @@
 @inject NavigationManager NavigationManager
 @inject AuthenticationStateProvider AuthenticationStateProvider
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki mót..." />
-}
-else if (_errorMessage is not null)
-{
-    <div role="alert" class="error-message">
-        <p>@_errorMessage</p>
-        <a href="/meets">Til baka í mótslista</a>
-    </div>
-}
-else
-{
-<div class="page-header">
-    <h1>@Meet?.Title</h1>
-    <AuthorizeView Roles="Admin">
-        <div class="admin-actions">
-            <a href="/meets/@Slug/edit" class="btn-action" aria-label="Breyta móti">
-                <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
-                    <path d="m15 5 4 4"/>
-                </svg>
-                Breyta
-            </a>
-            <button class="btn-action btn-danger" aria-label="Eyða móti" @onclick="ShowDeleteDialog">
-                <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M3 6h18"/>
-                    <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
-                    <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
-                    <line x1="10" x2="10" y1="11" y2="17"/>
-                    <line x1="14" x2="14" y1="11" y2="17"/>
-                </svg>
-                Eyða
-            </button>
-        </div>
-    </AuthorizeView>
-</div>
-<p>
-    @($"{Meet?.StartDate:dd-MM-yyyy}")
-    @if (Meet?.EndDate is DateOnly endDate && endDate != Meet?.StartDate)
-    {
-        <span> - @($"{endDate:dd-MM-yyyy}")</span>
-    }
-    <br />
-    @Meet?.Location<br />
-</p>
-
-<AuthorizeView Roles="Admin">
-    <AddParticipantForm MeetId="Meet!.MeetId"
-                        IncludedDisciplines="IncludedDisciplines"
-                        MeetStartDate="Meet!.StartDate"
-                        RegisteredAthletes="@Participations.Select(p => p.AthleteSlug).ToHashSet()"
-                        OnParticipantAdded="ReloadParticipations" />
-</AuthorizeView>
-
-<SectionNav Links="_navLinks" />
-
-@if (ShowIpfPointLeaders)
-{
-    <h2 id="stigahaestu">Stigahæstu keppendur</h2>
-    <div class="leaders-section">
-        <div class="leaders-grid">
-            @foreach (IGrouping<string, MeetParticipation> gender in Participations.GroupBy(x => x.Gender).OrderByDescending(x => x.Key))
+<DataLoader T="MeetPageData" Loader="LoadAsync" Noun="mót">
+    <ChildContent Context="pageData">
+        @{
+            if (!_pageDataCopied)
             {
-                <div class="leaders-gender-col">
-                    <h3 class="leaders-gender-heading">@gender.Key</h3>
-                    @foreach (var leader in gender.OrderByDescending(x => x.IpfPoints).Take(3).Select((x, i) => (Participation: x, Index: i)))
+                Meet = pageData.Meet;
+                Participations = pageData.Participations;
+                IncludedDisciplines = pageData.IncludedDisciplines;
+                ShowIpfPoints = pageData.ShowIpfPoints;
+                ShowClubs = pageData.ShowClubs;
+                ShowIpfPointLeaders = pageData.ShowIpfPointLeaders;
+                _teamPointsResponse = pageData.TeamPointsResponse;
+                ShowTeamStandings = pageData.ShowTeamStandings;
+                IsPreGenderSplit = pageData.IsPreGenderSplit;
+                _meetRecords = pageData.MeetRecords;
+                _navLinks = pageData.NavLinks;
+                _isAdmin = pageData.IsAdmin;
+                _pageDataCopied = true;
+            }
+        }
+
+        <div class="page-header">
+            <h1>@Meet?.Title</h1>
+            <AuthorizeView Roles="Admin">
+                <div class="admin-actions">
+                    <a href="/meets/@Slug/edit" class="btn-action" aria-label="Breyta móti">
+                        <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+                            <path d="m15 5 4 4"/>
+                        </svg>
+                        Breyta
+                    </a>
+                    <button class="btn-action btn-danger" aria-label="Eyða móti" @onclick="ShowDeleteDialog">
+                        <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 6h18"/>
+                            <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
+                            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
+                            <line x1="10" x2="10" y1="11" y2="17"/>
+                            <line x1="14" x2="14" y1="11" y2="17"/>
+                        </svg>
+                        Eyða
+                    </button>
+                </div>
+            </AuthorizeView>
+        </div>
+        <p>
+            @($"{Meet?.StartDate:dd-MM-yyyy}")
+            @if (Meet?.EndDate is DateOnly endDate && endDate != Meet?.StartDate)
+            {
+                <span> - @($"{endDate:dd-MM-yyyy}")</span>
+            }
+            <br />
+            @Meet?.Location<br />
+        </p>
+
+        <AuthorizeView Roles="Admin">
+            <AddParticipantForm MeetId="Meet!.MeetId"
+                                IncludedDisciplines="IncludedDisciplines"
+                                MeetStartDate="Meet!.StartDate"
+                                RegisteredAthletes="@Participations.Select(p => p.AthleteSlug).ToHashSet()"
+                                OnParticipantAdded="ReloadParticipations" />
+        </AuthorizeView>
+
+        <SectionNav Links="_navLinks" />
+
+        @if (ShowIpfPointLeaders)
+        {
+            <h2 id="stigahaestu">Stigahæstu keppendur</h2>
+            <div class="leaders-section">
+                <div class="leaders-grid">
+                    @foreach (IGrouping<string, MeetParticipation> gender in Participations.GroupBy(x => x.Gender).OrderByDescending(x => x.Key))
                     {
-                        <div class="leader-row">
-                            <span class="leader-medal" aria-hidden="true">
-                                @((leader.Index + 1) switch { 1 => "🥇", 2 => "🥈", _ => "🥉" })
-                            </span>
-                            <div class="leader-info">
-                                <NavLink class="leader-name" href="@($"/athletes/{leader.Participation.AthleteSlug}")">@leader.Participation.Athlete</NavLink>
-                                <span class="leader-meta">
-                                    @leader.Participation.YearOfBirth@(!string.IsNullOrWhiteSpace(leader.Participation.Club) ? $" · {leader.Participation.Club}" : string.Empty) · @($"{leader.Participation.BodyWeight:F2}") kg
-                                </span>
-                            </div>
-                            <span class="leader-pts">@($"{leader.Participation.IpfPoints:F2}")</span>
+                        <div class="leaders-gender-col">
+                            <h3 class="leaders-gender-heading">@gender.Key</h3>
+                            @foreach (var leader in gender.OrderByDescending(x => x.IpfPoints).Take(3).Select((x, i) => (Participation: x, Index: i)))
+                            {
+                                <div class="leader-row">
+                                    <span class="leader-medal" aria-hidden="true">
+                                        @((leader.Index + 1) switch { 1 => "🥇", 2 => "🥈", _ => "🥉" })
+                                    </span>
+                                    <div class="leader-info">
+                                        <NavLink class="leader-name" href="@($"/athletes/{leader.Participation.AthleteSlug}")">@leader.Participation.Athlete</NavLink>
+                                        <span class="leader-meta">
+                                            @leader.Participation.YearOfBirth@(!string.IsNullOrWhiteSpace(leader.Participation.Club) ? $" · {leader.Participation.Club}" : string.Empty) · @($"{leader.Participation.BodyWeight:F2}") kg
+                                        </span>
+                                    </div>
+                                    <span class="leader-pts">@($"{leader.Participation.IpfPoints:F2}")</span>
+                                </div>
+                            }
                         </div>
                     }
                 </div>
+            </div>
+            <br />
+        }
+
+        <h2 id="urslit">Úrslit</h2>
+
+        <div class="results-container">
+            @foreach (var genderAgeAgeCategory in Participations
+                .Where(x => !string.IsNullOrEmpty(x.AgeCategory))
+                .GroupBy(x => new { x.Gender, x.AgeCategory, x.AgeCategorySlug })
+                .OrderBy(x => Array.IndexOf(Constants.AgeCategoryOrder, x.Key.AgeCategorySlug.Length > 0 ? char.ToUpperInvariant(x.Key.AgeCategorySlug[0]) : ' '))
+                .ThenBy(x => x.Key.AgeCategorySlug)
+                .ThenByDescending(x => x.Key.Gender))
+            {
+                <section class="card-section">
+                    <h4>@genderAgeAgeCategory.Key.Gender — @genderAgeAgeCategory.Key.AgeCategory</h4>
+                    <br />
+
+                    @foreach (IGrouping<string, MeetParticipation> weightCategory in genderAgeAgeCategory
+                        .GroupBy(x => x.WeightCategory)
+                        .OrderBy(x => x.Max(y => y.BodyWeight)))
+                    {
+                        <h5>@weightCategory.Key kg</h5>
+
+                        <div class="card-col-headers" style="@($"--grid-template: {ResultsGridTemplate}")" aria-hidden="true">
+                            <span></span>
+                            <span>Nafn</span>
+                            @if (ShowClubs)
+                            {
+                                <span>Félag</span>
+                            }
+                            @foreach (Discipline disc in IncludedDisciplines.Keys.OrderBy(d => (byte)d))
+                            {
+                                <span class="col-header-center">@disc.ToDisplayName()</span>
+                            }
+                            <span class="col-header-right">@Constants.Total</span>
+                            @if (ShowIpfPoints)
+                            {
+                                <span class="col-header-right">IPF stig</span>
+                            }
+                        </div>
+
+                        @foreach (MeetParticipation p in weightCategory
+                            .OrderBy(x => x.Disqualified)
+                            .ThenBy(x => x.Rank <= 0)
+                            .ThenBy(x => x.Rank)
+                            .ThenBy(x => x.Athlete))
+                        {
+                            <ParticipationCard Participation="p"
+                                               ShowIpfPoints="ShowIpfPoints"
+                                               ShowClub="ShowClubs"
+                                               IncludedDisciplines="IncludedDisciplines"
+                                               DesktopGridTemplate="@ResultsGridTemplate"
+                                               IsAdmin="_isAdmin"
+                                               OnParticipantRemoved="ReloadParticipations"
+                                               OnBodyWeightUpdated="ReloadParticipations"
+                                               OnSaveError="AddToast" />
+                        }
+                    }
+                </section>
+                <br />
             }
         </div>
-    </div>
-    <br />
-}
 
-<h2 id="urslit">Úrslit</h2>
-
-<div class="results-container">
-    @foreach (var genderAgeAgeCategory in Participations
-        .Where(x => !string.IsNullOrEmpty(x.AgeCategory))
-        .GroupBy(x => new { x.Gender, x.AgeCategory, x.AgeCategorySlug })
-        .OrderBy(x => Array.IndexOf(Constants.AgeCategoryOrder, x.Key.AgeCategorySlug.Length > 0 ? char.ToUpperInvariant(x.Key.AgeCategorySlug[0]) : ' '))
-        .ThenBy(x => x.Key.AgeCategorySlug)
-        .ThenByDescending(x => x.Key.Gender))
-    {
-        <section class="card-section">
-            <h4>@genderAgeAgeCategory.Key.Gender — @genderAgeAgeCategory.Key.AgeCategory</h4>
-            <br />
-
-            @foreach (IGrouping<string, MeetParticipation> weightCategory in genderAgeAgeCategory
-                .GroupBy(x => x.WeightCategory)
-                .OrderBy(x => x.Max(y => y.BodyWeight)))
-            {
-                <h5>@weightCategory.Key kg</h5>
-
-                <div class="card-col-headers" style="@($"--grid-template: {ResultsGridTemplate}")" aria-hidden="true">
-                    <span></span>
-                    <span>Nafn</span>
-                    @if (ShowClubs)
-                    {
-                        <span>Félag</span>
-                    }
-                    @foreach (Discipline disc in IncludedDisciplines.Keys.OrderBy(d => (byte)d))
-                    {
-                        <span class="col-header-center">@disc.ToDisplayName()</span>
-                    }
-                    <span class="col-header-right">@Constants.Total</span>
-                    @if (ShowIpfPoints)
-                    {
-                        <span class="col-header-right">IPF stig</span>
-                    }
-                </div>
-
-                @foreach (MeetParticipation p in weightCategory
-                    .OrderBy(x => x.Disqualified)
-                    .ThenBy(x => x.Rank <= 0)
-                    .ThenBy(x => x.Rank)
-                    .ThenBy(x => x.Athlete))
-                {
-                    <ParticipationCard Participation="p"
-                                       ShowIpfPoints="ShowIpfPoints"
-                                       ShowClub="ShowClubs"
-                                       IncludedDisciplines="IncludedDisciplines"
-                                       DesktopGridTemplate="@ResultsGridTemplate"
-                                       IsAdmin="_isAdmin"
-                                       OnParticipantRemoved="ReloadParticipations"
-                                       OnBodyWeightUpdated="ReloadParticipations"
-                                       OnSaveError="AddToast" />
-                }
-            }
-        </section>
-        <br />
-    }
-</div>
-
-@if (ShowTeamStandings)
-{
-    <h2 id="lidakeppni">Liðakeppni</h2>
-
-    <div class="standings-container">
-        @if (IsPreGenderSplit)
+        @if (ShowTeamStandings)
         {
-            <ol class="standings-list">
-                @foreach (TeamCompetitionStanding standing in _teamPointsResponse!.Combined)
-                {
-                    <li><StandingsCard Standing="standing" /></li>
-                }
-            </ol>
-        }
-        else
-        {
-            <div class="standings-grid">
-                @if (_teamPointsResponse!.Women.Count > 0)
-                {
-                    <section class="standings-gender">
-                        <h4>@("f".ToGenderGroupLabel())</h4>
-                        <ol class="standings-list">
-                            @foreach (TeamCompetitionStanding standing in _teamPointsResponse!.Women)
-                            {
-                                <li><StandingsCard Standing="standing" /></li>
-                            }
-                        </ol>
-                    </section>
-                }
+            <h2 id="lidakeppni">Liðakeppni</h2>
 
-                @if (_teamPointsResponse!.Men.Count > 0)
+            <div class="standings-container">
+                @if (IsPreGenderSplit)
                 {
-                    <section class="standings-gender">
-                        <h4>@("m".ToGenderGroupLabel())</h4>
-                        <ol class="standings-list">
-                            @foreach (TeamCompetitionStanding standing in _teamPointsResponse!.Men)
-                            {
-                                <li><StandingsCard Standing="standing" /></li>
-                            }
-                        </ol>
-                    </section>
+                    <ol class="standings-list">
+                        @foreach (TeamCompetitionStanding standing in _teamPointsResponse!.Combined)
+                        {
+                            <li><StandingsCard Standing="standing" /></li>
+                        }
+                    </ol>
+                }
+                else
+                {
+                    <div class="standings-grid">
+                        @if (_teamPointsResponse!.Women.Count > 0)
+                        {
+                            <section class="standings-gender">
+                                <h4>@("f".ToGenderGroupLabel())</h4>
+                                <ol class="standings-list">
+                                    @foreach (TeamCompetitionStanding standing in _teamPointsResponse!.Women)
+                                    {
+                                        <li><StandingsCard Standing="standing" /></li>
+                                    }
+                                </ol>
+                            </section>
+                        }
+
+                        @if (_teamPointsResponse!.Men.Count > 0)
+                        {
+                            <section class="standings-gender">
+                                <h4>@("m".ToGenderGroupLabel())</h4>
+                                <ol class="standings-list">
+                                    @foreach (TeamCompetitionStanding standing in _teamPointsResponse!.Men)
+                                    {
+                                        <li><StandingsCard Standing="standing" /></li>
+                                    }
+                                </ol>
+                            </section>
+                        }
+                    </div>
+
+                    @if (_teamPointsResponse!.Women.Count == 0 && _teamPointsResponse!.Men.Count == 0)
+                    {
+                        <div class="empty-section">Engar niðurstöður.</div>
+                    }
                 }
             </div>
-
-            @if (_teamPointsResponse!.Women.Count == 0 && _teamPointsResponse!.Men.Count == 0)
-            {
-                <div class="empty-section">Engar niðurstöður.</div>
-            }
         }
-    </div>
-}
 
-@if (_meetRecords.Count > 0)
-{
-    <MeetRecordsSection Records="_meetRecords" />
-}
-}
+        @if (_meetRecords.Count > 0)
+        {
+            <MeetRecordsSection Records="_meetRecords" />
+        }
+
+        <ConfirmDialog @ref="_deleteDialog"
+                       Id="delete-meet-dialog"
+                       Title="Eyða móti"
+                       Message="@($"Ertu viss um að þú viljir eyða mótinu \"{Meet?.Title}\"?")"
+                       ConfirmLabel="Eyða móti"
+                       OnConfirm="HandleDelete"
+                       ErrorMessage="@_deleteErrorMessage"
+                       IsLoading="_isDeleting" />
+    </ChildContent>
+</DataLoader>
 
 <div class="toast-stack" aria-live="polite">
     @foreach (ToastItem toast in _toasts)
@@ -228,15 +246,6 @@ else
     }
 </div>
 
-<ConfirmDialog @ref="_deleteDialog"
-               Id="delete-meet-dialog"
-               Title="Eyða móti"
-               Message="@($"Ertu viss um að þú viljir eyða mótinu \"{Meet?.Title}\"?")"
-               ConfirmLabel="Eyða móti"
-               OnConfirm="HandleDelete"
-               ErrorMessage="@_deleteErrorMessage"
-               IsLoading="_isDeleting" />
-
 @code {
     private sealed class ToastItem(Guid Id, string Message)
     {
@@ -244,6 +253,20 @@ else
         public string Message { get; } = Message;
         public bool IsExiting { get; set; }
     }
+
+    private sealed record MeetPageData(
+        MeetDetails Meet,
+        IReadOnlyList<MeetParticipation> Participations,
+        Dictionary<Discipline, bool> IncludedDisciplines,
+        bool ShowIpfPoints,
+        bool ShowClubs,
+        bool ShowIpfPointLeaders,
+        MeetTeamPointsResponse? TeamPointsResponse,
+        bool ShowTeamStandings,
+        bool IsPreGenderSplit,
+        IReadOnlyList<MeetRecordEntry> MeetRecords,
+        IReadOnlyList<SectionNav.SectionNavLink> NavLinks,
+        bool IsAdmin);
 
     private const int MaxToasts = 5;
     private const int ToastDurationMs = 4000;
@@ -255,11 +278,12 @@ else
 
     private ConfirmDialog _deleteDialog = null!;
     private bool _isDeleting;
-    private bool _isLoading = true;
     private string? _deleteErrorMessage;
     private bool _isAdmin;
+    private bool _pageDataCopied;
     private IReadOnlyList<MeetRecordEntry> _meetRecords = [];
     private IReadOnlyList<SectionNav.SectionNavLink> _navLinks = [];
+    private MeetTeamPointsResponse? _teamPointsResponse;
 
     [Parameter]
     public string Slug { get; set; } = string.Empty;
@@ -267,13 +291,11 @@ else
     private MeetDetails? Meet;
     private IReadOnlyList<MeetParticipation> Participations = [];
     private Dictionary<Discipline, bool> IncludedDisciplines = new();
-    private MeetTeamPointsResponse? _teamPointsResponse;
     private bool ShowIpfPoints;
     private bool ShowIpfPointLeaders;
     private bool ShowClubs;
     private bool ShowTeamStandings;
     private bool IsPreGenderSplit;
-    private string? _errorMessage;
 
     private string ResultsGridTemplate
     {
@@ -287,6 +309,71 @@ else
                 ? $"22px 280px {clubPart}{discPart} 63px 68px"
                 : $"22px 280px {clubPart}{discPart} 63px";
         }
+    }
+
+    private async Task<MeetPageData?> LoadAsync()
+    {
+        MeetDetails? meet = await HttpClient.GetFromJsonAsync<MeetDetails>($"/meets/{Slug}");
+
+        if (meet is null)
+        {
+            return null;
+        }
+
+        IReadOnlyList<MeetParticipation> participations =
+            await HttpClient.GetFromJsonAsync<IReadOnlyList<MeetParticipation>>($"/meets/{Slug}/participations") ?? [];
+
+        Dictionary<Discipline, bool> attemptWeights = participations
+            .SelectMany(p => p.Attempts)
+            .GroupBy(a => a.Discipline)
+            .ToDictionary(g => g.Key, g => g.Any(a => a.Weight > 0));
+
+        Dictionary<Discipline, bool> includedDisciplines = meet.Disciplines
+            .ToDictionary(d => d, d => attemptWeights.GetValueOrDefault(d, false));
+
+        bool showIpfPoints = participations.Any(x => x.IpfPoints > 0);
+        bool showClubs = participations.Any(p => !string.IsNullOrWhiteSpace(p.Club));
+        bool showIpfPointLeaders = meet.CalculatePlaces && showIpfPoints;
+
+        MeetTeamPointsResponse? teamPointsResponse = null;
+        bool showTeamStandings = false;
+        bool isPreGenderSplit = false;
+
+        if (meet.ShowTeamPoints)
+        {
+            teamPointsResponse = await HttpClient.GetFromJsonAsync<MeetTeamPointsResponse>($"/meets/{Slug}/team-points");
+            showTeamStandings = teamPointsResponse is not null
+                && (teamPointsResponse.Women.Count > 0
+                    || teamPointsResponse.Men.Count > 0
+                    || teamPointsResponse.Combined.Count > 0);
+            isPreGenderSplit = meet.StartDate.Year < 2015;
+        }
+
+        IReadOnlyList<MeetRecordEntry> meetRecords =
+            await HttpClient.GetFromJsonAsync<IReadOnlyList<MeetRecordEntry>>($"/meets/{Slug}/records") ?? [];
+
+        List<SectionNav.SectionNavLink> navLinks = [];
+        if (showIpfPointLeaders) { navLinks.Add(new SectionNav.SectionNavLink("Stigahæstu keppendur", $"/meets/{Slug}#stigahaestu")); }
+        navLinks.Add(new SectionNav.SectionNavLink("Úrslit", $"/meets/{Slug}#urslit"));
+        if (showTeamStandings) { navLinks.Add(new SectionNav.SectionNavLink("Liðakeppni", $"/meets/{Slug}#lidakeppni")); }
+        if (meetRecords.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Met", $"/meets/{Slug}#met")); }
+
+        AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        bool isAdmin = authState.User.IsInRole("Admin");
+
+        return new MeetPageData(
+            meet,
+            participations,
+            includedDisciplines,
+            showIpfPoints,
+            showClubs,
+            showIpfPointLeaders,
+            teamPointsResponse,
+            showTeamStandings,
+            isPreGenderSplit,
+            meetRecords,
+            navLinks,
+            isAdmin);
     }
 
     private async Task AddToast(string message)
@@ -454,63 +541,6 @@ else
         finally
         {
             _isDeleting = false;
-        }
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        try
-        {
-            Meet = await HttpClient.GetFromJsonAsync<MeetDetails>($"/meets/{Slug}");
-            Participations = await HttpClient.GetFromJsonAsync<IReadOnlyList<MeetParticipation>>($"/meets/{Slug}/participations") ?? [];
-
-            if (Meet is null)
-            {
-                _errorMessage = "Mót fannst ekki.";
-                return;
-            }
-
-            Dictionary<Discipline, bool> attemptWeights = Participations
-                .SelectMany(p => p.Attempts)
-                .GroupBy(a => a.Discipline)
-                .ToDictionary(g => g.Key, g => g.Any(a => a.Weight > 0));
-
-            IncludedDisciplines = Meet!.Disciplines
-                .ToDictionary(d => d, d => attemptWeights.GetValueOrDefault(d, false));
-
-            ShowIpfPoints = Participations.Any(x => x.IpfPoints > 0);
-            ShowClubs = Participations.Any(p => !string.IsNullOrWhiteSpace(p.Club));
-            ShowIpfPointLeaders = Meet?.CalculatePlaces is true && ShowIpfPoints;
-
-            if (Meet?.ShowTeamPoints is true)
-            {
-                _teamPointsResponse = await HttpClient.GetFromJsonAsync<MeetTeamPointsResponse>($"/meets/{Slug}/team-points");
-                ShowTeamStandings = _teamPointsResponse is not null
-                    && (_teamPointsResponse.Women.Count > 0
-                        || _teamPointsResponse.Men.Count > 0
-                        || _teamPointsResponse.Combined.Count > 0);
-                IsPreGenderSplit = Meet.StartDate.Year < 2015;
-            }
-
-            await ReloadMeetRecords();
-
-            List<SectionNav.SectionNavLink> navLinks = [];
-            if (ShowIpfPointLeaders) { navLinks.Add(new SectionNav.SectionNavLink("Stigahæstu keppendur", $"/meets/{Slug}#stigahaestu")); }
-            navLinks.Add(new SectionNav.SectionNavLink("Úrslit", $"/meets/{Slug}#urslit"));
-            if (ShowTeamStandings) { navLinks.Add(new SectionNav.SectionNavLink("Liðakeppni", $"/meets/{Slug}#lidakeppni")); }
-            if (_meetRecords.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Met", $"/meets/{Slug}#met")); }
-            _navLinks = navLinks;
-
-            AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-            _isAdmin = authState.User.IsInRole("Admin");
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp við að sækja mót. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isLoading = false;
         }
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -15,8 +15,9 @@
 <DataLoader T="MeetPageData" Loader="LoadAsync" Noun="mót">
     <ChildContent Context="pageData">
         @{
-            if (!_pageDataCopied)
+            if (!ReferenceEquals(_lastPageData, pageData))
             {
+                _lastPageData = pageData;
                 Meet = pageData.Meet;
                 Participations = pageData.Participations;
                 IncludedDisciplines = pageData.IncludedDisciplines;
@@ -29,7 +30,6 @@
                 _meetRecords = pageData.MeetRecords;
                 _navLinks = pageData.NavLinks;
                 _isAdmin = pageData.IsAdmin;
-                _pageDataCopied = true;
             }
         }
 
@@ -280,7 +280,7 @@
     private bool _isDeleting;
     private string? _deleteErrorMessage;
     private bool _isAdmin;
-    private bool _pageDataCopied;
+    private MeetPageData? _lastPageData;
     private IReadOnlyList<MeetRecordEntry> _meetRecords = [];
     private IReadOnlyList<SectionNav.SectionNavLink> _navLinks = [];
     private MeetTeamPointsResponse? _teamPointsResponse;

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
@@ -1,7 +1,6 @@
 @page "/meets/{year:int?}"
 
 @using System.Globalization
-@using System.Linq
 @using KRAFT.Results.Contracts.Meets
 @using KRAFT.Results.Web.Client.Components
 
@@ -13,77 +12,49 @@
     </TitleContent>
 </PageHeader>
 
-@if (_errorMessage is not null)
-{
-    <ErrorMessage Message="@_errorMessage" />
-}
-
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki mót..." />
-}
-else
-{
-    @foreach (IGrouping<string, MeetSummary> group in Meets.GroupBy(x => x.StartDate.ToString("MMMM", CultureInfo.CurrentCulture)))
-    {
-        <h4>@($"{char.ToUpper(group.Key[0])}{group.Key[1..]}")</h4>
-        @foreach (MeetSummary meet in group)
+<DataLoader @key="Year" T="IReadOnlyCollection<MeetSummary>" Loader="LoadAsync" Noun="mót">
+    <ChildContent Context="meets">
+        @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => x.StartDate.ToString("MMMM", CultureInfo.CurrentCulture)))
         {
-            <article class="meet-item">
-                <div class="date-box">
-                    @meet.StartDate.ToString("dd")
-                </div>
-                <div>
-                    <NavLink class="nav-link" href="@($"/meets/{meet.Slug}")">
-                        <div class="index-item-title">@meet.Title</div>
-                    </NavLink>
-                    <div class="location">
-                        <svg class="location-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-                            <path d="M12.166 8.94c-.524 1.062-1.234 2.12-1.96 3.07A32 32 0 0 1 8 14.58a32 32 0 0 1-2.206-2.57c-.726-.95-1.436-2.008-1.96-3.07C3.304 7.867 3 6.862 3 6a5 5 0 0 1 10 0c0 .862-.305 1.867-.834 2.94M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10"/>
-                            <path d="M8 8a2 2 0 1 1 0-4 2 2 0 0 1 0 4m0 1a3 3 0 1 0 0-6 3 3 0 0 0 0 6"/>
-                        </svg>
-                        @meet.Location
+            <h4>@($"{char.ToUpper(group.Key[0])}{group.Key[1..]}")</h4>
+            @foreach (MeetSummary meet in group)
+            {
+                <article class="meet-item">
+                    <div class="date-box">
+                        @meet.StartDate.ToString("dd")
                     </div>
-                </div>
-            </article>
+                    <div>
+                        <NavLink class="nav-link" href="@($"/meets/{meet.Slug}")">
+                            <div class="index-item-title">@meet.Title</div>
+                        </NavLink>
+                        <div class="location">
+                            <svg class="location-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                                <path d="M12.166 8.94c-.524 1.062-1.234 2.12-1.96 3.07A32 32 0 0 1 8 14.58a32 32 0 0 1-2.206-2.57c-.726-.95-1.436-2.008-1.96-3.07C3.304 7.867 3 6.862 3 6a5 5 0 0 1 10 0c0 .862-.305 1.867-.834 2.94M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10"/>
+                                <path d="M8 8a2 2 0 1 1 0-4 2 2 0 0 1 0 4m0 1a3 3 0 1 0 0-6 3 3 0 0 0 0 6"/>
+                            </svg>
+                            @meet.Location
+                        </div>
+                    </div>
+                </article>
+            }
         }
-    }
-}
+    </ChildContent>
+</DataLoader>
 
 @code {
     [Parameter]
     public int Year { get; set; }
 
-    private bool _isLoading = true;
-    private int _loadedYear;
-    private string? _errorMessage;
-    private IReadOnlyCollection<MeetSummary> Meets = [];
-
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
         if (Year == 0)
         {
             Year = DateTime.Now.Year;
         }
+    }
 
-        if (Year != _loadedYear)
-        {
-            _loadedYear = Year;
-            _errorMessage = null;
-            _isLoading = true;
-
-            try
-            {
-                Meets = await HttpClient.GetFromJsonAsync<IReadOnlyCollection<MeetSummary>>($"/meets?year={Year}") ?? [];
-            }
-            catch (HttpRequestException)
-            {
-                _errorMessage = "Villa kom upp við að sækja mót. Reyndu aftur síðar.";
-            }
-            finally
-            {
-                _isLoading = false;
-            }
-        }
+    private async Task<IReadOnlyCollection<MeetSummary>?> LoadAsync()
+    {
+        return await HttpClient.GetFromJsonAsync<IReadOnlyCollection<MeetSummary>>($"/meets?year={Year}");
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor
@@ -14,7 +14,7 @@
 <div class="filter-bar">
     <div class="filter-group">
         <label class="filter-label" for="discipline">Grein</label>
-        <select id="discipline" class="filter-select" @bind="Discipline" @bind:after="OnFilterChangedAsync">
+        <select id="discipline" class="filter-select" @bind="Discipline" @bind:after="OnFilterChanged">
             <option value="total">@Constants.Total</option>
             <option value="squat">@Constants.Squat</option>
             <option value="bench">@Constants.Bench</option>
@@ -24,7 +24,7 @@
 
     <div class="filter-group">
         <label class="filter-label" for="year">Ár</label>
-        <select id="year" class="filter-select" @bind="Year" @bind:after="OnFilterChangedAsync">
+        <select id="year" class="filter-select" @bind="Year" @bind:after="OnFilterChanged">
             <option value="">Öll ár</option>
             @for (int y = DateTime.Now.Year; y >= 1985; y--)
             {
@@ -35,7 +35,7 @@
 
     <div class="filter-group">
         <label class="filter-label" for="equipmentType">Flokkur</label>
-        <select id="equipmentType" class="filter-select" @bind="EquipmentType" @bind:after="OnFilterChangedAsync">
+        <select id="equipmentType" class="filter-select" @bind="EquipmentType" @bind:after="OnFilterChanged">
             <option value="">Allir</option>
             <option value="classic">@DisplayNames.EquipmentType(true)</option>
             <option value="equipped">@DisplayNames.EquipmentType(false)</option>
@@ -44,7 +44,7 @@
 
     <div class="filter-group">
         <label class="filter-label" for="gender">Kyn</label>
-        <select id="gender" class="filter-select" @bind="Gender" @bind:after="OnFilterChangedAsync">
+        <select id="gender" class="filter-select" @bind="Gender" @bind:after="OnFilterChanged">
             <option value="">Allir</option>
             <option value="m">@("m".ToGenderGroupLabel())</option>
             <option value="f">@("f".ToGenderGroupLabel())</option>
@@ -52,46 +52,46 @@
     </div>
 </div>
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki stigatöflur..." />
-}
-else if (_hasError)
-{
-    <ErrorMessage Message="Villa kom upp. Reyndu aftur." OnRetry="LoadDataAsync" />
-}
-else if (_response is not null && _response.Items.Count > 0)
-{
-    <div class="rankings-list">
-        @foreach (RankingEntry entry in _response.Items)
+<DataLoader @key="FilterKey" T="PagedResponse<RankingEntry>" Loader="LoadAsync" Noun="stigatöflur">
+    <ChildContent Context="response">
+        @if (response.Items.Count > 0)
         {
-            <RankingCard Entry="entry" DisciplineLabel="@DisciplineLabel" />
+            int totalPages = response.TotalCount == 0
+                ? 1
+                : (int)Math.Ceiling((double)response.TotalCount / PageSize);
+
+            <div class="rankings-list">
+                @foreach (RankingEntry entry in response.Items)
+                {
+                    <RankingCard Entry="entry" DisciplineLabel="@DisciplineLabel" />
+                }
+            </div>
+
+            if (totalPages > 1)
+            {
+                <div class="pagination">
+                    <button class="page-btn" disabled="@(_page <= 1)" @onclick="OnPreviousPage" aria-label="Fyrri síða">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                        </svg>
+                    </button>
+
+                    <span class="page-info">Síða @_page af @totalPages</span>
+
+                    <button class="page-btn" disabled="@(_page >= totalPages)" @onclick="() => OnNextPage(totalPages)" aria-label="Næsta síða">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                        </svg>
+                    </button>
+                </div>
+            }
         }
-    </div>
-
-    @if (TotalPages > 1)
-    {
-        <div class="pagination">
-            <button class="page-btn" disabled="@(_page <= 1)" @onclick="OnPreviousPageAsync" aria-label="Fyrri síða">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-                    <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                </svg>
-            </button>
-
-            <span class="page-info">Síða @_page af @TotalPages</span>
-
-            <button class="page-btn" disabled="@(_page >= TotalPages)" @onclick="OnNextPageAsync" aria-label="Næsta síða">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-                    <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                </svg>
-            </button>
-        </div>
-    }
-}
-else
-{
-    <EmptyState Message="Engar niðurstöður fundust." />
-}
+        else
+        {
+            <EmptyState Message="Engar niðurstöður fundust." />
+        }
+    </ChildContent>
+</DataLoader>
 
 @code {
     private const int PageSize = 50;
@@ -112,13 +112,8 @@ else
     public int? PageParam { get; set; }
 
     private int _page = 1;
-    private bool _isLoading = true;
-    private bool _hasError;
-    private PagedResponse<RankingEntry>? _response;
 
-    private int TotalPages => _response is null || _response.TotalCount == 0
-        ? 1
-        : (int)Math.Ceiling((double)_response.TotalCount / PageSize);
+    private string FilterKey => $"{Discipline}|{Year}|{EquipmentType}|{Gender}|{_page}";
 
     private string DisciplineLabel => Discipline?.ToLowerInvariant() switch
     {
@@ -128,40 +123,38 @@ else
         _ => Constants.Total,
     };
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         Discipline ??= "total";
         Year ??= DateTime.Now.Year.ToString();
         EquipmentType ??= "classic";
         _page = PageParam ?? 1;
-
-        await LoadDataAsync();
     }
 
-    private async Task OnFilterChangedAsync()
+    private void OnFilterChanged()
     {
         _page = 1;
         UpdateUrl();
-        await LoadDataAsync();
+        StateHasChanged();
     }
 
-    private async Task OnPreviousPageAsync()
+    private void OnPreviousPage()
     {
         if (_page > 1)
         {
             _page--;
             UpdateUrl();
-            await LoadDataAsync();
+            StateHasChanged();
         }
     }
 
-    private async Task OnNextPageAsync()
+    private void OnNextPage(int totalPages)
     {
-        if (_page < TotalPages)
+        if (_page < totalPages)
         {
             _page++;
             UpdateUrl();
-            await LoadDataAsync();
+            StateHasChanged();
         }
     }
 
@@ -179,39 +172,25 @@ else
         NavigationManager.NavigateTo(url, replace: true);
     }
 
-    private async Task LoadDataAsync()
+    private async Task<PagedResponse<RankingEntry>?> LoadAsync()
     {
-        _isLoading = true;
-        _hasError = false;
+        string url = $"/rankings?discipline={Uri.EscapeDataString(Discipline ?? "total")}&page={_page}&pageSize={PageSize}";
 
-        try
+        if (!string.IsNullOrEmpty(Year))
         {
-            string url = $"/rankings?discipline={Uri.EscapeDataString(Discipline ?? "total")}&page={_page}&pageSize={PageSize}";
-
-            if (!string.IsNullOrEmpty(Year))
-            {
-                url += $"&year={Uri.EscapeDataString(Year)}";
-            }
-
-            if (!string.IsNullOrEmpty(EquipmentType))
-            {
-                url += $"&equipmentType={Uri.EscapeDataString(EquipmentType)}";
-            }
-
-            if (!string.IsNullOrEmpty(Gender))
-            {
-                url += $"&gender={Uri.EscapeDataString(Gender)}";
-            }
-
-            _response = await HttpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(url);
+            url += $"&year={Uri.EscapeDataString(Year)}";
         }
-        catch
+
+        if (!string.IsNullOrEmpty(EquipmentType))
         {
-            _hasError = true;
+            url += $"&equipmentType={Uri.EscapeDataString(EquipmentType)}";
         }
-        finally
+
+        if (!string.IsNullOrEmpty(Gender))
         {
-            _isLoading = false;
+            url += $"&gender={Uri.EscapeDataString(Gender)}";
         }
+
+        return await HttpClient.GetFromJsonAsync<PagedResponse<RankingEntry>>(url);
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor
@@ -1,12 +1,11 @@
 @page "/records/{Id:int}/history"
 
 @using KRAFT.Results.Contracts.Records
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
-
-<PageTitle>Saga metsins@(_response is not null ? $" - {_response.Category} {_response.WeightCategory}" : "")</PageTitle>
 
 <nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
@@ -19,75 +18,49 @@
 
 <h1>Saga metsins</h1>
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki sögu..." />
-}
-else if (_hasError)
-{
-    <ErrorMessage Message="Villa kom upp. Reyndu aftur." OnRetry="LoadDataAsync" />
-}
-else if (_response is not null && _response.Entries.Count > 0)
-{
-    <div class="record-meta">
-        <span>@_response.Category</span>
-        <span class="meta-separator">&middot;</span>
-        <span>@_response.WeightCategory</span>
-        <span class="meta-separator">&middot;</span>
-        <span>@_response.AgeCategory</span>
-        <span class="meta-separator">&middot;</span>
-        <span>@_response.Gender</span>
-        <span class="meta-separator">&middot;</span>
-        <span>@_response.EquipmentType</span>
-        @if (_response.Era is not null)
-        {
-            <span class="meta-separator">&middot;</span>
-            <span>@_response.Era</span>
-        }
-    </div>
+<DataLoader T="RecordHistoryResponse" Loader="LoadAsync" Noun="sögu">
+    <ChildContent Context="response">
+        <PageTitle>Saga metsins - @response.Category @response.WeightCategory</PageTitle>
 
-    <div class="rhc-list">
-        @foreach (RecordHistoryEntry entry in _response.Entries)
+        @if (response.Entries.Count > 0)
         {
-            <RecordHistoryCard Entry="entry" />
+            <div class="record-meta">
+                <span>@response.Category</span>
+                <span class="meta-separator">&middot;</span>
+                <span>@response.WeightCategory</span>
+                <span class="meta-separator">&middot;</span>
+                <span>@response.AgeCategory</span>
+                <span class="meta-separator">&middot;</span>
+                <span>@response.Gender</span>
+                <span class="meta-separator">&middot;</span>
+                <span>@response.EquipmentType</span>
+                @if (response.Era is not null)
+                {
+                    <span class="meta-separator">&middot;</span>
+                    <span>@response.Era</span>
+                }
+            </div>
+
+            <div class="rhc-list">
+                @foreach (RecordHistoryEntry entry in response.Entries)
+                {
+                    <RecordHistoryCard Entry="entry" />
+                }
+            </div>
         }
-    </div>
-}
-else
-{
-    <EmptyState Message="Engar færslur fundust." />
-}
+        else
+        {
+            <EmptyState Message="Engar færslur fundust." />
+        }
+    </ChildContent>
+</DataLoader>
 
 @code {
     [Parameter]
     public int Id { get; set; }
 
-    private RecordHistoryResponse? _response;
-    private bool _isLoading = true;
-    private bool _hasError;
-
-    protected override async Task OnInitializedAsync()
+    private async Task<RecordHistoryResponse?> LoadAsync()
     {
-        await LoadDataAsync();
-    }
-
-    private async Task LoadDataAsync()
-    {
-        _isLoading = true;
-        _hasError = false;
-
-        try
-        {
-            _response = await HttpClient.GetFromJsonAsync<RecordHistoryResponse>(
-                $"/records/{Id}/history");
-        }
-        catch
-        {
-            _hasError = true;
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        return await HttpClient.GetFromJsonAsync<RecordHistoryResponse>($"/records/{Id}/history");
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor
@@ -7,6 +7,8 @@
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 
+<PageTitle>Saga metsins</PageTitle>
+
 <nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
         <li>

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordsPage.razor
@@ -16,35 +16,31 @@
                 CurrentEraSlug="@_currentEraSlug"
                 InitialEquipmentType="@_equipmentType"
                 InitialEraSlug="@_eraSlug"
-                Disabled="@(_isLoading || !RendererInfo.IsInteractive)"
+                Disabled="@(!RendererInfo.IsInteractive)"
                 OnEquipmentTypeChanged="HandleEquipmentTypeChanged"
                 OnEraChanged="HandleEraChanged" />
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki met..." />
-}
-else if (_hasError)
-{
-    <ErrorMessage Message="Villa kom upp. Reyndu aftur." OnRetry="LoadDataAsync" />
-}
-else if (_groups is not null && _groups.Count > 0)
-{
-    @foreach (RecordGroup group in _groups)
-    {
-        <section class="record-section">
-            <h2>@group.Category</h2>
-            @foreach (RecordEntry record in group.Records)
+<DataLoader @key="@($"{_eraSlug}|{_equipmentType}")" T="List<RecordGroup>" Loader="LoadAsync" Noun="met">
+    <ChildContent Context="groups">
+        @if (groups.Count > 0)
+        {
+            @foreach (RecordGroup group in groups)
             {
-                <RecordCard Record="record" />
+                <section class="record-section">
+                    <h2>@group.Category</h2>
+                    @foreach (RecordEntry record in group.Records)
+                    {
+                        <RecordCard Record="record" />
+                    }
+                </section>
             }
-        </section>
-    }
-}
-else
-{
-    <EmptyState Message="Engin met fundust." />
-}
+        }
+        else
+        {
+            <EmptyState Message="Engin met fundust." />
+        }
+    </ChildContent>
+</DataLoader>
 
 @code {
     [Parameter]
@@ -64,9 +60,6 @@ else
     private string _currentEraSlug = "";
     private List<EraSummary>? _eras;
     private EraSummary? _selectedEra;
-    private bool _isLoading = true;
-    private bool _hasError;
-    private List<RecordGroup>? _groups;
 
     private string GenderLabel => Gender is not null ? Gender.ToGenderGroupLabel() : "";
     private string AgeCategoryLabel => AgeCategory is not null ? AgeCategory.ToAgeCategoryLabel(Gender) : "";
@@ -103,19 +96,17 @@ else
         {
             _eras = null;
         }
-
-        await LoadDataAsync();
     }
 
-    private async Task HandleEraChanged(string slug)
+    private void HandleEraChanged(string slug)
     {
         _eraSlug = slug;
         _selectedEra = _eras?.FirstOrDefault(e => e.Slug == _eraSlug);
         UpdateUrl(replace: true);
-        await LoadDataAsync();
+        StateHasChanged();
     }
 
-    private async Task HandleEquipmentTypeChanged(string type)
+    private void HandleEquipmentTypeChanged(string type)
     {
         if (_equipmentType == type)
         {
@@ -124,7 +115,7 @@ else
 
         _equipmentType = type;
         UpdateUrl(replace: true);
-        await LoadDataAsync();
+        StateHasChanged();
     }
 
     private void UpdateUrl(bool replace)
@@ -142,29 +133,15 @@ else
         NavigationManager.NavigateTo(url, replace: replace);
     }
 
-    private async Task LoadDataAsync()
+    private async Task<List<RecordGroup>?> LoadAsync()
     {
-        _isLoading = true;
-        _hasError = false;
+        string url = $"/records?gender={Uri.EscapeDataString(Gender)}&ageCategory={Uri.EscapeDataString(AgeCategory)}&equipmentType={Uri.EscapeDataString(_equipmentType)}";
 
-        try
+        if (!string.IsNullOrEmpty(_eraSlug))
         {
-            string url = $"/records?gender={Uri.EscapeDataString(Gender)}&ageCategory={Uri.EscapeDataString(AgeCategory)}&equipmentType={Uri.EscapeDataString(_equipmentType)}";
+            url += $"&era={Uri.EscapeDataString(_eraSlug)}";
+        }
 
-            if (!string.IsNullOrEmpty(_eraSlug))
-            {
-                url += $"&era={Uri.EscapeDataString(_eraSlug)}";
-            }
-
-            _groups = await HttpClient.GetFromJsonAsync<List<RecordGroup>>(url);
-        }
-        catch
-        {
-            _hasError = true;
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        return await HttpClient.GetFromJsonAsync<List<RecordGroup>>(url);
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/TeamCompetitionIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/TeamCompetitionIndex.razor
@@ -11,112 +11,80 @@
 
 <YearNav Label="Liðakeppni" Year="@Year" BaseUrl="/team-competition" MinYear="2010" MaxYear="@DateTime.Now.Year" />
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Seki gögn..." />
-}
-else if (_hasError)
-{
-    <ErrorMessage Message="Villa kom upp. Reyndu aftur." OnRetry="LoadDataAsync" />
-}
-else if (_response is not null)
-{
-    @if (_response.IsGenderSplit)
-    {
-        <div class="standings-container">
-            <div class="standings-grid">
-                @if (_response.Women.Count > 0)
-                {
-                    <section class="standings-gender">
-                        <h4>@("f".ToGenderGroupLabel())</h4>
-                        <ol class="standings-list">
-                            @foreach (TeamCompetitionStanding standing in _response.Women)
-                            {
-                                <li><StandingsCard Standing="standing" /></li>
-                            }
-                        </ol>
-                    </section>
-                }
-
-                @if (_response.Men.Count > 0)
-                {
-                    <section class="standings-gender">
-                        <h4>@("m".ToGenderGroupLabel())</h4>
-                        <ol class="standings-list">
-                            @foreach (TeamCompetitionStanding standing in _response.Men)
-                            {
-                                <li><StandingsCard Standing="standing" /></li>
-                            }
-                        </ol>
-                    </section>
-                }
-            </div>
-
-            @if (_response.Women.Count == 0 && _response.Men.Count == 0)
-            {
-                <div class="empty-section">Engar nidurstödur.</div>
-            }
-        </div>
-    }
-    else
-    {
-        @if (_response.Combined.Count > 0)
+<DataLoader @key="Year" T="TeamCompetitionResponse" Loader="LoadAsync" Noun="gögn">
+    <ChildContent Context="response">
+        @if (response.IsGenderSplit)
         {
             <div class="standings-container">
-                <ol class="standings-list">
-                    @foreach (TeamCompetitionStanding standing in _response.Combined)
+                <div class="standings-grid">
+                    @if (response.Women.Count > 0)
                     {
-                        <li><StandingsCard Standing="standing" /></li>
+                        <section class="standings-gender">
+                            <h4>@("f".ToGenderGroupLabel())</h4>
+                            <ol class="standings-list">
+                                @foreach (TeamCompetitionStanding standing in response.Women)
+                                {
+                                    <li><StandingsCard Standing="standing" /></li>
+                                }
+                            </ol>
+                        </section>
                     }
-                </ol>
+
+                    @if (response.Men.Count > 0)
+                    {
+                        <section class="standings-gender">
+                            <h4>@("m".ToGenderGroupLabel())</h4>
+                            <ol class="standings-list">
+                                @foreach (TeamCompetitionStanding standing in response.Men)
+                                {
+                                    <li><StandingsCard Standing="standing" /></li>
+                                }
+                            </ol>
+                        </section>
+                    }
+                </div>
+
+                @if (response.Women.Count == 0 && response.Men.Count == 0)
+                {
+                    <div class="empty-section">Engar nidurstödur.</div>
+                }
             </div>
         }
         else
         {
-            <EmptyState Message="Engin gögn fundust fyrir þetta ar." />
+            @if (response.Combined.Count > 0)
+            {
+                <div class="standings-container">
+                    <ol class="standings-list">
+                        @foreach (TeamCompetitionStanding standing in response.Combined)
+                        {
+                            <li><StandingsCard Standing="standing" /></li>
+                        }
+                    </ol>
+                </div>
+            }
+            else
+            {
+                <EmptyState Message="Engin gögn fundust fyrir þetta ar." />
+            }
         }
-    }
-}
+    </ChildContent>
+</DataLoader>
 
 @code {
     [Parameter]
     public int Year { get; set; }
 
-    private int _loadedYear;
-    private bool _isLoading = true;
-    private bool _hasError;
-    private TeamCompetitionResponse? _response;
-
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
         if (Year == 0)
         {
             Year = DateTime.Now.Year;
         }
-
-        if (Year != _loadedYear)
-        {
-            _loadedYear = Year;
-            await LoadDataAsync();
-        }
     }
 
-    private async Task LoadDataAsync()
+    private async Task<TeamCompetitionResponse?> LoadAsync()
     {
-        _isLoading = true;
-        _hasError = false;
-
-        try
-        {
-            _response = await HttpClient.GetFromJsonAsync<TeamCompetitionResponse>($"/team-competition/{Year}");
-        }
-        catch
-        {
-            _hasError = true;
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        return await HttpClient.GetFromJsonAsync<TeamCompetitionResponse>($"/team-competition/{Year}");
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Teams/CreateTeamPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/CreateTeamPage.razor
@@ -9,6 +9,7 @@
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Countries
 @using KRAFT.Results.Contracts.Teams
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
@@ -16,40 +17,29 @@
 <PageTitle>Nýtt félag</PageTitle>
 <h3>Nýtt félag</h3>
 
-@if (_isInitializing)
-{
-    <LoadingSpinner Label="Sæki gögn..." />
-}
-else
-{
-    <TeamForm Countries="_countries"
-              OnSubmit="HandleSubmit"
-              IsLoading="_isLoading"
-              ErrorMessage="@_errorMessage"
-              SubmitLabel="Stofna félag"
-              BackUrl="/teams" />
-}
+<DataLoader T="CreateTeamData" Loader="LoadAsync" Noun="gögn">
+    <ChildContent Context="data">
+        <TeamForm Countries="data.Countries"
+                  OnSubmit="HandleSubmit"
+                  IsLoading="_isLoading"
+                  ErrorMessage="@_errorMessage"
+                  SubmitLabel="Stofna félag"
+                  BackUrl="/teams" />
+    </ChildContent>
+</DataLoader>
 
 @code {
-    private IReadOnlyCollection<CountrySummary> _countries = [];
-    private bool _isInitializing = true;
+    private sealed record CreateTeamData(IReadOnlyCollection<CountrySummary> Countries);
+
     private bool _isLoading;
     private string? _errorMessage;
 
-    protected override async Task OnInitializedAsync()
+    private async Task<CreateTeamData?> LoadAsync()
     {
-        try
-        {
-            _countries = await HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries") ?? [];
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Gat ekki sótt lönd. Reyndu að endurhlaða síðuna.";
-        }
-        finally
-        {
-            _isInitializing = false;
-        }
+        IReadOnlyCollection<CountrySummary> countries =
+            await HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries") ?? [];
+
+        return new CreateTeamData(countries);
     }
 
     private async Task HandleSubmit(TeamFormValues values)

--- a/src/KRAFT.Results.Web.Client/Features/Teams/CreateTeamPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/CreateTeamPage.razor
@@ -39,6 +39,11 @@
         IReadOnlyCollection<CountrySummary> countries =
             await HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries") ?? [];
 
+        if (countries.Count == 0)
+        {
+            throw new HttpRequestException("Required reference data is unavailable.");
+        }
+
         return new CreateTeamData(countries);
     }
 

--- a/src/KRAFT.Results.Web.Client/Features/Teams/EditTeamPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/EditTeamPage.razor
@@ -9,6 +9,7 @@
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Countries
 @using KRAFT.Results.Contracts.Teams
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
@@ -16,65 +17,47 @@
 <PageTitle>Breyta félagi</PageTitle>
 <h3>Breyta félagi</h3>
 
-@if (_isInitializing)
-{
-    <LoadingSpinner Label="Sæki gögn..." />
-}
-else if (_initialValues is not null)
-{
-    <TeamForm Countries="_countries"
-              OnSubmit="HandleSubmit"
-              IsLoading="_isLoading"
-              ErrorMessage="@_errorMessage"
-              SubmitLabel="Vista breytingar"
-              BackUrl="@($"/teams/{Slug}")"
-              InitialValues="_initialValues" />
-}
-else if (_errorMessage is not null)
-{
-    <div role="alert" class="error-message">
-        <p>@_errorMessage</p>
-        <a href="/teams">Til baka í félagalista</a>
-    </div>
-}
+<DataLoader T="EditTeamData" Loader="LoadAsync" Noun="gögn">
+    <ChildContent Context="data">
+        <TeamForm Countries="data.Countries"
+                  OnSubmit="HandleSubmit"
+                  IsLoading="_isLoading"
+                  ErrorMessage="@_errorMessage"
+                  SubmitLabel="Vista breytingar"
+                  BackUrl="@($"/teams/{Slug}")"
+                  InitialValues="data.InitialValues" />
+    </ChildContent>
+</DataLoader>
 
 @code {
+    private sealed record EditTeamData(
+        TeamFormInitialValues InitialValues,
+        IReadOnlyCollection<CountrySummary> Countries);
+
     [Parameter]
     public string Slug { get; set; } = string.Empty;
 
-    private IReadOnlyCollection<CountrySummary> _countries = [];
-    private TeamFormInitialValues? _initialValues;
-    private bool _isInitializing = true;
     private bool _isLoading;
     private string? _errorMessage;
 
-    protected override async Task OnInitializedAsync()
+    private async Task<EditTeamData?> LoadAsync()
     {
-        try
-        {
-            TeamDetails? team = await HttpClient.GetFromJsonAsync<TeamDetails>($"/teams/{Slug}");
-            _countries = await HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries") ?? [];
+        TeamDetails? team = await HttpClient.GetFromJsonAsync<TeamDetails>($"/teams/{Slug}");
+        IReadOnlyCollection<CountrySummary> countries =
+            await HttpClient.GetFromJsonAsync<IReadOnlyCollection<CountrySummary>>("/countries") ?? [];
 
-            if (team is null)
-            {
-                _errorMessage = "Félag fannst ekki.";
-                return;
-            }
+        if (team is null)
+        {
+            return null;
+        }
 
-            _initialValues = new TeamFormInitialValues(
-                team.Title,
-                team.ShortTitle,
-                team.FullTitle,
-                team.CountryCode);
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isInitializing = false;
-        }
+        TeamFormInitialValues initialValues = new(
+            team.Title,
+            team.ShortTitle,
+            team.FullTitle,
+            team.CountryCode);
+
+        return new EditTeamData(initialValues, countries);
     }
 
     private async Task HandleSubmit(TeamFormValues values)

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
@@ -1,6 +1,5 @@
-﻿@page "/teams/{slug}"
+@page "/teams/{slug}"
 
-@using KRAFT
 @using KRAFT.Results.Contracts.Teams
 @using KRAFT.Results.Web.Client.Components
 @using Microsoft.AspNetCore.Components.Routing
@@ -8,87 +7,78 @@
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
 
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki félag..." />
-}
-else if (_errorMessage is not null)
-{
-    <div role="alert" class="error-message">
-        <p>@_errorMessage</p>
-        <a href="/teams">Til baka í félagslista</a>
-    </div>
-}
-else
-{
-    <div class="page-header">
-        <h1>@Team?.FullTitle (@Team?.ShortTitle)</h1>
-        <AuthorizeView Roles="Admin">
-            <div class="admin-actions">
-                <a href="/teams/@Slug/edit" class="btn-action" aria-label="Breyta félagi">
-                    <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
-                        <path d="m15 5 4 4"/>
-                    </svg>
-                    Breyta
-                </a>
-                <button class="btn-action btn-danger" aria-label="Eyða félagi" @onclick="ShowDeleteDialog">
-                    <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M3 6h18"/>
-                        <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
-                        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
-                        <line x1="10" x2="10" y1="11" y2="17"/>
-                        <line x1="14" x2="14" y1="11" y2="17"/>
-                    </svg>
-                    Eyða
-                </button>
-            </div>
-        </AuthorizeView>
-    </div>
+<DataLoader T="TeamDetails" Loader="LoadAsync" Noun="félag">
+    <ChildContent Context="team">
+        <div class="page-header">
+            <h1>@team.FullTitle (@team.ShortTitle)</h1>
+            <AuthorizeView Roles="Admin">
+                <div class="admin-actions">
+                    <a href="/teams/@Slug/edit" class="btn-action" aria-label="Breyta félagi">
+                        <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+                            <path d="m15 5 4 4"/>
+                        </svg>
+                        Breyta
+                    </a>
+                    <button class="btn-action btn-danger" aria-label="Eyða félagi" @onclick="ShowDeleteDialog">
+                        <svg class="btn-icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 6h18"/>
+                            <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
+                            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
+                            <line x1="10" x2="10" y1="11" y2="17"/>
+                            <line x1="14" x2="14" y1="11" y2="17"/>
+                        </svg>
+                        Eyða
+                    </button>
+                </div>
+            </AuthorizeView>
+        </div>
 
-    <br/>
+        <br/>
 
-    <h2>Meðlimir</h2>
+        <h2>Meðlimir</h2>
 
-    @if (Team?.Members is { Count: > 0 } members)
-    {
-        <ul class="member-list">
-            @foreach (TeamMember member in members)
-            {
-                <li>
-                    <NavLink class="nav-link" href="@($"/athletes/{member.Slug}")">
-                        @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
-                    </NavLink>
-                </li>
-            }
-        </ul>
-    }
-    else
-    {
-        <p>Engir meðlimir skráðir.</p>
-    }
+        @if (team.Members is { Count: > 0 } members)
+        {
+            <ul class="member-list">
+                @foreach (TeamMember member in members)
+                {
+                    <li>
+                        <NavLink class="nav-link" href="@($"/athletes/{member.Slug}")">
+                            @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
+                        </NavLink>
+                    </li>
+                }
+            </ul>
+        }
+        else
+        {
+            <p>Engir meðlimir skráðir.</p>
+        }
 
-    <ConfirmDialog @ref="_deleteDialog"
-                   Id="delete-team-dialog"
-                   Title="Eyða liði"
-                   Message="@($"Ertu viss um að þú viljir eyða liðinu \"{Team?.FullTitle}\"?")"
-                   ConfirmLabel="Eyða liði"
-                   OnConfirm="HandleDelete"
-                   ErrorMessage="@_deleteErrorMessage"
-                   IsLoading="_isDeleting" />
-}
+        <ConfirmDialog @ref="_deleteDialog"
+                       Id="delete-team-dialog"
+                       Title="Eyða liði"
+                       Message="@($"Ertu viss um að þú viljir eyða liðinu \"{team.FullTitle}\"?")"
+                       ConfirmLabel="Eyða liði"
+                       OnConfirm="HandleDelete"
+                       ErrorMessage="@_deleteErrorMessage"
+                       IsLoading="_isDeleting" />
+    </ChildContent>
+</DataLoader>
 
 @code {
     private ConfirmDialog _deleteDialog = null!;
     private bool _isDeleting;
     private string? _deleteErrorMessage;
-    private bool _isLoading = true;
-    private string? _errorMessage;
 
     [Parameter]
     public string Slug { get; set; } = string.Empty;
 
-    private TeamDetails? Team;
+    private async Task<TeamDetails?> LoadAsync()
+    {
+        return await HttpClient.GetFromJsonAsync<TeamDetails>($"/teams/{Slug}");
+    }
 
     private async Task ShowDeleteDialog()
     {
@@ -130,27 +120,6 @@ else
         finally
         {
             _isDeleting = false;
-        }
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        try
-        {
-            Team = await HttpClient.GetFromJsonAsync<TeamDetails>($"/teams/{Slug}");
-
-            if (Team is null)
-            {
-                _errorMessage = "Félag fannst ekki.";
-            }
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp við að sækja félag. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isLoading = false;
         }
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
@@ -9,51 +9,28 @@
 
 <PageHeader Title="Félög" ActionHref="/teams/create" ActionLabel="Stofna félag" />
 
-@if (_errorMessage is not null)
-{
-    <ErrorMessage Message="@_errorMessage" />
-}
-
-@if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki félög..." />
-}
-else
-{
-    <div class="card-grid">
-        @foreach (TeamSummary team in Teams)
-        {
-            <Card>
-                <a href="@($"/teams/{team.Slug}")" aria-label="@team.Title"></a>
-                <div class="team-name">@team.Title</div>
-                <div class="team-short">@team.ShortTitle</div>
-                <div class="team-count">
-                    <span class="count-value">@team.AthleteCount</span>
-                    <span class="count-label">meðlimir</span>
-                </div>
-            </Card>
-        }
-    </div>
-}
+<DataLoader T="IReadOnlyCollection<TeamSummary>" Loader="LoadAsync" Noun="félög">
+    <ChildContent Context="context">
+        <div class="card-grid">
+            @foreach (TeamSummary team in context)
+            {
+                <Card>
+                    <a href="@($"/teams/{team.Slug}")" aria-label="@team.Title"></a>
+                    <div class="team-name">@team.Title</div>
+                    <div class="team-short">@team.ShortTitle</div>
+                    <div class="team-count">
+                        <span class="count-value">@team.AthleteCount</span>
+                        <span class="count-label">meðlimir</span>
+                    </div>
+                </Card>
+            }
+        </div>
+    </ChildContent>
+</DataLoader>
 
 @code {
-    private bool _isLoading = true;
-    private IReadOnlyCollection<TeamSummary> Teams = [];
-    private string? _errorMessage;
-
-    protected override async Task OnInitializedAsync()
+    private async Task<IReadOnlyCollection<TeamSummary>?> LoadAsync()
     {
-        try
-        {
-            Teams = await HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamSummary>>("/teams") ?? [];
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp við að sækja félög. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        return await HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamSummary>>("/teams");
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Users/EditUserPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/EditUserPage.razor
@@ -20,11 +20,11 @@
 <DataLoader T="EditUserData" Loader="LoadAsync" Noun="gögn">
     <ChildContent Context="data">
         @{
-            if (!_modelCaptured)
+            if (!ReferenceEquals(_lastUserData, data))
             {
+                _lastUserData = data;
                 _model = data.Model;
                 _isSelfEdit = data.IsSelfEdit;
-                _modelCaptured = true;
             }
         }
 
@@ -136,7 +136,7 @@
     public int UserId { get; set; }
 
     private EditUserModel? _model;
-    private bool _modelCaptured;
+    private EditUserData? _lastUserData;
     private bool _isLoading;
     private string? _errorMessage;
     private string? _deleteErrorMessage;

--- a/src/KRAFT.Results.Web.Client/Features/Users/EditUserPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/EditUserPage.razor
@@ -8,6 +8,7 @@
 @using System.Net
 @using System.Security.Claims
 @using KRAFT.Results.Contracts.Users
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
@@ -16,125 +17,126 @@
 <PageTitle>Breyta notanda</PageTitle>
 <h3>Breyta notanda</h3>
 
-@if (_isInitializing)
-{
-    <LoadingSpinner Label="Sæki gögn..." />
-}
-else if (_model is not null)
-{
-    <div class="form-card">
-        <EditForm Model="_model" OnValidSubmit="HandleSubmit" FormName="edit-user">
-            <DataAnnotationsValidator />
-
-            <div class="form-field">
-                <label class="form-label" for="firstname">Fornafn</label>
-                <InputText id="firstname"
-                           class="form-input"
-                           autocomplete="given-name"
-                           aria-describedby="@(HasError ? "edit-error" : null)"
-                           @bind-Value="_model.FirstName"
-                           disabled="@_isLoading" />
-                <ValidationMessage For="@(() => _model.FirstName)" />
-            </div>
-
-            <div class="form-field">
-                <label class="form-label" for="lastname">Eftirnafn</label>
-                <InputText id="lastname"
-                           class="form-input"
-                           autocomplete="family-name"
-                           aria-describedby="@(HasError ? "edit-error" : null)"
-                           @bind-Value="_model.LastName"
-                           disabled="@_isLoading" />
-                <ValidationMessage For="@(() => _model.LastName)" />
-            </div>
-
-            <div class="form-field">
-                <label class="form-label" for="email">Tölvupóstfang</label>
-                <InputText type="email"
-                           id="email"
-                           class="form-input"
-                           autocomplete="email"
-                           aria-describedby="@(HasError ? "edit-error" : null)"
-                           @bind-Value="_model.Email"
-                           disabled="@_isLoading" />
-                <ValidationMessage For="@(() => _model.Email)" />
-            </div>
-
-            <fieldset class="form-field role-field" aria-describedby="@(_rolesError is not null ? "roles-error" : null)">
-                <legend class="form-label">Hlutverk</legend>
-                <div class="role-checkbox-group">
-                    @foreach (string role in _availableRoles)
-                    {
-                        <label class="role-checkbox-label" for="@($"role-{role.ToLowerInvariant()}")">
-                            <input type="checkbox"
-                                   id="@($"role-{role.ToLowerInvariant()}")"
-                                   class="role-checkbox"
-                                   checked="@IsRoleSelected(role)"
-                                   disabled="@(_isSelfEdit || _isLoading)"
-                                   @onchange="@(e => ToggleRole(role, e))" />
-                            <span class="role-checkbox-text">@role</span>
-                        </label>
-                    }
-                </div>
-                @if (_isSelfEdit)
-                {
-                    <p class="role-note">Þú getur ekki breytt hlutverki þíns eigin aðgangs</p>
-                }
-                @if (_rolesError is not null)
-                {
-                    <p id="roles-error" class="role-error" role="alert">@_rolesError</p>
-                }
-            </fieldset>
-
-            <div class="form-actions">
-                <div class="form-actions-primary">
-                    <SubmitButton Label="Vista breytingar" IsLoading="@_isLoading" />
-                    <a href="/users" class="btn-cancel">Til baka</a>
-                </div>
-
-                <hr class="form-actions-divider" />
-
-                <div class="form-actions-danger">
-                    @if (_showDeleteConfirmation)
-                    {
-                        <p class="delete-confirm-text">Ertu viss um að þú viljir eyða þessum notanda?</p>
-                        <div class="danger-actions">
-                            <button type="button" class="btn-danger" @onclick="HandleDelete" disabled="@_isLoading">Já, eyða</button>
-                            <button type="button" class="btn-cancel-danger" @ref="_cancelDeleteButton" @onclick="CancelDelete" disabled="@_isLoading">Hætta við</button>
-                        </div>
-                    }
-                    else
-                    {
-                        <button type="button" class="btn-delete-ghost" @onclick="ConfirmDelete" disabled="@_isLoading">Eyða notanda</button>
-                    }
-                    @if (!string.IsNullOrEmpty(_deleteErrorMessage))
-                    {
-                        <ErrorMessage Message="@_deleteErrorMessage" />
-                    }
-                </div>
-            </div>
-
-            @if (!string.IsNullOrEmpty(_errorMessage))
+<DataLoader T="EditUserData" Loader="LoadAsync" Noun="gögn">
+    <ChildContent Context="data">
+        @{
+            if (!_modelCaptured)
             {
-                <ErrorMessage Id="edit-error" Message="@_errorMessage" />
+                _model = data.Model;
+                _isSelfEdit = data.IsSelfEdit;
+                _modelCaptured = true;
             }
-        </EditForm>
-    </div>
-}
-else if (_errorMessage is not null)
-{
-    <div role="alert" class="error-message">
-        <p>@_errorMessage</p>
-        <a href="/users">Til baka í notandalista</a>
-    </div>
-}
+        }
+
+        <div class="form-card">
+            <EditForm Model="_model" OnValidSubmit="HandleSubmit" FormName="edit-user">
+                <DataAnnotationsValidator />
+
+                <div class="form-field">
+                    <label class="form-label" for="firstname">Fornafn</label>
+                    <InputText id="firstname"
+                               class="form-input"
+                               autocomplete="given-name"
+                               aria-describedby="@(HasError ? "edit-error" : null)"
+                               @bind-Value="_model!.FirstName"
+                               disabled="@_isLoading" />
+                    <ValidationMessage For="@(() => _model!.FirstName)" />
+                </div>
+
+                <div class="form-field">
+                    <label class="form-label" for="lastname">Eftirnafn</label>
+                    <InputText id="lastname"
+                               class="form-input"
+                               autocomplete="family-name"
+                               aria-describedby="@(HasError ? "edit-error" : null)"
+                               @bind-Value="_model!.LastName"
+                               disabled="@_isLoading" />
+                    <ValidationMessage For="@(() => _model!.LastName)" />
+                </div>
+
+                <div class="form-field">
+                    <label class="form-label" for="email">Tölvupóstfang</label>
+                    <InputText type="email"
+                               id="email"
+                               class="form-input"
+                               autocomplete="email"
+                               aria-describedby="@(HasError ? "edit-error" : null)"
+                               @bind-Value="_model!.Email"
+                               disabled="@_isLoading" />
+                    <ValidationMessage For="@(() => _model!.Email)" />
+                </div>
+
+                <fieldset class="form-field role-field" aria-describedby="@(_rolesError is not null ? "roles-error" : null)">
+                    <legend class="form-label">Hlutverk</legend>
+                    <div class="role-checkbox-group">
+                        @foreach (string role in _availableRoles)
+                        {
+                            <label class="role-checkbox-label" for="@($"role-{role.ToLowerInvariant()}")">
+                                <input type="checkbox"
+                                       id="@($"role-{role.ToLowerInvariant()}")"
+                                       class="role-checkbox"
+                                       checked="@IsRoleSelected(role)"
+                                       disabled="@(_isSelfEdit || _isLoading)"
+                                       @onchange="@(e => ToggleRole(role, e))" />
+                                <span class="role-checkbox-text">@role</span>
+                            </label>
+                        }
+                    </div>
+                    @if (_isSelfEdit)
+                    {
+                        <p class="role-note">Þú getur ekki breytt hlutverki þíns eigin aðgangs</p>
+                    }
+                    @if (_rolesError is not null)
+                    {
+                        <p id="roles-error" class="role-error" role="alert">@_rolesError</p>
+                    }
+                </fieldset>
+
+                <div class="form-actions">
+                    <div class="form-actions-primary">
+                        <SubmitButton Label="Vista breytingar" IsLoading="@_isLoading" />
+                        <a href="/users" class="btn-cancel">Til baka</a>
+                    </div>
+
+                    <hr class="form-actions-divider" />
+
+                    <div class="form-actions-danger">
+                        @if (_showDeleteConfirmation)
+                        {
+                            <p class="delete-confirm-text">Ertu viss um að þú viljir eyða þessum notanda?</p>
+                            <div class="danger-actions">
+                                <button type="button" class="btn-danger" @onclick="HandleDelete" disabled="@_isLoading">Já, eyða</button>
+                                <button type="button" class="btn-cancel-danger" @ref="_cancelDeleteButton" @onclick="CancelDelete" disabled="@_isLoading">Hætta við</button>
+                            </div>
+                        }
+                        else
+                        {
+                            <button type="button" class="btn-delete-ghost" @onclick="ConfirmDelete" disabled="@_isLoading">Eyða notanda</button>
+                        }
+                        @if (!string.IsNullOrEmpty(_deleteErrorMessage))
+                        {
+                            <ErrorMessage Message="@_deleteErrorMessage" />
+                        }
+                    </div>
+                </div>
+
+                @if (!string.IsNullOrEmpty(_errorMessage))
+                {
+                    <ErrorMessage Id="edit-error" Message="@_errorMessage" />
+                }
+            </EditForm>
+        </div>
+    </ChildContent>
+</DataLoader>
 
 @code {
+    private sealed record EditUserData(EditUserModel Model, bool IsSelfEdit);
+
     [Parameter]
     public int UserId { get; set; }
 
     private EditUserModel? _model;
-    private bool _isInitializing = true;
+    private bool _modelCaptured;
     private bool _isLoading;
     private string? _errorMessage;
     private string? _deleteErrorMessage;
@@ -175,40 +177,32 @@ else if (_errorMessage is not null)
         }
     }
 
-    protected override async Task OnInitializedAsync()
+    private async Task<EditUserData?> LoadAsync()
     {
-        try
+        AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        string? currentUserId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? authState.User.FindFirst("sub")?.Value;
+
+        bool isSelfEdit = currentUserId is not null
+            && int.TryParse(currentUserId, out int parsedId)
+            && parsedId == UserId;
+
+        UserEditDetails? user = await HttpClient.GetFromJsonAsync<UserEditDetails>($"/users/{UserId}/edit");
+
+        if (user is null)
         {
-            AuthenticationState authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-            string? currentUserId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                ?? authState.User.FindFirst("sub")?.Value;
-
-            _isSelfEdit = currentUserId is not null && int.TryParse(currentUserId, out int parsedId) && parsedId == UserId;
-
-            UserEditDetails? user = await HttpClient.GetFromJsonAsync<UserEditDetails>($"/users/{UserId}/edit");
-
-            if (user is null)
-            {
-                _errorMessage = "Notandi fannst ekki.";
-                return;
-            }
-
-            _model = new EditUserModel
-            {
-                FirstName = user.FirstName,
-                LastName = user.LastName,
-                Email = user.Email ?? string.Empty,
-                Roles = [..user.Roles],
-            };
+            return null;
         }
-        catch (HttpRequestException)
+
+        EditUserModel model = new()
         {
-            _errorMessage = "Villa kom upp. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isInitializing = false;
-        }
+            FirstName = user.FirstName,
+            LastName = user.LastName,
+            Email = user.Email ?? string.Empty,
+            Roles = [..user.Roles],
+        };
+
+        return new EditUserData(model, isSelfEdit);
     }
 
     private async Task HandleSubmit()
@@ -340,7 +334,7 @@ else if (_errorMessage is not null)
         }
     }
 
-    private sealed class EditUserModel
+    internal sealed class EditUserModel
     {
         [Required]
         public string FirstName { get; set; } = string.Empty;

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
@@ -5,80 +5,67 @@
 @attribute [Authorize(Roles = "Admin")]
 
 @using KRAFT.Results.Contracts.Users
+@using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient;
 @inject NavigationManager NavigationManager;
 
 <div class="page-header">
     <h3>Notendur</h3>
-    @if (!_isLoading)
-    {
-        <button class="btn-action" @onclick="NavigateToCreate">
-            <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-                <path fill-rule="evenodd" d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2" />
-            </svg>
-            Stofna notanda
-        </button>
-    }
+    <button class="btn-action" @onclick="NavigateToCreate">
+        <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+            <path fill-rule="evenodd" d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2" />
+        </svg>
+        Stofna notanda
+    </button>
 </div>
 
-@if (!string.IsNullOrEmpty(_errorMessage))
-{
-    <ErrorMessage Message="@_errorMessage" />
-}
-else if (_isLoading)
-{
-    <LoadingSpinner Label="Sæki notendur..." />
-}
-else
-{
-    <table>
-        <thead>
-            <tr>
-                <th>Nafn</th>
-                <th>Tölvupóstfang</th>
-                <th>Hlutverk</th>
-                <th>Stofnaður</th>
-                <th><span class="visually-hidden">Aðgerðir</span></th>
-            </tr>
-        </thead>
-
-        <tbody>
-            @if (!Users.Any())
-            {
+<DataLoader T="IReadOnlyCollection<UserSummary>" Loader="LoadAsync" Noun="notendur">
+    <ChildContent Context="context">
+        <table>
+            <thead>
                 <tr>
-                    <td colspan="5">Engir notendur fundust.</td>
+                    <th>Nafn</th>
+                    <th>Tölvupóstfang</th>
+                    <th>Hlutverk</th>
+                    <th>Stofnaður</th>
+                    <th><span class="visually-hidden">Aðgerðir</span></th>
                 </tr>
-            }
-            else
-            {
-                @foreach (UserSummary User in Users)
+            </thead>
+
+            <tbody>
+                @if (!context.Any())
                 {
                     <tr>
-                        <td>@User.Name</td>
-                        <td>@User.Email</td>
-                        <td>@string.Join(", ", User.Roles)</td>
-                        <td>@User.CreatedOn.ToShortDateString()</td>
-                        <td>
-                            <button type="button" class="btn-edit" @onclick="@(() => NavigateToEdit(User.UserId))" aria-label="@($"Breyta {User.Name}")">
-                                <svg class="btn-edit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                    <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/>
-                                </svg>
-                                <span>Breyta</span>
-                            </button>
-                        </td>
+                        <td colspan="5">Engir notendur fundust.</td>
                     </tr>
                 }
-            }
-        </tbody>
-    </table>
-}
+                else
+                {
+                    @foreach (UserSummary User in context)
+                    {
+                        <tr>
+                            <td>@User.Name</td>
+                            <td>@User.Email</td>
+                            <td>@string.Join(", ", User.Roles)</td>
+                            <td>@User.CreatedOn.ToShortDateString()</td>
+                            <td>
+                                <button type="button" class="btn-edit" @onclick="@(() => NavigateToEdit(User.UserId))" aria-label="@($"Breyta {User.Name}")">
+                                    <svg class="btn-edit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/>
+                                    </svg>
+                                    <span>Breyta</span>
+                                </button>
+                            </td>
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
+    </ChildContent>
+</DataLoader>
 
 @code {
-    private IReadOnlyCollection<UserSummary> Users = [];
-    private bool _isLoading = true;
-    private string? _errorMessage;
-
     private void NavigateToCreate()
     {
         NavigationManager.NavigateTo("/users/create");
@@ -89,25 +76,8 @@ else
         NavigationManager.NavigateTo($"/users/{userId}/edit");
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    private async Task<IReadOnlyCollection<UserSummary>?> LoadAsync()
     {
-        if (!firstRender)
-        {
-            return;
-        }
-
-        try
-        {
-            Users = await HttpClient.GetFromJsonAsync<IReadOnlyCollection<UserSummary>>("/users") ?? [];
-        }
-        catch (HttpRequestException)
-        {
-            _errorMessage = "Villa kom upp við að sækja notendur. Reyndu aftur síðar.";
-        }
-        finally
-        {
-            _isLoading = false;
-            StateHasChanged();
-        }
+        return await HttpClient.GetFromJsonAsync<IReadOnlyCollection<UserSummary>>("/users");
     }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
@@ -8,7 +8,8 @@ namespace KRAFT.Results.Web.Client.Tests;
 internal sealed class AthleteDetailsPageMockHandler(
     List<AthleteRecord> records,
     List<AthletePersonalBest> personalBests,
-    List<AthleteParticipation> participations) : HttpMessageHandler
+    List<AthleteParticipation> participations,
+    bool delay = false) : HttpMessageHandler
 {
     private static readonly AthleteDetails DefaultAthlete = new(
         Slug: "test-athlete",
@@ -18,8 +19,13 @@ internal sealed class AthleteDetailsPageMockHandler(
         ClubSlug: "test-club",
         RecordCount: 0);
 
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        if (delay)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+
         string path = request.RequestUri?.AbsolutePath ?? string.Empty;
 
         HttpResponseMessage response;
@@ -41,6 +47,6 @@ internal sealed class AthleteDetailsPageMockHandler(
             response = new(HttpStatusCode.OK) { Content = JsonContent.Create(DefaultAthlete) };
         }
 
-        return Task.FromResult(response);
+        return response;
     }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/DataLoaderTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/DataLoaderTests.cs
@@ -1,0 +1,186 @@
+using Bunit;
+
+using KRAFT.Results.Web.Client.Components;
+
+using Microsoft.AspNetCore.Components;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Components;
+
+public sealed class DataLoaderTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        TaskCompletionSource<string?> tcs = new();
+        RenderFragment<string> childContent = _ => builder => { };
+
+        // Act
+        IRenderedComponent<DataLoader<string>> cut = _context.Render<DataLoader<string>>(
+            p => p.Add(c => c.Loader, () => tcs.Task)
+                  .Add(c => c.Noun, "gögn")
+                  .Add(c => c.ChildContent, childContent));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsErrorMessage_WhenLoaderThrows()
+    {
+        // Arrange
+        static async Task<string?> FailingLoader()
+        {
+            await Task.Yield();
+            throw new HttpRequestException("Server error");
+        }
+
+        RenderFragment<string> childContent = _ => builder => { };
+
+        // Act
+        IRenderedComponent<DataLoader<string>> cut = _context.Render<DataLoader<string>>(
+            p => p.Add(c => c.Loader, FailingLoader)
+                  .Add(c => c.Noun, "gögn")
+                  .Add(c => c.ChildContent, childContent));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("gögn");
+        });
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenLoaderReturnsNull()
+    {
+        // Arrange
+        static Task<string?> NullLoader() => Task.FromResult<string?>(null);
+        RenderFragment<string> childContent = _ => builder => { };
+
+        // Act
+        IRenderedComponent<DataLoader<string>> cut = _context.Render<DataLoader<string>>(
+            p => p.Add(c => c.Loader, NullLoader)
+                  .Add(c => c.Noun, "keppanda")
+                  .Add(c => c.ChildContent, childContent));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("Keppanda");
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void RendersChildContent_WhenLoaderReturnsData()
+    {
+        // Arrange
+        static Task<string?> SuccessLoader() => Task.FromResult<string?>("hello");
+        RenderFragment<string> childContent = data => builder =>
+            builder.AddMarkupContent(0, $"<span class='result'>{data}</span>");
+
+        // Act
+        IRenderedComponent<DataLoader<string>> cut = _context.Render<DataLoader<string>>(
+            p => p.Add(c => c.Loader, SuccessLoader)
+                  .Add(c => c.Noun, "gögn")
+                  .Add(c => c.ChildContent, childContent));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".result").TextContent.ShouldBe("hello");
+        });
+    }
+
+    [Fact]
+    public void ErrorState_HasRetryButton_ThatResetsToLoading()
+    {
+        // Arrange
+        TaskCompletionSource<string?> tcs = new();
+        int callCount = 0;
+        RenderFragment<string> childContent = _ => builder => { };
+
+        Task<string?> Loader()
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                throw new HttpRequestException("fail");
+            }
+
+            return tcs.Task;
+        }
+
+        // Act
+        IRenderedComponent<DataLoader<string>> cut = _context.Render<DataLoader<string>>(
+            p => p.Add(c => c.Loader, Loader)
+                  .Add(c => c.Noun, "gögn")
+                  .Add(c => c.ChildContent, childContent));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+
+        // Act — click retry resets to loading state
+        cut.Find(".retry-btn").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='status']").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void NotFoundState_DoesNotHaveRetryButton()
+    {
+        // Arrange
+        static Task<string?> NullLoader() => Task.FromResult<string?>(null);
+        RenderFragment<string> childContent = _ => builder => { };
+
+        // Act
+        IRenderedComponent<DataLoader<string>> cut = _context.Render<DataLoader<string>>(
+            p => p.Add(c => c.Loader, NullLoader)
+                  .Add(c => c.Noun, "gögn")
+                  .Add(c => c.ChildContent, childContent));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".retry-btn").Count.ShouldBe(0);
+        });
+    }
+
+    [Fact]
+    public void CapitalizesFirstLetterOfNoun_InNotFoundMessage()
+    {
+        // Arrange
+        static Task<string?> NullLoader() => Task.FromResult<string?>(null);
+        RenderFragment<string> childContent = _ => builder => { };
+
+        // Act
+        IRenderedComponent<DataLoader<string>> cut = _context.Render<DataLoader<string>>(
+            p => p.Add(c => c.Loader, NullLoader)
+                  .Add(c => c.Noun, "mót")
+                  .Add(c => c.ChildContent, childContent));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").TextContent.ShouldContain("Mót fannst ekki");
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/FailingHttpMessageHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/FailingHttpMessageHandler.cs
@@ -1,0 +1,9 @@
+namespace KRAFT.Results.Web.Client.Tests;
+
+internal sealed class FailingHttpMessageHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        throw new HttpRequestException("Server error");
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
@@ -302,6 +302,75 @@ public sealed class AthleteDetailsPageTests : IDisposable
         });
     }
 
+    [Fact]
+    public void ShowsLoadingStateInitially()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki keppanda...");
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenAthleteReturnsNull()
+    {
+        // Arrange
+        RegisterNullAthleteHttpClient();
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "nonexistent"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("keppanda");
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsAthleteName_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("h1").TextContent.ShouldBe("Test Athlete");
+        });
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -311,15 +380,54 @@ public sealed class AthleteDetailsPageTests : IDisposable
     private void RegisterHttpClient(
         List<AthleteRecord>? records = null,
         List<AthletePersonalBest>? personalBests = null,
-        List<AthleteParticipation>? participations = null)
+        List<AthleteParticipation>? participations = null,
+        bool delay = false)
     {
         AthleteDetailsPageMockHandler handler = new(
             records ?? [],
             personalBests ?? [],
-            participations ?? []);
+            participations ?? [],
+            delay);
 
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
         _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterNullAthleteHttpClient()
+    {
+        NullAthleteHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingAthleteHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class NullAthleteHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FailingAthleteHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
     }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
@@ -247,6 +247,23 @@ public sealed class AthletesIndexTests : IDisposable
         });
     }
 
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -255,9 +272,26 @@ public sealed class AthletesIndexTests : IDisposable
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
     private void RegisterHttpClient(List<AthleteSummary> athletes, bool delay = false)
     {
-        MockHttpMessageHandler handler = new(athletes, delay);
+        MockHttpMessageHandler<AthleteSummary> handler = new(athletes, delay);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
         _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
     }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
@@ -286,12 +286,4 @@ public sealed class AthletesIndexTests : IDisposable
         _context.Services.AddSingleton(httpClient);
         _context.AddAuthorization();
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/CreateAthletePageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/CreateAthletePageTests.cs
@@ -127,12 +127,4 @@ public sealed class CreateAthletePageTests : IDisposable
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/CreateAthletePageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/CreateAthletePageTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Countries;
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.Web.Client.Features.Athletes;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Athletes;
+
+public sealed class CreateAthletePageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<CreateAthletePage> cut = _context.Render<CreateAthletePage>();
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<CreateAthletePage> cut = _context.Render<CreateAthletePage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsAthleteForm_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<CreateAthletePage> cut = _context.Render<CreateAthletePage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("form").ShouldNotBeNull();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(bool delay = false)
+    {
+        CreateAthletePageMockHandler handler = new(delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class CreateAthletePageMockHandler(bool delay = false) : HttpMessageHandler
+    {
+        private static readonly List<CountrySummary> DefaultCountries =
+        [
+            new("ISL", "Iceland"),
+        ];
+
+        private static readonly List<TeamOption> DefaultTeams =
+        [
+            new(1, "Þór"),
+        ];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (path.StartsWith("/countries", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(DefaultCountries),
+                };
+            }
+
+            if (path.StartsWith("/teams/options", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(DefaultTeams),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/EditAthletePageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/EditAthletePageTests.cs
@@ -201,12 +201,4 @@ public sealed class EditAthletePageTests : IDisposable
             });
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/EditAthletePageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/EditAthletePageTests.cs
@@ -1,0 +1,212 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Countries;
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.Web.Client.Features.Athletes;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Athletes;
+
+public sealed class EditAthletePageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<EditAthletePage> cut = _context.Render<EditAthletePage>(
+            p => p.Add(c => c.Slug, "test-athlete"));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenAthleteReturnsNull()
+    {
+        // Arrange
+        RegisterNullAthleteHttpClient();
+
+        // Act
+        IRenderedComponent<EditAthletePage> cut = _context.Render<EditAthletePage>(
+            p => p.Add(c => c.Slug, "nonexistent"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<EditAthletePage> cut = _context.Render<EditAthletePage>(
+            p => p.Add(c => c.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsAthleteForm_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<EditAthletePage> cut = _context.Render<EditAthletePage>(
+            p => p.Add(c => c.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("form").ShouldNotBeNull();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(bool delay = false)
+    {
+        EditAthletePageMockHandler handler = new(delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterNullAthleteHttpClient()
+    {
+        NullAthleteHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class EditAthletePageMockHandler(bool delay = false) : HttpMessageHandler
+    {
+        private static readonly AthleteEditDetails DefaultAthlete = new(
+            FirstName: "Jon",
+            LastName: "Jonsson",
+            DateOfBirth: new DateOnly(1990, 1, 1),
+            Gender: "M",
+            CountryCode: "ISL",
+            TeamId: null);
+
+        private static readonly List<CountrySummary> DefaultCountries =
+        [
+            new("ISL", "Iceland"),
+        ];
+
+        private static readonly List<TeamOption> DefaultTeams =
+        [
+            new(1, "Þór"),
+        ];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (path.StartsWith("/countries", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(DefaultCountries),
+                };
+            }
+
+            if (path.StartsWith("/teams/options", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(DefaultTeams),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(DefaultAthlete),
+            };
+        }
+    }
+
+    private sealed class NullAthleteHttpMessageHandler : HttpMessageHandler
+    {
+        private static readonly List<CountrySummary> DefaultCountries = [new("ISL", "Iceland")];
+        private static readonly List<TeamOption> DefaultTeams = [new(1, "Þór")];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (path.StartsWith("/countries", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(DefaultCountries),
+                });
+            }
+
+            if (path.StartsWith("/teams/options", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(DefaultTeams),
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/EditMeetPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/EditMeetPageTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.Web.Client.Features.Meets;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Meets;
+
+public sealed class EditMeetPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<EditMeetPage> cut = _context.Render<EditMeetPage>(
+            p => p.Add(c => c.Slug, "test-meet"));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenMeetReturnsNull()
+    {
+        // Arrange
+        RegisterNullMeetHttpClient();
+
+        // Act
+        IRenderedComponent<EditMeetPage> cut = _context.Render<EditMeetPage>(
+            p => p.Add(c => c.Slug, "nonexistent"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<EditMeetPage> cut = _context.Render<EditMeetPage>(
+            p => p.Add(c => c.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsMeetForm_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<EditMeetPage> cut = _context.Render<EditMeetPage>(
+            p => p.Add(c => c.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("form").ShouldNotBeNull();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(bool delay = false)
+    {
+        EditMeetPageMockHandler handler = new(delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterNullMeetHttpClient()
+    {
+        NullMeetHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class EditMeetPageMockHandler(bool delay = false) : HttpMessageHandler
+    {
+        private readonly MeetDetails _meet = new(
+            MeetId: 1,
+            Title: "Test Meet",
+            Slug: "test-meet",
+            Location: "Reykjavik",
+            Text: string.Empty,
+            StartDate: new DateOnly(2024, 1, 1),
+            EndDate: null,
+            Type: "Powerlifting",
+            MeetTypeId: 1,
+            ResultMode: "Open",
+            CalculatePlaces: true,
+            IsInTeamCompetition: false,
+            ShowWilks: false,
+            ShowTeams: false,
+            ShowBodyWeight: false,
+            PublishedInCalendar: false,
+            PublishedResults: false,
+            RecordsPossible: false,
+            IsClassic: false,
+            ShowTeamPoints: false,
+            Disciplines: []);
+
+        private readonly List<MeetTypeSummary> _meetTypes =
+        [
+            new(1, "Powerlifting", "Styrktarþraut", ["Squat", "Bench", "Deadlift"]),
+        ];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (path.StartsWith("/meets/types", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(_meetTypes),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(_meet),
+            };
+        }
+    }
+
+    private sealed class NullMeetHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly List<MeetTypeSummary> _meetTypes =
+        [
+            new(1, "Powerlifting", "Styrktarþraut", ["Squat", "Bench", "Deadlift"]),
+        ];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (path.StartsWith("/meets/types", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(_meetTypes),
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/EditMeetPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/EditMeetPageTests.cs
@@ -196,12 +196,4 @@ public sealed class EditMeetPageTests : IDisposable
             });
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetDetailsPageTests.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.Web.Client.Features.Meets;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Meets;
+
+public sealed class MeetDetailsPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-meet"));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki mót...");
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenMeetReturnsNull()
+    {
+        // Arrange
+        RegisterNullMeetHttpClient();
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "nonexistent"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("Mót");
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsMeetTitle_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("h1").TextContent.ShouldBe("Test Meet");
+        });
+    }
+
+    [Fact]
+    public void DoesNotShowIpfPointLeaders_WhenNoIpfPointsPresent()
+    {
+        // Arrange
+        List<MeetParticipation> participations = [MakeParticipation(ipfPoints: 0m)];
+        RegisterHttpClient(participations: participations, calculatePlaces: true);
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("#stigahaestu").Count.ShouldBe(0);
+        });
+    }
+
+    [Fact]
+    public void ShowsIpfPointLeaders_WhenCalculatePlacesAndIpfPointsPresent()
+    {
+        // Arrange
+        List<MeetParticipation> participations = [MakeParticipation(ipfPoints: 450.5m)];
+        RegisterHttpClient(participations: participations, calculatePlaces: true);
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#stigahaestu").ShouldNotBeNull();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private static MeetParticipation MakeParticipation(decimal ipfPoints = 0m) =>
+        new(
+            ParticipationId: 1,
+            MeetId: 1,
+            Rank: 1,
+            Athlete: "Jón Jónsson",
+            AthleteSlug: "jon-jonsson",
+            Gender: "M",
+            YearOfBirth: 1990,
+            AgeCategory: "Open",
+            AgeCategorySlug: "open",
+            WeightCategory: "83",
+            Club: string.Empty,
+            ClubSlug: string.Empty,
+            BodyWeight: 82.5m,
+            Total: 600m,
+            IpfPoints: ipfPoints,
+            Disqualified: false,
+            Attempts: []);
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(
+        List<MeetParticipation>? participations = null,
+        bool calculatePlaces = false,
+        bool delay = false)
+    {
+        MeetDetailsPageMockHandler handler = new(
+            participations ?? [],
+            calculatePlaces,
+            delay);
+
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+        _context.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterNullMeetHttpClient()
+    {
+        NullMeetHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+        _context.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingMeetHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+        _context.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    private sealed class NullMeetHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FailingMeetHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetIndexTests.cs
@@ -107,12 +107,4 @@ public sealed class MeetIndexTests : IDisposable
         _context.Services.AddSingleton(httpClient);
         _context.AddAuthorization();
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetIndexTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.Web.Client.Features.Meets;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Meets;
+
+public sealed class MeetIndexTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient([], delay: true);
+
+        // Act
+        IRenderedComponent<MeetIndex> cut = _context.Render<MeetIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki mót...");
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<MeetIndex> cut = _context.Render<MeetIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsMeetItems_WhenMeetsAreLoaded()
+    {
+        // Arrange
+        List<MeetSummary> meets =
+        [
+            new("nationals-2024", "Nationals 2024", "Reykjavik", new DateOnly(2024, 3, 15)),
+            new("spring-cup-2024", "Spring Cup 2024", "Akureyri", new DateOnly(2024, 4, 20)),
+        ];
+        RegisterHttpClient(meets);
+
+        // Act
+        IRenderedComponent<MeetIndex> cut = _context.Render<MeetIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".meet-item").Count.ShouldBe(2);
+        });
+    }
+
+    [Fact]
+    public void YearNavRemainsVisible_WhileLoading()
+    {
+        // Arrange
+        RegisterHttpClient([], delay: true);
+
+        // Act
+        IRenderedComponent<MeetIndex> cut = _context.Render<MeetIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert — YearNav is outside DataLoader and always renders
+        cut.Find(".year-nav").ShouldNotBeNull();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(List<MeetSummary> meets, bool delay = false)
+    {
+        MockHttpMessageHandler<MeetSummary> handler = new(meets, delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Rankings/RankingsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Rankings/RankingsIndexTests.cs
@@ -127,12 +127,4 @@ public sealed class RankingsIndexTests : IDisposable
             };
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Rankings/RankingsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Rankings/RankingsIndexTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Rankings;
+using KRAFT.Results.Web.Client.Features.Rankings;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Rankings;
+
+public sealed class RankingsIndexTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(MakeResponse(), delay: true);
+
+        // Act
+        IRenderedComponent<RankingsIndex> cut = _context.Render<RankingsIndex>();
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki stigatöflur...");
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<RankingsIndex> cut = _context.Render<RankingsIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsRankingCards_WhenDataIsLoaded()
+    {
+        // Arrange
+        PagedResponse<RankingEntry> response = MakeResponse(items:
+        [
+            new(1, "Jón Jónsson", "jon-jonsson", "m", 200m, "83", 80m, null, 150m, "nationals-2024", true, new DateOnly(2024, 3, 15)),
+            new(2, "Sigríður Sigurðardóttir", "sigridur-sigurdardottir", "f", 180m, "63", 60m, null, 140m, "nationals-2024", true, new DateOnly(2024, 3, 15)),
+        ]);
+        RegisterHttpClient(response);
+
+        // Act
+        IRenderedComponent<RankingsIndex> cut = _context.Render<RankingsIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".rankings-list .r-card").Count.ShouldBe(2);
+        });
+    }
+
+    [Fact]
+    public void FilterBarRemainsVisible_WhileLoading()
+    {
+        // Arrange
+        RegisterHttpClient(MakeResponse(), delay: true);
+
+        // Act
+        IRenderedComponent<RankingsIndex> cut = _context.Render<RankingsIndex>();
+
+        // Assert — filter bar is outside DataLoader and always renders
+        cut.Find(".filter-bar").ShouldNotBeNull();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private static PagedResponse<RankingEntry> MakeResponse(IReadOnlyList<RankingEntry>? items = null) =>
+        new(
+            Items: items ?? [],
+            Page: 1,
+            PageSize: 50,
+            TotalCount: items?.Count ?? 0);
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(PagedResponse<RankingEntry> response, bool delay = false)
+    {
+        RankingsMockHandler handler = new(response, delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class RankingsMockHandler(PagedResponse<RankingEntry> response, bool delay = false) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(response),
+            };
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordHistoryPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordHistoryPageTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Records;
+using KRAFT.Results.Web.Client.Features.Records;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Records;
+
+public sealed class RecordHistoryPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(MakeResponse(), delay: true);
+
+        // Act
+        IRenderedComponent<RecordHistoryPage> cut = _context.Render<RecordHistoryPage>(
+            parameters => parameters.Add(p => p.Id, 1));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki sögu...");
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<RecordHistoryPage> cut = _context.Render<RecordHistoryPage>(
+            parameters => parameters.Add(p => p.Id, 1));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsRecordHistoryEntries_WhenLoaded()
+    {
+        // Arrange
+        RecordHistoryResponse response = MakeResponse(entries:
+        [
+            new(new DateOnly(2024, 1, 15), "Jón Jónsson", "jon-jonsson", 200m, 83m, "Nationals 2024", "nationals-2024", true, false, null),
+        ]);
+        RegisterHttpClient(response);
+
+        // Act
+        IRenderedComponent<RecordHistoryPage> cut = _context.Render<RecordHistoryPage>(
+            parameters => parameters.Add(p => p.Id, 1));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".rhc-list .rhc-card").Count.ShouldBe(1);
+        });
+    }
+
+    [Fact]
+    public void BreadcrumbRemainsVisible_WhileLoading()
+    {
+        // Arrange
+        RegisterHttpClient(MakeResponse(), delay: true);
+
+        // Act
+        IRenderedComponent<RecordHistoryPage> cut = _context.Render<RecordHistoryPage>(
+            parameters => parameters.Add(p => p.Id, 1));
+
+        // Assert — breadcrumb nav is outside DataLoader and always renders
+        cut.Find("nav.breadcrumb").ShouldNotBeNull();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private static RecordHistoryResponse MakeResponse(IReadOnlyList<RecordHistoryEntry>? entries = null) =>
+        new(
+            Category: "Squat",
+            WeightCategory: "83",
+            AgeCategory: "Open",
+            Gender: "M",
+            EquipmentType: "Classic",
+            Era: null,
+            Entries: entries ?? []);
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(RecordHistoryResponse response, bool delay = false)
+    {
+        RecordHistoryMockHandler handler = new(response, delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+        _context.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+        _context.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    private sealed class RecordHistoryMockHandler(RecordHistoryResponse response, bool delay = false) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(response),
+            };
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordHistoryPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordHistoryPageTests.cs
@@ -134,12 +134,4 @@ public sealed class RecordHistoryPageTests : IDisposable
             };
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordsPageTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Eras;
+using KRAFT.Results.Contracts.Records;
+using KRAFT.Results.Web.Client.Features.Records;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Records;
+
+public sealed class RecordsPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenRecordsAreBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(eras: MakeEras(), groups: MakeGroups(), delayRecords: true);
+
+        // Act
+        IRenderedComponent<RecordsPage> cut = _context.Render<RecordsPage>(
+            parameters => parameters
+                .Add(p => p.Gender, "m")
+                .Add(p => p.AgeCategory, "open"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='status']").ShouldNotBeNull();
+            cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki met...");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenRecordsFetchFails()
+    {
+        // Arrange
+        RegisterHttpClient(eras: MakeEras(), groups: null, failRecords: true);
+
+        // Act
+        IRenderedComponent<RecordsPage> cut = _context.Render<RecordsPage>(
+            parameters => parameters
+                .Add(p => p.Gender, "m")
+                .Add(p => p.AgeCategory, "open"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsRecordSections_WhenGroupsAreLoaded()
+    {
+        // Arrange
+        List<RecordGroup> groups =
+        [
+            new("Squat", [new(1, "83", "Jón Jónsson", "jon-jonsson", null, null, 200m, new DateOnly(2024, 1, 1), null, true)]),
+        ];
+        RegisterHttpClient(eras: MakeEras(), groups: groups);
+
+        // Act
+        IRenderedComponent<RecordsPage> cut = _context.Render<RecordsPage>(
+            parameters => parameters
+                .Add(p => p.Gender, "m")
+                .Add(p => p.AgeCategory, "open"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".record-section").Count.ShouldBe(1);
+        });
+    }
+
+    [Fact]
+    public void ToolbarRemainsVisible_WhileRecordsAreLoading()
+    {
+        // Arrange
+        RegisterHttpClient(eras: MakeEras(), groups: MakeGroups(), delayRecords: true);
+
+        // Act
+        IRenderedComponent<RecordsPage> cut = _context.Render<RecordsPage>(
+            parameters => parameters
+                .Add(p => p.Gender, "m")
+                .Add(p => p.AgeCategory, "open"));
+
+        // Assert — toolbar is outside DataLoader and always renders after eras load
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".records-toolbar").ShouldNotBeNull();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private static List<EraSummary> MakeEras() =>
+    [
+        new(1, "IPF Era", "ipf-era", new DateOnly(2020, 1, 1), new DateOnly(2024, 12, 31), true, false),
+    ];
+
+    private static List<RecordGroup> MakeGroups() => [];
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(
+        List<EraSummary> eras,
+        List<RecordGroup>? groups,
+        bool delayRecords = false,
+        bool failRecords = false)
+    {
+        RecordsMockHandler handler = new(eras, groups, delayRecords, failRecords);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+        _context.SetRendererInfo(new RendererInfo("WebAssembly", isInteractive: true));
+    }
+
+    private sealed class RecordsMockHandler(
+        List<EraSummary> eras,
+        List<RecordGroup>? groups,
+        bool delayRecords = false,
+        bool failRecords = false) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri?.PathAndQuery.StartsWith("/eras", StringComparison.Ordinal) == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(eras),
+                };
+            }
+
+            if (failRecords)
+            {
+                throw new HttpRequestException("Server error");
+            }
+
+            if (delayRecords)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(groups),
+            };
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -134,12 +134,4 @@ public sealed class TeamCompetitionIndexTests : IDisposable
             };
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.TeamCompetition;
+using KRAFT.Results.Web.Client.Features.TeamCompetition;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.TeamCompetition;
+
+public sealed class TeamCompetitionIndexTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(MakeResponse(), delay: true);
+
+        // Act
+        IRenderedComponent<TeamCompetitionIndex> cut = _context.Render<TeamCompetitionIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<TeamCompetitionIndex> cut = _context.Render<TeamCompetitionIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsStandings_WhenDataIsLoaded()
+    {
+        // Arrange
+        TeamCompetitionResponse response = MakeResponse(combined:
+        [
+            new(1, "Þór", "Þór", "thor", null, 100),
+            new(2, "KR", "KR", "kr", null, 80),
+        ]);
+        RegisterHttpClient(response);
+
+        // Act
+        IRenderedComponent<TeamCompetitionIndex> cut = _context.Render<TeamCompetitionIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".standings-list li").Count.ShouldBe(2);
+        });
+    }
+
+    [Fact]
+    public void YearNavRemainsVisible_WhileLoading()
+    {
+        // Arrange
+        RegisterHttpClient(MakeResponse(), delay: true);
+
+        // Act
+        IRenderedComponent<TeamCompetitionIndex> cut = _context.Render<TeamCompetitionIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert — YearNav is outside DataLoader and always renders
+        cut.Find(".year-nav").ShouldNotBeNull();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private static TeamCompetitionResponse MakeResponse(
+        IReadOnlyList<TeamCompetitionStanding>? combined = null,
+        IReadOnlyList<TeamCompetitionStanding>? women = null,
+        IReadOnlyList<TeamCompetitionStanding>? men = null) =>
+        new(
+            Year: 2024,
+            IsGenderSplit: false,
+            Women: women ?? [],
+            Men: men ?? [],
+            Combined: combined ?? []);
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(TeamCompetitionResponse response, bool delay = false)
+    {
+        TeamCompetitionMockHandler handler = new(response, delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class TeamCompetitionMockHandler(TeamCompetitionResponse response, bool delay = false) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(response),
+            };
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/CreateTeamPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/CreateTeamPageTests.cs
@@ -106,12 +106,4 @@ public sealed class CreateTeamPageTests : IDisposable
             };
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/CreateTeamPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/CreateTeamPageTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Countries;
+using KRAFT.Results.Web.Client.Features.Teams;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Teams;
+
+public sealed class CreateTeamPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<CreateTeamPage> cut = _context.Render<CreateTeamPage>();
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<CreateTeamPage> cut = _context.Render<CreateTeamPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsTeamForm_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<CreateTeamPage> cut = _context.Render<CreateTeamPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("form").ShouldNotBeNull();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(bool delay = false)
+    {
+        CreateTeamPageMockHandler handler = new(delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class CreateTeamPageMockHandler(bool delay = false) : HttpMessageHandler
+    {
+        private static readonly List<CountrySummary> DefaultCountries =
+        [
+            new("ISL", "Iceland"),
+        ];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(DefaultCountries),
+            };
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/EditTeamPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/EditTeamPageTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Countries;
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.Web.Client.Features.Teams;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Teams;
+
+public sealed class EditTeamPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<EditTeamPage> cut = _context.Render<EditTeamPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenTeamReturnsNull()
+    {
+        // Arrange
+        RegisterNullTeamHttpClient();
+
+        // Act
+        IRenderedComponent<EditTeamPage> cut = _context.Render<EditTeamPage>(
+            p => p.Add(c => c.Slug, "nonexistent"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<EditTeamPage> cut = _context.Render<EditTeamPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsTeamForm_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<EditTeamPage> cut = _context.Render<EditTeamPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("form").ShouldNotBeNull();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(bool delay = false)
+    {
+        EditTeamPageMockHandler handler = new(delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterNullTeamHttpClient()
+    {
+        NullTeamHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class EditTeamPageMockHandler(bool delay = false) : HttpMessageHandler
+    {
+        private readonly TeamDetails _team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", []);
+
+        private readonly List<CountrySummary> _countries = [new("ISL", "Iceland")];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (path.StartsWith("/countries", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(_countries),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(_team),
+            };
+        }
+    }
+
+    private sealed class NullTeamHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly List<CountrySummary> _countries = [new("ISL", "Iceland")];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (path.StartsWith("/countries", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(_countries),
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/EditTeamPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/EditTeamPageTests.cs
@@ -169,12 +169,4 @@ public sealed class EditTeamPageTests : IDisposable
             });
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.Web.Client.Features.Teams;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Teams;
+
+public sealed class TeamDetailsPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingStateInitially()
+    {
+        // Arrange
+        RegisterHttpClient(new TeamDetails("thor", "Þór", "Þór", "Þór IF", "ISL", []), delay: true);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki félag...");
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenTeamReturnsNull()
+    {
+        // Arrange
+        RegisterNullHttpClient();
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "nonexistent"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("félag");
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsTeamTitle_WhenLoaded()
+    {
+        // Arrange
+        TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", []);
+        RegisterHttpClient(team);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("h1").TextContent.ShouldContain("Þór IF");
+        });
+    }
+
+    [Fact]
+    public void ShowsMemberList_WhenTeamHasMembers()
+    {
+        // Arrange
+        TeamDetails team = new(
+            "thor",
+            "Þór IF",
+            "Þór",
+            "Þór IF",
+            "ISL",
+            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990)]);
+        RegisterHttpClient(team);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".member-list").ShouldNotBeNull();
+            cut.Find(".member-list").TextContent.ShouldContain("Jon Jonsson");
+        });
+    }
+
+    [Fact]
+    public void ShowsEmptyMembersMessage_WhenTeamHasNoMembers()
+    {
+        // Arrange
+        TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", []);
+        RegisterHttpClient(team);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".member-list").Count.ShouldBe(0);
+            cut.Find("p").TextContent.ShouldContain("Engir meðlimir");
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(TeamDetails team, bool delay = false)
+    {
+        TeamDetailsPageMockHandler handler = new(team, delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterNullHttpClient()
+    {
+        NullTeamHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class TeamDetailsPageMockHandler(TeamDetails team, bool delay = false) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(team),
+            };
+        }
+    }
+
+    private sealed class NullTeamHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -188,12 +188,4 @@ public sealed class TeamDetailsPageTests : IDisposable
             });
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -1,32 +1,32 @@
-using System.Reflection;
+using System.Net;
 
 using Bunit;
 
-using KRAFT.Results.Contracts.Users;
-using KRAFT.Results.Web.Client.Features.Users;
+using KRAFT.Results.Contracts.Teams;
+using KRAFT.Results.Web.Client.Features.Teams;
 
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 
 using Shouldly;
 
-namespace KRAFT.Results.Web.Client.Tests.Features.Users;
+namespace KRAFT.Results.Web.Client.Tests.Features.Teams;
 
-public sealed class UserIndexTests : IDisposable
+public sealed class TeamsIndexTests : IDisposable
 {
     private readonly BunitContext _context = new();
 
     [Fact]
-    public void RequiresAdminRole()
+    public void ShowsLoadingStateInitially()
     {
         // Arrange
-        AuthorizeAttribute? attribute = typeof(UserIndex).GetCustomAttribute<AuthorizeAttribute>();
+        RegisterHttpClient([], delay: true);
 
         // Act
+        IRenderedComponent<TeamsIndex> cut = _context.Render<TeamsIndex>();
 
         // Assert
-        attribute.ShouldNotBeNull();
-        attribute.Roles.ShouldBe("Admin");
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki félög...");
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public sealed class UserIndexTests : IDisposable
         RegisterFailingHttpClient();
 
         // Act
-        IRenderedComponent<UserIndex> cut = _context.Render<UserIndex>();
+        IRenderedComponent<TeamsIndex> cut = _context.Render<TeamsIndex>();
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -47,37 +47,23 @@ public sealed class UserIndexTests : IDisposable
     }
 
     [Fact]
-    public void AlwaysShowsCreateUserButtonInHeader()
+    public void ShowsTeamCards_WhenTeamsAreLoaded()
     {
         // Arrange
-        RegisterHttpClient([]);
-
-        // Act
-        IRenderedComponent<UserIndex> cut = _context.Render<UserIndex>();
-
-        // Assert
-        cut.Find("button.btn-action").ShouldNotBeNull();
-        cut.Find("button.btn-action").TextContent.ShouldContain("Stofna notanda");
-    }
-
-    [Fact]
-    public void ShowsUserTable_WhenUsersAreLoaded()
-    {
-        // Arrange
-        List<UserSummary> users =
+        List<TeamSummary> teams =
         [
-            new(1, "Jon Jonsson", "jon@example.com", DateTime.Today, ["Admin"]),
-            new(2, "Anna Karlsdottir", "anna@example.com", DateTime.Today, ["User"]),
+            new("thor", "Þór", "Þór", 12),
+            new("kr", "Kraftlyftingafélag Reykjavíkur", "KR", 5),
         ];
-        RegisterHttpClient(users);
+        RegisterHttpClient(teams);
 
         // Act
-        IRenderedComponent<UserIndex> cut = _context.Render<UserIndex>();
+        IRenderedComponent<TeamsIndex> cut = _context.Render<TeamsIndex>();
 
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.FindAll("table tbody tr").Count.ShouldBe(2);
+            cut.FindAll(".card-grid .card").Count.ShouldBe(2);
         });
     }
 
@@ -87,9 +73,9 @@ public sealed class UserIndexTests : IDisposable
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
-    private void RegisterHttpClient(List<UserSummary> users)
+    private void RegisterHttpClient(List<TeamSummary> teams, bool delay = false)
     {
-        MockHttpMessageHandler<UserSummary> handler = new(users);
+        MockHttpMessageHandler<TeamSummary> handler = new(teams, delay);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
         _context.AddAuthorization();

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -89,12 +89,4 @@ public sealed class TeamsIndexTests : IDisposable
         _context.Services.AddSingleton(httpClient);
         _context.AddAuthorization();
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Users/EditUserPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Users/EditUserPageTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+
+using Bunit;
+using Bunit.TestDoubles;
+
+using KRAFT.Results.Contracts.Users;
+using KRAFT.Results.Web.Client.Features.Users;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Users;
+
+public sealed class EditUserPageTests : IDisposable
+{
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void ShowsLoadingSpinner_WhenDataIsBeingFetched()
+    {
+        // Arrange
+        RegisterHttpClient(delay: true);
+
+        // Act
+        IRenderedComponent<EditUserPage> cut = _context.Render<EditUserPage>(
+            p => p.Add(c => c.UserId, 1));
+
+        // Assert
+        cut.Find("[role='status']").ShouldNotBeNull();
+        cut.Find(".visually-hidden").TextContent.ShouldBe("Sæki gögn...");
+    }
+
+    [Fact]
+    public void ShowsNotFoundMessage_WhenUserReturnsNull()
+    {
+        // Arrange
+        RegisterNullUserHttpClient();
+
+        // Act
+        IRenderedComponent<EditUserPage> cut = _context.Render<EditUserPage>(
+            p => p.Add(c => c.UserId, 99));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find("[role='alert']").TextContent.ShouldContain("fannst ekki");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorWithRetryButton_WhenHttpRequestFails()
+    {
+        // Arrange
+        RegisterFailingHttpClient();
+
+        // Act
+        IRenderedComponent<EditUserPage> cut = _context.Render<EditUserPage>(
+            p => p.Add(c => c.UserId, 1));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[role='alert']").ShouldNotBeNull();
+            cut.Find(".retry-btn").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsUserForm_WhenLoaded()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<EditUserPage> cut = _context.Render<EditUserPage>(
+            p => p.Add(c => c.UserId, 1));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("form").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void DisablesRoleCheckboxes_WhenEditingSelf()
+    {
+        // Arrange
+        RegisterHttpClient(currentUserId: 1);
+
+        // Act
+        IRenderedComponent<EditUserPage> cut = _context.Render<EditUserPage>(
+            p => p.Add(c => c.UserId, 1));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            IReadOnlyList<AngleSharp.Dom.IElement> roleCheckboxes = cut.FindAll("input[type='checkbox']");
+            roleCheckboxes.Count.ShouldBeGreaterThan(0);
+            bool allDisabled = roleCheckboxes.All(cb => cb.GetAttribute("disabled") != null);
+            allDisabled.ShouldBeTrue();
+        });
+    }
+
+    [Fact]
+    public void EnablesRoleCheckboxes_WhenEditingAnotherUser()
+    {
+        // Arrange
+        RegisterHttpClient(currentUserId: 2);
+
+        // Act
+        IRenderedComponent<EditUserPage> cut = _context.Render<EditUserPage>(
+            p => p.Add(c => c.UserId, 1));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            IReadOnlyList<AngleSharp.Dom.IElement> roleCheckboxes = cut.FindAll("input[type='checkbox']");
+            roleCheckboxes.Count.ShouldBeGreaterThan(0);
+            bool allEnabled = roleCheckboxes.All(cb => cb.GetAttribute("disabled") is null);
+            allEnabled.ShouldBeTrue();
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(bool delay = false, int currentUserId = 99)
+    {
+        EditUserPageMockHandler handler = new(delay);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        BunitAuthorizationContext authContext = _context.AddAuthorization();
+        authContext.SetAuthorized("test-user");
+        authContext.SetClaims(new Claim(ClaimTypes.NameIdentifier, currentUserId.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterNullUserHttpClient()
+    {
+        NullUserHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterFailingHttpClient()
+    {
+        FailingHttpMessageHandler handler = new();
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        _context.AddAuthorization();
+    }
+
+    private sealed class EditUserPageMockHandler(bool delay = false) : HttpMessageHandler
+    {
+        private readonly UserEditDetails _user = new(
+            FirstName: "Jon",
+            LastName: "Jonsson",
+            Email: "jon@example.com",
+            Roles: ["Admin"]);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (delay)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(_user),
+            };
+        }
+    }
+
+    private sealed class NullUserHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Server error");
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Users/EditUserPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Users/EditUserPageTests.cs
@@ -192,12 +192,4 @@ public sealed class EditUserPageTests : IDisposable
             });
         }
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Users/UserIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Users/UserIndexTests.cs
@@ -103,12 +103,4 @@ public sealed class UserIndexTests : IDisposable
         _context.Services.AddSingleton(httpClient);
         _context.AddAuthorization();
     }
-
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new HttpRequestException("Server error");
-        }
-    }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/MeetDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/MeetDetailsPageMockHandler.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Meets;
+
+namespace KRAFT.Results.Web.Client.Tests;
+
+internal sealed class MeetDetailsPageMockHandler(
+    List<MeetParticipation> participations,
+    bool calculatePlaces = false,
+    bool delay = false) : HttpMessageHandler
+{
+    private readonly MeetDetails _meet = new(
+        MeetId: 1,
+        Title: "Test Meet",
+        Slug: "test-meet",
+        Location: "Reykjavík",
+        Text: string.Empty,
+        StartDate: new DateOnly(2024, 3, 15),
+        EndDate: null,
+        Type: "Powerlifting",
+        MeetTypeId: 1,
+        ResultMode: "Standard",
+        CalculatePlaces: calculatePlaces,
+        IsInTeamCompetition: false,
+        ShowWilks: false,
+        ShowTeams: false,
+        ShowBodyWeight: true,
+        PublishedInCalendar: true,
+        PublishedResults: true,
+        RecordsPossible: false,
+        IsClassic: true,
+        ShowTeamPoints: false,
+        Disciplines: [Discipline.Squat, Discipline.Bench, Discipline.Deadlift]);
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (delay)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+
+        string path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+        if (path.EndsWith("/participations", StringComparison.OrdinalIgnoreCase))
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(participations),
+            };
+        }
+
+        if (path.EndsWith("/records", StringComparison.OrdinalIgnoreCase))
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new List<MeetRecordEntry>()),
+            };
+        }
+
+        if (path.EndsWith("/team-points", StringComparison.OrdinalIgnoreCase))
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create<MeetTeamPointsResponse?>(null),
+            };
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(_meet),
+        };
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/MockHttpMessageHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/MockHttpMessageHandler.cs
@@ -1,11 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
 
-using KRAFT.Results.Contracts.Athletes;
-
 namespace KRAFT.Results.Web.Client.Tests;
 
-internal sealed class MockHttpMessageHandler(List<AthleteSummary> athletes, bool delay = false) : HttpMessageHandler
+internal sealed class MockHttpMessageHandler<T>(List<T> items, bool delay = false) : HttpMessageHandler
 {
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
@@ -16,7 +14,7 @@ internal sealed class MockHttpMessageHandler(List<AthleteSummary> athletes, bool
 
         HttpResponseMessage response = new(HttpStatusCode.OK)
         {
-            Content = JsonContent.Create(athletes),
+            Content = JsonContent.Create(items),
         };
 
         return response;


### PR DESCRIPTION
## Summary

Introduces a generic `DataLoader<T>` Blazor component that encapsulates the loading/error/content lifecycle previously duplicated across 18 data-loading pages. The component derives spinner and error messages from a single Icelandic noun parameter, always offers retry on transient errors, and treats null responses as not-found.

- New `DataLoader<T>` component in `Web.Client/Components/` with four states: Loading, Loaded, Error, NotFound
- All 18 data-loading pages migrated to use `DataLoader`, eliminating per-page `_isLoading`/`_errorMessage`/`_hasError` boilerplate
- Pages with parameter-driven reloads use `@key` for idiomatic Blazor recreation
- Multi-source pages compose loads into a single delegate returning a record/tuple
- Fixed `LoadingSpinner.razor.css` bug: `var(--color-accent)` → `var(--color-primary)`
- Fixed "Seki" typo in TeamCompetitionIndex (now derived correctly as "Sæki")
- Extracted `FailingHttpMessageHandler` to shared test helper (was duplicated across 14 test files)
- 105 bUnit tests (67 new) covering all component states and page migrations

Closes #485

## Test plan

- [x] All 105 bUnit tests pass
- [x] Solution builds with 0 warnings
- [ ] Manual verification: each migrated page shows loading spinner, error with retry, and content correctly
- [ ] Manual verification: retry button re-attempts load successfully
- [ ] Manual verification: detail pages show not-found message for invalid slugs
- [ ] Manual verification: create/edit pages show error when reference data unavailable