### PR TITLE
refactor(webapi): replace GUID-named Records index with IX_Records_Slot

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Records/RecordConfiguration.cs
+++ b/src/KRAFT.Results.WebApi/Features/Records/RecordConfiguration.cs
@@ -11,7 +11,7 @@ internal sealed class RecordConfiguration : IEntityTypeConfiguration<Record>
 
         builder.HasIndex(e => new { e.IsCurrent, e.EraId }, "nci_wi_Records_3CB8ADEAD69A6DA29B4DC80D395ABC87");
 
-        builder.HasIndex(e => new { e.AgeCategoryId, e.EraId, e.RecordCategoryId, e.WeightCategoryId, e.IsRaw, e.Date }, "nci_wi_Records_40FB705E-F1AE-4E31-998B-DE4A0332DA61");
+        builder.HasIndex(e => new { e.EraId, e.AgeCategoryId, e.WeightCategoryId, e.RecordCategoryId, e.IsRaw, e.IsStandard, e.Date }, "IX_Records_Slot");
 
         builder.HasIndex(e => new { e.AttemptId, e.EraId, e.IsCurrent }, "nci_wi_Records_FCB2C18B-AF9A-44EE-BAE9-051E384EC259");
 

--- a/src/KRAFT.Results.WebApi/Migrations/20260510165518_RenameRecordsSlotIndex.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260510165518_RenameRecordsSlotIndex.Designer.cs
@@ -4,6 +4,7 @@ using KRAFT.Results.WebApi;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KRAFT.Results.WebApi.Migrations
 {
     [DbContext(typeof(ResultsDbContext))]
-    partial class ResultsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510165518_RenameRecordsSlotIndex")]
+    partial class RenameRecordsSlotIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/KRAFT.Results.WebApi/Migrations/20260510165518_RenameRecordsSlotIndex.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260510165518_RenameRecordsSlotIndex.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KRAFT.Results.WebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameRecordsSlotIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Records_EraId",
+                schema: "dbo",
+                table: "Records");
+
+            migrationBuilder.DropIndex(
+                name: "nci_wi_Records_40FB705E-F1AE-4E31-998B-DE4A0332DA61",
+                schema: "dbo",
+                table: "Records");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Records_AgeCategoryId",
+                schema: "dbo",
+                table: "Records",
+                column: "AgeCategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Records_Slot",
+                schema: "dbo",
+                table: "Records",
+                columns: new[] { "EraId", "AgeCategoryId", "WeightCategoryId", "RecordCategoryId", "IsRaw", "IsStandard", "Date" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Records_AgeCategoryId",
+                schema: "dbo",
+                table: "Records");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Records_Slot",
+                schema: "dbo",
+                table: "Records");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Records_EraId",
+                schema: "dbo",
+                table: "Records",
+                column: "EraId");
+
+            migrationBuilder.CreateIndex(
+                name: "nci_wi_Records_40FB705E-F1AE-4E31-998B-DE4A0332DA61",
+                schema: "dbo",
+                table: "Records",
+                columns: new[] { "AgeCategoryId", "EraId", "RecordCategoryId", "WeightCategoryId", "IsRaw", "Date" });
+        }
+    }
+}

--- a/src/KRAFT.Results.WebApi/Migrations/20260510171205_RenameRecordsSlotIndex.Designer.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260510171205_RenameRecordsSlotIndex.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KRAFT.Results.WebApi.Migrations
 {
     [DbContext(typeof(ResultsDbContext))]
-    [Migration("20260510165518_RenameRecordsSlotIndex")]
+    [Migration("20260510171205_RenameRecordsSlotIndex")]
     partial class RenameRecordsSlotIndex
     {
         /// <inheritdoc />

--- a/src/KRAFT.Results.WebApi/Migrations/20260510171205_RenameRecordsSlotIndex.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/20260510171205_RenameRecordsSlotIndex.cs
@@ -11,11 +11,6 @@ namespace KRAFT.Results.WebApi.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropIndex(
-                name: "IX_Records_EraId",
-                schema: "dbo",
-                table: "Records");
-
-            migrationBuilder.DropIndex(
                 name: "nci_wi_Records_40FB705E-F1AE-4E31-998B-DE4A0332DA61",
                 schema: "dbo",
                 table: "Records");
@@ -45,12 +40,6 @@ namespace KRAFT.Results.WebApi.Migrations
                 name: "IX_Records_Slot",
                 schema: "dbo",
                 table: "Records");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Records_EraId",
-                schema: "dbo",
-                table: "Records",
-                column: "EraId");
 
             migrationBuilder.CreateIndex(
                 name: "nci_wi_Records_40FB705E-F1AE-4E31-998B-DE4A0332DA61",


### PR DESCRIPTION
## Summary

- Replace cryptic GUID-named index `nci_wi_Records_40FB705E-…` with `IX_Records_Slot` on `(EraId, AgeCategoryId, WeightCategoryId, RecordCategoryId, IsRaw, IsStandard, Date)`
- Add `IsStandard` as a key column to enable full seek support for `GetLatestStandardRecordAsync`
- Handle FK index swap: drop redundant `IX_Records_EraId`, create `IX_Records_AgeCategoryId`

Closes #382

## Test plan

- [ ] `dotnet build` passes with zero warnings
- [ ] Migration `Up` creates `IX_Records_Slot` and drops old GUID index
- [ ] Migration `Down` restores original GUID index and FK indexes
- [ ] Run locally with `dotnet run --project src/KRAFT.Results.AppHost` and verify records computation works