### PR TITLE
style(web): add active variant, mobile responsive, and focus-ring refinements to MeetCard

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/MeetCard.razor
+++ b/src/KRAFT.Results.Web.Client/Components/MeetCard.razor
@@ -4,7 +4,7 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Routing
 
-<article class="meet-card @(IsFuture ? "meet-card--ghost" : "") @(_isLinked ? "meet-card--linked" : "")">
+<article class="meet-card @(_variant) @(_isLinked ? "meet-card--linked" : "")">
     <div class="meet-card-header">
         <time class="meet-card-date" datetime="@Meet.StartDate.ToString("yyyy-MM-dd")">
             @Meet.StartDate.ToString("dd. MMM yyyy")
@@ -70,11 +70,19 @@
     private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
 
     private bool _hasParticipants;
+    private string _variant = "";
     private bool _isLinked;
 
     protected override void OnParametersSet()
     {
         _hasParticipants = Meet.ParticipantCount > 0;
+        _variant = (IsFuture, _hasParticipants) switch
+        {
+            (true, true) => "meet-card--active",
+            (true, false) => "meet-card--ghost",
+            (false, false) => "meet-card--ghost",
+            _ => "",
+        };
     }
 
     protected override async Task OnParametersSetAsync()

--- a/src/KRAFT.Results.Web.Client/Components/MeetCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/MeetCard.razor.css
@@ -1,17 +1,19 @@
 .meet-card {
     position: relative;
+    max-width: 40rem;
     background: var(--color-white);
     border: 1px solid var(--color-border);
     border-inline-start: 4px solid var(--color-primary);
     border-radius: var(--radius-md);
     padding-block: 1rem;
     padding-inline: 1.25rem;
+    margin-block-end: 0.75rem;
     box-shadow: var(--shadow-sm);
     transition: transform var(--transition-base) ease,
                 box-shadow var(--transition-base) ease;
     cursor: default;
 
-    &:focus-within {
+    &:has(:focus-visible) {
         outline: 2px solid var(--color-primary);
         outline-offset: 2px;
     }
@@ -27,10 +29,19 @@
     }
 }
 
+.meet-card--active {
+    background: var(--color-primary-light);
+    border-inline-start-color: var(--color-primary);
+
+    & .meet-card-count {
+        color: var(--color-primary);
+        font-weight: 600;
+    }
+}
+
 .meet-card--ghost {
     background: transparent;
     border: 1px dashed var(--color-border);
-    border-inline-start: 4px dashed var(--color-text-muted);
     box-shadow: none;
 
     & .meet-card-title-link,
@@ -159,6 +170,24 @@
 
 ::deep a.meet-card-title-link:hover {
     color: var(--color-primary);
+}
+
+@media (max-width: 480px) {
+    .meet-card {
+        padding-inline: 1rem;
+    }
+
+    .meet-card-header {
+        flex-direction: column;
+    }
+
+    .meet-card-title-text {
+        white-space: normal;
+    }
+
+    ::deep a.meet-card-title-link {
+        white-space: normal;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
@@ -2,3 +2,4 @@
     border-block-end: 1px solid var(--color-border);
     margin-block-end: 1rem;
 }
+

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/MeetCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/MeetCardTests.cs
@@ -36,7 +36,7 @@ public sealed class MeetCardTests : IDisposable
     public void DoesNotHaveGhostModifier_WhenPastMeet()
     {
         // Arrange
-        MeetSummary meet = MakePastMeet();
+        MeetSummary meet = MakePastMeet(participantCount: 10);
 
         // Act
         IRenderedComponent<MeetCard> cut = _context.Render<MeetCard>(
@@ -47,7 +47,21 @@ public sealed class MeetCardTests : IDisposable
     }
 
     [Fact]
-    public void HasGhostModifier_WhenFutureMeet()
+    public void HasGhostModifier_WhenPastMeetWithNoParticipants()
+    {
+        // Arrange
+        MeetSummary meet = MakePastMeet();
+
+        // Act
+        IRenderedComponent<MeetCard> cut = _context.Render<MeetCard>(
+            p => p.Add(c => c.Meet, meet));
+
+        // Assert
+        cut.FindAll("article.meet-card--ghost").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HasGhostModifier_WhenFutureMeetWithNoParticipants()
     {
         // Arrange
         MeetSummary meet = MakeFutureMeet();
@@ -59,6 +73,21 @@ public sealed class MeetCardTests : IDisposable
 
         // Assert
         cut.Find("article.meet-card--ghost").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HasActiveModifier_WhenFutureMeetWithParticipants()
+    {
+        // Arrange
+        MeetSummary meet = MakeFutureMeet(participantCount: 15);
+
+        // Act
+        IRenderedComponent<MeetCard> cut = _context.Render<MeetCard>(
+            p => p.Add(c => c.Meet, meet)
+                  .Add(c => c.IsFuture, true));
+
+        // Assert
+        cut.Find("article.meet-card--active").ShouldNotBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add `meet-card--active` variant for future meets with participants (primary-light background, bold count)
- Add 480px mobile breakpoint — stacked header, text wrapping
- Switch focus ring from `:focus-within` to `:has(:focus-visible)` for keyboard-only visibility
- Cap card width at 40rem, add bottom margin, simplify ghost border

## Test plan

- [ ] Verify future meets with participants show the active highlight
- [ ] Verify future meets without participants and past meets without participants show ghost style
- [ ] Verify past meets with participants show default style
- [ ] Resize below 480px — header stacks, title wraps
- [ ] Tab through meet cards — focus ring appears only on keyboard navigation