### PR TITLE
refactor(web): extend Card component with clickable, compact, and CssClass variants

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/Card.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor
@@ -1,4 +1,4 @@
-<article class="card @(_classes)">
+<article class="@_classes">
     @ChildContent
 </article>
 
@@ -14,6 +14,7 @@
     {
         _classes = string.Join(" ",
             new[] {
+                "card",
                 Clickable ? "card--clickable" : null,
                 Compact ? "card--compact" : null,
                 CssClass

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor
@@ -1,7 +1,22 @@
-<article class="card">
+<article class="card @(_classes)">
     @ChildContent
 </article>
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public bool Clickable { get; set; }
+    [Parameter] public bool Compact { get; set; }
+    [Parameter] public string? CssClass { get; set; }
+
+    private string _classes = "";
+
+    protected override void OnParametersSet()
+    {
+        _classes = string.Join(" ",
+            new[] {
+                Clickable ? "card--clickable" : null,
+                Compact ? "card--compact" : null,
+                CssClass
+            }.Where(c => !string.IsNullOrEmpty(c)));
+    }
 }

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -24,10 +24,6 @@
         outline-offset: 2px;
     }
 
-    &:has(:focus-visible) ::deep a:focus-visible {
-        outline: none;
-    }
-
     ::deep a {
         position: static;
     }

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -6,23 +6,48 @@
     padding: 1.25rem 1.5rem;
     background: var(--color-white);
     box-shadow: var(--shadow-sm);
+}
+
+.card--clickable {
+    cursor: pointer;
     transition: transform var(--transition-base) ease,
                 box-shadow var(--transition-base) ease;
-    cursor: pointer;
 
     &:hover,
     &:focus-within {
         transform: translateY(-4px);
         box-shadow: var(--shadow-lg);
     }
+
+    &:has(:focus-visible) {
+        outline: 2px solid var(--color-primary);
+        outline-offset: 2px;
+    }
+
+    &:has(:focus-visible) ::deep a:focus-visible {
+        outline: none;
+    }
+
+    ::deep a {
+        position: static;
+    }
+
+    ::deep a::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+    }
 }
 
-::deep a {
-    position: static;
+.card--compact {
+    padding: 0.75rem 1rem;
 }
 
-::deep a::after {
-    content: "";
-    position: absolute;
-    inset: 0;
+@media (prefers-reduced-motion: reduce) {
+    .card--clickable {
+        &:hover,
+        &:focus-within {
+            transform: none;
+        }
+    }
 }

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -41,6 +41,8 @@
 
 @media (prefers-reduced-motion: reduce) {
     .card--clickable {
+        transition: none;
+
         &:hover,
         &:focus-within {
             transform: none;

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -23,16 +23,16 @@
         outline: 2px solid var(--color-primary);
         outline-offset: 2px;
     }
+}
 
-    ::deep a {
-        position: static;
-    }
+.card--clickable ::deep a {
+    position: static;
+}
 
-    ::deep a::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-    }
+.card--clickable ::deep a::after {
+    content: "";
+    position: absolute;
+    inset: 0;
 }
 
 .card--compact {

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordsIndex.razor
@@ -24,43 +24,43 @@
 <section class="gender-section">
     <h2>@("m".ToGenderGroupLabel())</h2>
     <div class="category-grid">
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("m", "open")">
                 <span class="card-label-name">@("open".ToAgeCategoryLabel("m"))</span>
                 <span class="card-label-range">@("open".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("m", "subjunior")">
                 <span class="card-label-name">@("subjunior".ToAgeCategoryLabel("m"))</span>
                 <span class="card-label-range">@("subjunior".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("m", "junior")">
                 <span class="card-label-name">@("junior".ToAgeCategoryLabel("m"))</span>
                 <span class="card-label-range">@("junior".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("m", "masters1")">
                 <span class="card-label-name">@("masters1".ToAgeCategoryLabel("m"))</span>
                 <span class="card-label-range">@("masters1".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("m", "masters2")">
                 <span class="card-label-name">@("masters2".ToAgeCategoryLabel("m"))</span>
                 <span class="card-label-range">@("masters2".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("m", "masters3")">
                 <span class="card-label-name">@("masters3".ToAgeCategoryLabel("m"))</span>
                 <span class="card-label-range">@("masters3".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("m", "masters4")">
                 <span class="card-label-name">@("masters4".ToAgeCategoryLabel("m"))</span>
                 <span class="card-label-range">@("masters4".ToAgeCategoryAgeRange())</span>
@@ -72,43 +72,43 @@
 <section class="gender-section">
     <h2>@("f".ToGenderGroupLabel())</h2>
     <div class="category-grid">
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("f", "open")">
                 <span class="card-label-name">@("open".ToAgeCategoryLabel("f"))</span>
                 <span class="card-label-range">@("open".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("f", "subjunior")">
                 <span class="card-label-name">@("subjunior".ToAgeCategoryLabel("f"))</span>
                 <span class="card-label-range">@("subjunior".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("f", "junior")">
                 <span class="card-label-name">@("junior".ToAgeCategoryLabel("f"))</span>
                 <span class="card-label-range">@("junior".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("f", "masters1")">
                 <span class="card-label-name">@("masters1".ToAgeCategoryLabel("f"))</span>
                 <span class="card-label-range">@("masters1".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("f", "masters2")">
                 <span class="card-label-name">@("masters2".ToAgeCategoryLabel("f"))</span>
                 <span class="card-label-range">@("masters2".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("f", "masters3")">
                 <span class="card-label-name">@("masters3".ToAgeCategoryLabel("f"))</span>
                 <span class="card-label-range">@("masters3".ToAgeCategoryAgeRange())</span>
             </NavLink>
         </Card>
-        <Card>
+        <Card Clickable="true">
             <NavLink class="card-link" href="@GetRecordUrl("f", "masters4")">
                 <span class="card-label-name">@("masters4".ToAgeCategoryLabel("f"))</span>
                 <span class="card-label-range">@("masters4".ToAgeCategoryAgeRange())</span>

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
@@ -14,7 +14,7 @@
         <div class="card-grid">
             @foreach (TeamSummary team in context)
             {
-                <Card>
+                <Card Clickable="true">
                     <a href="@($"/teams/{team.Slug}")" aria-label="@team.Title"></a>
                     <div class="team-name">@team.Title</div>
                     <div class="team-short">@team.ShortTitle</div>


### PR DESCRIPTION
## Summary

- Extended the shared `Card.razor` component with `Clickable`, `Compact`, and `CssClass` parameters
- Restructured `Card.razor.css` so the base card is static by default; clickable behavior is opt-in via `.card--clickable` modifier
- Updated all existing consumers (TeamsIndex, RecordsIndex) to pass `Clickable="true"`
- Added focus indicator fallback, clean class composition, and self-sufficient reduced-motion handling
- Fixed `::deep` overlay rules to use flat selectors (Blazor CSS isolation doesn't process `::deep` inside CSS nesting blocks)

Closes #501

## Test plan

- [x] Default `<Card>` renders static: white bg, primary left border, shadow, no hover-lift, default cursor
- [x] `<Card Clickable="true">` shows pointer cursor and lift animation on hover
- [x] Clicking anywhere on a clickable card navigates (not just the link text)
- [x] `<Card Compact="true">` renders with tighter padding (0.75rem / 1rem)
- [x] `<Card CssClass="test">` appends "test" to the rendered class attribute
- [x] TeamsIndex cards remain clickable with hover-lift
- [x] RecordsIndex cards remain clickable with hover-lift
- [x] Keyboard tab into clickable card shows focus ring on the card
- [x] With OS reduced-motion enabled, clickable card hover shows no transform or transition
- [x] `dotnet build` passes with 0 warnings