### PR TITLE
fix(webapi): filter dashboard to current records, add empty states and a11y

### DIFF
--- a/src/KRAFT.Results.AppHost/KRAFT.Results.AppHost.csproj
+++ b/src/KRAFT.Results.AppHost/KRAFT.Results.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.2">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/KRAFT.Results.Contracts/Dashboard/DashboardSummary.cs
+++ b/src/KRAFT.Results.Contracts/Dashboard/DashboardSummary.cs
@@ -10,7 +10,7 @@ public sealed record DashboardSummary(
     IReadOnlyList<MeetSummary> UpcomingMeets,
     IReadOnlyList<RankingEntry> TopRankingsMen,
     IReadOnlyList<RankingEntry> TopRankingsWomen,
-    IReadOnlyList<DashboardRecordEntry> RecentRecordsMen,
-    IReadOnlyList<DashboardRecordEntry> RecentRecordsWomen,
+    IReadOnlyList<DashboardRecordEntry> LatestRecordsMen,
+    IReadOnlyList<DashboardRecordEntry> LatestRecordsWomen,
     IReadOnlyList<TeamCompetitionStanding> TeamStandingsMen,
     IReadOnlyList<TeamCompetitionStanding> TeamStandingsWomen);

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -114,48 +114,62 @@
             <div class="split-columns">
                 <div class="split-col">
                     <div class="split-col-header">Karlar</div>
-                    @foreach (DashboardRecordEntry record in context.LatestRecordsMen)
+                    @if (context.LatestRecordsMen.Count == 0)
                     {
-                        <div class="record-item">
-                            <div class="record-left">
-                                <div class="record-top">
-                                    <span class="record-lift">@record.Lift</span>
-                                    <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
+                        <p class="empty-col">Engin gildandi met skráð</p>
+                    }
+                    else
+                    {
+                        @foreach (DashboardRecordEntry record in context.LatestRecordsMen)
+                        {
+                            <div class="record-item">
+                                <div class="record-left">
+                                    <div class="record-top">
+                                        <span class="record-lift">@record.Lift</span>
+                                        <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
+                                    </div>
+                                    <div class="record-meta">
+                                        <span class="badge">@record.WeightCategory</span>
+                                        <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
+                                        <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
+                                    </div>
                                 </div>
-                                <div class="record-meta">
-                                    <span class="badge">@record.WeightCategory</span>
-                                    <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
-                                    <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
+                                <div class="record-right">
+                                    <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")" aria-label="@($"{record.AthleteName} — {record.Lift} — {record.Weight} kg")">@record.Weight kg</NavLink>
+                                    <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
                                 </div>
                             </div>
-                            <div class="record-right">
-                                <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")">@record.Weight kg</NavLink>
-                                <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
-                            </div>
-                        </div>
+                        }
                     }
                 </div>
                 <div class="split-col">
                     <div class="split-col-header">Konur</div>
-                    @foreach (DashboardRecordEntry record in context.LatestRecordsWomen)
+                    @if (context.LatestRecordsWomen.Count == 0)
                     {
-                        <div class="record-item">
-                            <div class="record-left">
-                                <div class="record-top">
-                                    <span class="record-lift">@record.Lift</span>
-                                    <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
+                        <p class="empty-col">Engin gildandi met skráð</p>
+                    }
+                    else
+                    {
+                        @foreach (DashboardRecordEntry record in context.LatestRecordsWomen)
+                        {
+                            <div class="record-item">
+                                <div class="record-left">
+                                    <div class="record-top">
+                                        <span class="record-lift">@record.Lift</span>
+                                        <NavLink class="record-athlete" href="@($"/athletes/{record.AthleteSlug}")">@record.AthleteName</NavLink>
+                                    </div>
+                                    <div class="record-meta">
+                                        <span class="badge">@record.WeightCategory</span>
+                                        <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
+                                        <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
+                                    </div>
                                 </div>
-                                <div class="record-meta">
-                                    <span class="badge">@record.WeightCategory</span>
-                                    <span class="badge">@record.AgeCategory.ToAgeCategoryLabel()</span>
-                                    <span class="badge badge--@(record.IsClassic ? "classic" : "equipped")">@DisplayNames.EquipmentType(record.IsClassic)</span>
+                                <div class="record-right">
+                                    <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")" aria-label="@($"{record.AthleteName} — {record.Lift} — {record.Weight} kg")">@record.Weight kg</NavLink>
+                                    <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
                                 </div>
                             </div>
-                            <div class="record-right">
-                                <NavLink class="record-weight" href="@($"/meets/{record.MeetSlug}")">@record.Weight kg</NavLink>
-                                <span class="record-date">@record.MeetDate.ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture)</span>
-                            </div>
-                        </div>
+                        }
                     }
                 </div>
             </div>

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -108,13 +108,13 @@
 
         <div class="widget">
             <div class="widget-header">
-                <h2 class="widget-title">Ný met</h2>
+                <h2 class="widget-title">Nýjustu met</h2>
                 <NavLink class="widget-link" href="/records">Allt →</NavLink>
             </div>
             <div class="split-columns">
                 <div class="split-col">
                     <div class="split-col-header">Karlar</div>
-                    @foreach (DashboardRecordEntry record in context.RecentRecordsMen)
+                    @foreach (DashboardRecordEntry record in context.LatestRecordsMen)
                     {
                         <div class="record-item">
                             <div class="record-left">
@@ -137,7 +137,7 @@
                 </div>
                 <div class="split-col">
                     <div class="split-col-header">Konur</div>
-                    @foreach (DashboardRecordEntry record in context.RecentRecordsWomen)
+                    @foreach (DashboardRecordEntry record in context.LatestRecordsWomen)
                     {
                         <div class="record-item">
                             <div class="record-left">

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -87,21 +87,35 @@
             <div class="split-columns">
                 <div class="split-col">
                     <div class="split-col-header">Karlar</div>
-                    <div class="ranking-list">
-                        @foreach (RankingEntry entry in context.TopRankingsMen)
-                        {
-                            <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
-                        }
-                    </div>
+                    @if (context.TopRankingsMen.Count == 0)
+                    {
+                        <p class="empty-col">Engin úrslit skráð</p>
+                    }
+                    else
+                    {
+                        <div class="ranking-list">
+                            @foreach (RankingEntry entry in context.TopRankingsMen)
+                            {
+                                <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
+                            }
+                        </div>
+                    }
                 </div>
                 <div class="split-col">
                     <div class="split-col-header">Konur</div>
-                    <div class="ranking-list">
-                        @foreach (RankingEntry entry in context.TopRankingsWomen)
-                        {
-                            <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
-                        }
-                    </div>
+                    @if (context.TopRankingsWomen.Count == 0)
+                    {
+                        <p class="empty-col">Engin úrslit skráð</p>
+                    }
+                    else
+                    {
+                        <div class="ranking-list">
+                            @foreach (RankingEntry entry in context.TopRankingsWomen)
+                            {
+                                <RankingCard Entry="entry" DisciplineLabel="Kraftlyftingar" IpfPointsHref="@($"/meets/{entry.MeetSlug}")" />
+                            }
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/src/KRAFT.Results.WebApi/Features/Dashboard/GetDashboard/GetDashboardHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Dashboard/GetDashboard/GetDashboardHandler.cs
@@ -41,8 +41,8 @@ internal sealed class GetDashboardHandler(ResultsDbContext dbContext)
         List<RankingEntry> rankingsMen = await GetTopRankingsAsync("m", currentYear, cancellationToken);
         List<RankingEntry> rankingsWomen = await GetTopRankingsAsync("f", currentYear, cancellationToken);
 
-        List<DashboardRecordEntry> recordsMen = await GetRecentRecordsAsync("m", cancellationToken);
-        List<DashboardRecordEntry> recordsWomen = await GetRecentRecordsAsync("f", cancellationToken);
+        List<DashboardRecordEntry> recordsMen = await GetLatestRecordsAsync("m", cancellationToken);
+        List<DashboardRecordEntry> recordsWomen = await GetLatestRecordsAsync("f", cancellationToken);
 
         (List<TeamCompetitionStanding> teamsMen, List<TeamCompetitionStanding> teamsWomen) =
             await GetTeamStandingsAsync(currentYear, cancellationToken);
@@ -93,7 +93,9 @@ internal sealed class GetDashboardHandler(ResultsDbContext dbContext)
             .CountAsync(cancellationToken);
 
         int records = await dbContext.Set<Record>()
-            .Where(r => r.AttemptId != null && r.Date.Year == year)
+            .Where(r => r.AttemptId != null)
+            .Where(r => r.IsCurrent)
+            .Where(r => r.Date.Year == year)
             .CountAsync(cancellationToken);
 
         int clubs = await dbContext.Set<Participation>()
@@ -157,15 +159,17 @@ internal sealed class GetDashboardHandler(ResultsDbContext dbContext)
             .ToList();
     }
 
-    private async Task<List<DashboardRecordEntry>> GetRecentRecordsAsync(
+    private async Task<List<DashboardRecordEntry>> GetLatestRecordsAsync(
         string gender, CancellationToken cancellationToken)
     {
         List<RawRecordRow> rows = await dbContext.Set<Record>()
             .Where(r => r.AttemptId != null)
+            .Where(r => r.IsCurrent)
             .Where(r => r.RecordCategoryId != RecordCategory.TotalWilks
                      && r.RecordCategoryId != RecordCategory.TotalIpfPoints)
             .Where(r => r.Attempt!.Participation.Athlete.Gender == Gender.Parse(gender))
             .OrderByDescending(r => r.Date)
+            .ThenBy(r => Guid.NewGuid())
             .Take(3)
             .Select(r => new RawRecordRow(
                 r.RecordCategoryId,

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/GetDashboardRecordsTestsCollection.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/GetDashboardRecordsTestsCollection.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+[CollectionDefinition(nameof(GetDashboardRecordsTestsCollection))]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "xUnit collection definition")]
+public sealed class GetDashboardRecordsTestsCollection : ICollectionFixture<CollectionFixture>
+{
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardRecordFilterTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardRecordFilterTests.cs
@@ -1,0 +1,185 @@
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts;
+using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Contracts.Dashboard;
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.Features.Records.ComputeRecords;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+using KRAFT.Results.WebApi.IntegrationTests.Collections;
+using KRAFT.Results.WebApi.ValueObjects;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Dashboard;
+
+/// <summary>
+/// Tests that the dashboard filters to only current (IsCurrent=true) records.
+///
+/// Setup: one female athlete sets records in a meet, then we directly mark her squat record
+/// as IsCurrent=false (simulating it having been superseded).  With the IsCurrent filter
+/// absent, the superseded squat record would appear among the latest-records widget entries
+/// because there are so few female records in the test DB (fewer than 3 current ones).
+/// </summary>
+[Collection(nameof(GetDashboardRecordsTestsCollection))]
+public sealed class GetDashboardRecordFilterTests(CollectionFixture fixture) : IAsyncLifetime
+{
+    private const string DashboardPath = "/dashboard";
+    private const string MeetsPath = "/meets";
+
+    private const decimal SquatWeight = 62.5m;
+
+    // 63f weight category (body weight 57.01–63.00 kg)
+    private const decimal BodyWeight63f = 60.0m;
+
+    private readonly string _suffix = UniqueShortCode.Next();
+    private readonly List<string> _athleteSlugs = [];
+    private readonly List<string> _meetSlugs = [];
+    private readonly List<(int MeetId, int ParticipationId)> _participations = [];
+    private HttpClient _httpClient = null!;
+    private HttpClient _authorizedHttpClient = null!;
+    private RecordComputationChannel _channel = null!;
+    private int _meetId;
+
+    public async ValueTask InitializeAsync()
+    {
+        _httpClient = fixture.Factory!.CreateClient();
+        (_authorizedHttpClient, _channel) = fixture.CreateAuthorizedHttpClientWithRecordComputation();
+
+        string firstName = $"DF{_suffix}";
+        string lastName = "Rc";
+
+        CreateAthleteCommand athleteCommand = new CreateAthleteCommandBuilder()
+            .WithFirstName(firstName)
+            .WithLastName(lastName)
+            .WithGender("f")
+            .WithDateOfBirth(new DateOnly(1990, 1, 1))
+            .Build();
+
+        HttpResponseMessage athleteResponse = await _authorizedHttpClient.PostAsJsonAsync(
+            "/athletes", athleteCommand, CancellationToken.None);
+        athleteResponse.EnsureSuccessStatusCode();
+        _athleteSlugs.Add(Slug.Create($"{firstName} {lastName}"));
+
+        _meetId = await CreateMeetAndGetIdAsync(new DateOnly(2022, 6, 1), isRaw: false);
+
+        int participationId = await AddParticipantAsync(_meetId, Slug.Create($"{firstName} {lastName}"), BodyWeight63f);
+        _participations.Add((_meetId, participationId));
+
+        // Record all 3 lifts to produce a valid total and create records (squat, bench, deadlift, total, singles)
+        await RecordAttemptAsync(_meetId, participationId, Discipline.Squat, 1, SquatWeight);
+        await RecordAttemptAsync(_meetId, participationId, Discipline.Bench, 1, 40.0m);
+        await RecordAttemptAsync(_meetId, participationId, Discipline.Deadlift, 1, 80.0m);
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Simulate the squat record being superseded: mark it IsCurrent=false directly.
+        // Filter by meetId to avoid affecting records from other test runs.
+        // This is the scenario the dashboard IsCurrent filter must handle.
+        await fixture.ExecuteSqlAsync(
+            $"""
+            UPDATE r
+            SET r.IsCurrent = 0
+            FROM Records r
+            INNER JOIN Attempts a ON a.AttemptId = r.AttemptId
+            INNER JOIN Participations p ON p.ParticipationId = a.ParticipationId
+            WHERE p.MeetId = {_meetId}
+              AND r.RecordCategoryId = 1
+              AND r.IsCurrent = 1
+            """);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach ((int meetId, int participationId) in _participations)
+        {
+            await _authorizedHttpClient.DeleteAsync(
+                $"{MeetsPath}/{meetId}/participants/{participationId}", CancellationToken.None);
+        }
+
+        foreach (string slug in _meetSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"{MeetsPath}/{slug}", CancellationToken.None);
+        }
+
+        foreach (string slug in _athleteSlugs)
+        {
+            await _authorizedHttpClient.DeleteAsync($"/athletes/{slug}", CancellationToken.None);
+        }
+
+        _authorizedHttpClient.Dispose();
+        _httpClient.Dispose();
+    }
+
+    [Fact]
+    public async Task LatestRecordsWomen_ExcludesSupersededRecord()
+    {
+        // Arrange
+        // The athlete's squat record at SquatWeight was marked IsCurrent=false in InitializeAsync,
+        // simulating a superseded record. Without the IsCurrent filter in the query, this record
+        // would appear among the top-3 female records (the test DB has very few female records).
+
+        // Act
+        DashboardSummary? result = await _httpClient.GetFromJsonAsync<DashboardSummary>(
+            DashboardPath, CancellationToken.None);
+
+        // Assert
+        DashboardSummary dashboard = result.ShouldNotBeNull();
+        dashboard.LatestRecordsWomen.ShouldNotContain(r => r.Weight == SquatWeight);
+    }
+
+    private async Task<int> CreateMeetAndGetIdAsync(DateOnly startDate, bool isRaw)
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder()
+            .WithStartDate(startDate)
+            .WithIsRaw(isRaw)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            MeetsPath, command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+        _meetSlugs.Add(slug);
+
+        MeetDetails? meetDetails = await _authorizedHttpClient.GetFromJsonAsync<MeetDetails>(
+            $"{MeetsPath}/{slug}", CancellationToken.None);
+
+        return meetDetails!.MeetId;
+    }
+
+    private async Task<int> AddParticipantAsync(int meetId, string athleteSlug, decimal bodyWeight)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder()
+            .WithAthleteSlug(athleteSlug)
+            .WithBodyWeight(bodyWeight)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PostAsJsonAsync(
+            $"{MeetsPath}/{meetId}/participants", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+
+        return result!.ParticipationId;
+    }
+
+    private async Task RecordAttemptAsync(
+        int meetId,
+        int participationId,
+        Discipline discipline,
+        int round,
+        decimal weight)
+    {
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(weight)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedHttpClient.PutAsJsonAsync(
+            $"{MeetsPath}/{meetId}/participants/{participationId}/attempts/{(int)discipline}/{round}",
+            command,
+            CancellationToken.None);
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
@@ -90,8 +90,8 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
         result.UpcomingMeets.ShouldNotBeNull();
         result.TopRankingsMen.ShouldNotBeNull();
         result.TopRankingsWomen.ShouldNotBeNull();
-        result.RecentRecordsMen.ShouldNotBeNull();
-        result.RecentRecordsWomen.ShouldNotBeNull();
+        result.LatestRecordsMen.ShouldNotBeNull();
+        result.LatestRecordsWomen.ShouldNotBeNull();
         result.TeamStandingsMen.ShouldNotBeNull();
         result.TeamStandingsWomen.ShouldNotBeNull();
     }


### PR DESCRIPTION
## Summary

- Add `IsCurrent` filter to both the season stats record count and the latest records widget in `GetDashboardHandler`
- Add `NEWID()` random tiebreak (`.ThenBy(r => Guid.NewGuid())`) for same-date records in the widget
- Rename `RecentRecordsMen`/`RecentRecordsWomen` → `LatestRecordsMen`/`LatestRecordsWomen` in `DashboardSummary` contract
- Rename `GetRecentRecordsAsync` → `GetLatestRecordsAsync` in the handler
- Update widget heading from "Ný met" to "Nýjustu met" in `DashboardPage.razor`
- Add empty-state guards to records and rankings widgets ("Engin gildandi met skráð" / "Engin úrslit skráð")
- Add `aria-label` to record weight links for screen reader accessibility
- Add `GetDashboardRecordFilterTests` integration test proving superseded records are excluded
- Update `GetDashboardTests` assertions for renamed contract properties

## Test plan

- [ ] `GetDashboardRecordFilterTests.LatestRecordsWomen_ExcludesSupersededRecord` — seeds a female athlete with records, marks the squat record `IsCurrent=false` via SQL, asserts it does not appear in `LatestRecordsWomen`
- [ ] `GetDashboardTests.Deserializes` — updated to reference renamed contract properties
- [ ] Dashboard loads with records showing only current (still-standing) records
- [ ] Dashboard displays empty-state message when no records/rankings exist
- [ ] Screen reader announces full context (athlete, lift, weight) on record weight links

Closes #491