### PR TITLE
refactor(web): migrate feature cards to shared Card component

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -2,9 +2,9 @@
     position: relative;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
-    border-inline-start: 4px solid var(--color-primary);
+    border-inline-start: 4px solid var(--card-accent, var(--color-primary));
     padding: 1.25rem 1.5rem;
-    background: var(--color-white);
+    background: var(--card-bg, var(--color-white));
     box-shadow: var(--shadow-sm);
 }
 

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -3,7 +3,7 @@
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     border-inline-start: 4px solid var(--card-accent, var(--color-primary));
-    padding: 1.25rem 1.5rem;
+    padding: var(--card-padding, 1.25rem 1.5rem);
     background: var(--card-bg, var(--color-white));
     box-shadow: var(--shadow-sm);
 }
@@ -36,7 +36,7 @@
 }
 
 .card--compact {
-    padding: 0.75rem 1rem;
+    --card-padding: 0.75rem 1rem;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -1,11 +1,11 @@
 .card {
     position: relative;
-    border: 1px solid var(--color-border);
+    border: var(--card-border, 1px solid var(--color-border));
     border-radius: var(--radius-md);
-    border-inline-start: 4px solid var(--card-accent, var(--color-primary));
+    border-inline-start: var(--card-border-start, 4px solid var(--card-accent, var(--color-primary)));
     padding: var(--card-padding, 1.25rem 1.5rem);
     background: var(--card-bg, var(--color-white));
-    box-shadow: var(--shadow-sm);
+    box-shadow: var(--card-shadow, var(--shadow-sm));
 }
 
 .card--clickable {
@@ -15,8 +15,8 @@
 
     &:hover,
     &:focus-within {
-        transform: translateY(-4px);
-        box-shadow: var(--shadow-lg);
+        transform: var(--card-hover-transform, translateY(-4px));
+        box-shadow: var(--card-hover-shadow, var(--shadow-lg));
     }
 
     &:has(:focus-visible) {

--- a/src/KRAFT.Results.Web.Client/Components/MeetCard.razor
+++ b/src/KRAFT.Results.Web.Client/Components/MeetCard.razor
@@ -4,7 +4,7 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Routing
 
-<article class="meet-card @(_variant) @(_isLinked ? "meet-card--linked" : "")">
+<Card Clickable="@_isLinked" CssClass="@_cardClasses">
     <div class="meet-card-header">
         <time class="meet-card-date" datetime="@Meet.StartDate.ToString("yyyy-MM-dd")">
             @Meet.StartDate.ToString("dd. MMM yyyy")
@@ -57,7 +57,7 @@
             </AuthorizeView>
         }
     </div>
-</article>
+</Card>
 
 @code {
     [Parameter, EditorRequired]
@@ -72,6 +72,7 @@
     private bool _hasParticipants;
     private string _variant = "";
     private bool _isLinked;
+    private string _cardClasses = "meet-card";
 
     protected override void OnParametersSet()
     {
@@ -83,6 +84,7 @@
             (false, false) => "meet-card--ghost",
             _ => "",
         };
+        _cardClasses = string.IsNullOrEmpty(_variant) ? "meet-card" : $"meet-card {_variant}";
     }
 
     protected override async Task OnParametersSetAsync()

--- a/src/KRAFT.Results.Web.Client/Components/MeetCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/MeetCard.razor.css
@@ -1,6 +1,5 @@
 .meet-card {
-    max-width: 40rem;
-    margin-block-end: 0.75rem;
+    min-width: 0;
 }
 
 ::deep a.meet-card-title-link:focus {

--- a/src/KRAFT.Results.Web.Client/Components/MeetCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/MeetCard.razor.css
@@ -1,66 +1,6 @@
 .meet-card {
-    position: relative;
     max-width: 40rem;
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    padding-block: 1rem;
-    padding-inline: 1.25rem;
     margin-block-end: 0.75rem;
-    box-shadow: var(--shadow-sm);
-    transition: transform var(--transition-base) ease,
-                box-shadow var(--transition-base) ease;
-    cursor: default;
-
-    &:has(:focus-visible) {
-        outline: 2px solid var(--color-primary);
-        outline-offset: 2px;
-    }
-}
-
-.meet-card--linked {
-    cursor: pointer;
-
-    &:hover,
-    &:focus-within {
-        transform: translateY(-2px);
-        box-shadow: var(--shadow-md);
-    }
-}
-
-.meet-card--active {
-    background: var(--color-primary-light);
-    border-inline-start-color: var(--color-primary);
-
-    & .meet-card-count {
-        color: var(--color-primary);
-        font-weight: 600;
-    }
-}
-
-.meet-card--ghost {
-    background: transparent;
-    border: 1px dashed var(--color-border);
-    box-shadow: none;
-
-    & .meet-card-title-link,
-    & .meet-card-title-text {
-        color: var(--color-text-muted);
-    }
-
-    &:hover,
-    &:focus-within {
-        box-shadow: none;
-    }
-}
-
-.meet-card--ghost.meet-card--linked {
-    &:hover,
-    &:focus-within {
-        transform: none;
-        box-shadow: none;
-    }
 }
 
 ::deep a.meet-card-title-link:focus {
@@ -158,14 +98,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    position: static;
     text-decoration: none;
-}
-
-::deep a.meet-card-title-link::after {
-    content: "";
-    position: absolute;
-    inset: 0;
 }
 
 ::deep a.meet-card-title-link:hover {
@@ -173,10 +106,6 @@
 }
 
 @media (max-width: 480px) {
-    .meet-card {
-        padding-inline: 1rem;
-    }
-
     .meet-card-header {
         flex-direction: column;
     }
@@ -187,16 +116,5 @@
 
     ::deep a.meet-card-title-link {
         white-space: normal;
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .meet-card {
-        transition: none;
-
-        &:hover,
-        &:focus-within {
-            transform: none;
-        }
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
@@ -53,7 +53,7 @@
         @if (pageData.PersonalBests.Count > 0)
         {
             <h3 id="bestaragangur">Besti árangur</h3>
-            <div class="pb-group-container">
+            <div class="content-column pb-group-container">
                 @foreach (IGrouping<bool, AthletePersonalBest> group in pageData.PersonalBests.GroupBy(x => x.IsClassic).OrderByDescending(g => g.Key))
                 {
                     <AthletePersonalBestGroupCard
@@ -67,7 +67,7 @@
         @if (pageData.Records.Count > 0)
         {
             <h3 id="islandsmet">Núverandi íslandsmet (@pageData.Records.Count)</h3>
-            <div class="pb-group-container">
+            <div class="content-column pb-group-container">
                 @foreach (IGrouping<bool, AthleteRecord> group in pageData.Records.GroupBy(x => x.IsClassic).OrderByDescending(g => g.Key))
                 {
                     <AthleteRecordGroupCard
@@ -88,7 +88,7 @@
                 {
                     <details class="career-group" open>
                         <summary class="career-group-summary">@meetType.Key</summary>
-                        <div class="card-list">
+                        <div class="content-column card-list">
                             @foreach (AthleteParticipation p in meetType)
                             {
                                 <AthleteParticipationCard
@@ -103,7 +103,7 @@
                 {
                     <details class="career-group">
                         <summary class="career-group-summary">@meetType.Key</summary>
-                        <div class="card-list">
+                        <div class="content-column card-list">
                             @foreach (AthleteParticipation p in meetType)
                             {
                                 <AthleteParticipationCard

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
@@ -17,8 +17,6 @@
 
 .card-list {
     width: 100%;
-    max-width: 720px;
-    margin-inline: auto;
     container-type: inline-size;
     margin-block-end: 1rem;
 }
@@ -26,8 +24,6 @@
 .pb-group-container {
     display: flex;
     gap: 16px;
-    max-width: 720px;
-    margin-inline: auto;
     margin-block-end: 1.5rem;
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor
@@ -2,7 +2,8 @@
 @using KRAFT.Results.Contracts.Athletes
 @using Microsoft.AspNetCore.Components.Routing
 
-<div class="ap-card @(Participation.IsDisqualified ? "ap-card-dq" : null)">
+<Card Compact="true" CssClass="@(Participation.IsDisqualified ? "ap-card-dq" : null)">
+<div class="ap-card">
     <div class="ap-header-row">
         <div class="ap-rank @_rankClass">@_rankDisplay</div>
         <div class="ap-name-col">
@@ -44,6 +45,7 @@
         </div>
     }
 </div>
+</Card>
 
 @code {
     [Parameter, EditorRequired]

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor
@@ -2,7 +2,7 @@
 @using KRAFT.Results.Contracts.Athletes
 @using Microsoft.AspNetCore.Components.Routing
 
-<Card Compact="true" CssClass="@(Participation.IsDisqualified ? "ap-card-dq" : null)">
+<Card Compact="true" CssClass="@(Participation.IsDisqualified ? "card-spaced ap-card-dq" : "card-spaced")">
 <div class="ap-card">
     <div class="ap-header-row">
         <div class="ap-rank @_rankClass">@_rankDisplay</div>

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor.css
@@ -1,5 +1,4 @@
 .ap-card {
-    margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor.css
@@ -1,18 +1,8 @@
 .ap-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    padding: 10px 14px;
     margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 8px;
-}
-
-.ap-card-dq {
-    border-inline-start-color: #9ca3af;
-    opacity: 0.7;
 }
 
 .ap-header-row {

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor
@@ -2,7 +2,7 @@
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Athletes
 
-<Card CssClass="card-flush">
+<Card CssClass="card-flush card-half">
 <div class="pbg-card">
     <h3 class="pbg-header">@Title</h3>
     <div class="pbg-rows">

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor
@@ -2,6 +2,7 @@
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Athletes
 
+<Card CssClass="card-flush">
 <div class="pbg-card">
     <h3 class="pbg-header">@Title</h3>
     <div class="pbg-rows">
@@ -47,6 +48,7 @@
         }
     </div>
 </div>
+</Card>
 
 @code {
     [Parameter, EditorRequired]

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor.css
@@ -18,6 +18,8 @@
 .pbg-rows {
     display: flex;
     flex-direction: column;
+    overflow: hidden;
+    border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .pbg-row {

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor.css
@@ -1,11 +1,6 @@
 .pbg-card {
     flex: 0 0 calc(50% - 8px);
     min-width: 0;
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    overflow: hidden;
 }
 
 .pbg-header {

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletePersonalBestGroupCard.razor.css
@@ -1,5 +1,4 @@
 .pbg-card {
-    flex: 0 0 calc(50% - 8px);
     min-width: 0;
 }
 
@@ -158,12 +157,6 @@
     font-size: 14px;
     font-weight: 500;
     color: var(--color-text-muted);
-}
-
-@media (max-width: 600px) {
-    .pbg-card {
-        flex: 1 1 auto;
-    }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor
@@ -2,6 +2,7 @@
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Athletes
 
+<Card CssClass="card-flush">
 <div class="arg-card">
     <h3 class="arg-header">@Title</h3>
     <div class="arg-rows">
@@ -26,6 +27,7 @@
         }
     </div>
 </div>
+</Card>
 
 @code {
     [Parameter, EditorRequired]

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor
@@ -2,7 +2,7 @@
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Athletes
 
-<Card CssClass="card-flush">
+<Card CssClass="card-flush card-half">
 <div class="arg-card">
     <h3 class="arg-header">@Title</h3>
     <div class="arg-rows">

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor.css
@@ -20,8 +20,10 @@
     flex-direction: column;
     max-height: 400px;
     overflow-y: auto;
+    overflow-x: hidden;
     scrollbar-width: thin;
     scrollbar-color: var(--color-border) transparent;
+    border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .arg-rows::-webkit-scrollbar {

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor.css
@@ -1,5 +1,4 @@
 .arg-card {
-    flex: 0 0 calc(50% - 8px);
     min-width: 0;
 }
 
@@ -127,10 +126,6 @@
 }
 
 @media (max-width: 600px) {
-    .arg-card {
-        flex: 1 1 auto;
-    }
-
     .arg-weight {
         font-size: 22px;
     }

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteRecordGroupCard.razor.css
@@ -1,11 +1,6 @@
 .arg-card {
     flex: 0 0 calc(50% - 8px);
     min-width: 0;
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    overflow: hidden;
 }
 
 .arg-header {

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
@@ -14,14 +14,16 @@
 
 <DataLoader @key="Year" T="IReadOnlyCollection<MeetSummary>" Loader="LoadAsync" Noun="mót">
     <ChildContent Context="meets">
-        @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => x.StartDate.ToString("MMMM", CultureInfo.CurrentCulture)))
-        {
-            <h4>@($"{char.ToUpper(group.Key[0])}{group.Key[1..]}")</h4>
-            @foreach (MeetSummary meet in group)
+        <div class="meet-list">
+            @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => x.StartDate.ToString("MMMM", CultureInfo.CurrentCulture)))
             {
-                <MeetCard @key="meet.Slug" Meet="meet" IsFuture="meet.StartDate > _today" />
+                <h4>@($"{char.ToUpper(group.Key[0])}{group.Key[1..]}")</h4>
+                @foreach (MeetSummary meet in group)
+                {
+                    <MeetCard @key="meet.Slug" Meet="meet" IsFuture="meet.StartDate > _today" />
+                }
             }
-        }
+        </div>
     </ChildContent>
 </DataLoader>
 

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
@@ -14,7 +14,7 @@
 
 <DataLoader @key="Year" T="IReadOnlyCollection<MeetSummary>" Loader="LoadAsync" Noun="mót">
     <ChildContent Context="meets">
-        <div class="meet-list">
+        <div class="content-column">
             @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => x.StartDate.ToString("MMMM", CultureInfo.CurrentCulture)))
             {
                 <h4>@($"{char.ToUpper(group.Key[0])}{group.Key[1..]}")</h4>

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
@@ -2,3 +2,4 @@
     border-block-end: 1px solid var(--color-border);
     margin-block-end: 1rem;
 }
+

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
@@ -3,7 +3,7 @@
     margin-block-end: 1rem;
 }
 
-::deep .meet-card {
+.meet-list {
     max-width: 40rem;
     margin-inline: auto;
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
@@ -4,7 +4,7 @@
 }
 
 .meet-list {
-    max-width: 40rem;
+    max-width: 720px;
     margin-inline: auto;
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
@@ -2,5 +2,3 @@
     border-block-end: 1px solid var(--color-border);
     margin-block-end: 1rem;
 }
-
-

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
@@ -3,3 +3,8 @@
     margin-block-end: 1rem;
 }
 
+::deep .meet-card {
+    max-width: 40rem;
+    margin-inline: auto;
+}
+

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor.css
@@ -3,8 +3,4 @@
     margin-block-end: 1rem;
 }
 
-.meet-list {
-    max-width: 720px;
-    margin-inline: auto;
-}
 

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
@@ -7,7 +7,8 @@
 @inject HttpClient HttpClient
 @inject IJSRuntime JS
 
-<div class="p-card @(Participation.Disqualified ? "p-card-dq" : null)"
+<Card Compact="true" CssClass="@(Participation.Disqualified ? "p-card-dq" : null)">
+<div class="p-card"
      style="@($"--grid-template: {DesktopGridTemplate}")">
 
     <div class="p-header-row">
@@ -164,6 +165,7 @@
         }
     </div>
 </div>
+</Card>
 
 <AuthorizeView Roles="Admin">
     <EditBodyWeightDialog @ref="_editDialog"

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
@@ -7,7 +7,7 @@
 @inject HttpClient HttpClient
 @inject IJSRuntime JS
 
-<Card Compact="true" CssClass="@(Participation.Disqualified ? "p-card-dq" : null)">
+<Card Compact="true" CssClass="@(Participation.Disqualified ? "card-spaced p-card-dq" : "card-spaced")">
 <div class="p-card"
      style="@($"--grid-template: {DesktopGridTemplate}")">
 

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
@@ -1,7 +1,6 @@
 /* ===== Shared / Mobile-first ===== */
 
 .p-card {
-    margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
@@ -1,20 +1,10 @@
 /* ===== Shared / Mobile-first ===== */
 
 .p-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    padding: 10px 14px;
     margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 8px;
-}
-
-.p-card-dq {
-    border-inline-start-color: #9ca3af;
-    opacity: 0.7;
 }
 
 /* Header row: rank badge + name block */
@@ -288,7 +278,6 @@
         grid-template-columns: var(--grid-template);
         align-items: center;
         gap: 8px;
-        padding: 6px 12px 10px;
         flex-direction: unset;
     }
 

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
@@ -1,5 +1,6 @@
 @using KRAFT.Results.Contracts.Rankings
 
+<Card Compact="true">
 <div class="r-card">
     <div class="r-header-row">
         <div class="r-rank @_rankClass" aria-hidden="true">@_rankDisplay</div>
@@ -23,6 +24,7 @@
         }
     </div>
 </div>
+</Card>
 
 @code {
     [Parameter, EditorRequired]

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
@@ -1,6 +1,6 @@
 @using KRAFT.Results.Contracts.Rankings
 
-<Card Compact="true">
+<Card Compact="true" CssClass="card-spaced">
 <div class="r-card">
     <div class="r-header-row">
         <div class="r-rank @_rankClass" aria-hidden="true">@_rankDisplay</div>

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor.css
@@ -1,11 +1,6 @@
 /* ===== Card — mobile-first ===== */
 
 .r-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    padding: 10px 14px;
     margin-block-end: 6px;
     display: flex;
     flex-direction: column;

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor.css
@@ -1,7 +1,6 @@
 /* ===== Card — mobile-first ===== */
 
 .r-card {
-    margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor
@@ -60,7 +60,7 @@
                 ? 1
                 : (int)Math.Ceiling((double)response.TotalCount / PageSize);
 
-            <div class="rankings-list">
+            <div class="content-column rankings-list">
                 @foreach (RankingEntry entry in response.Items)
                 {
                     <RankingCard Entry="entry" DisciplineLabel="@DisciplineLabel" />

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingsIndex.razor.css
@@ -39,8 +39,6 @@
 }
 
 .rankings-list {
-    max-width: 720px;
-    margin-inline: auto;
     container-type: inline-size;
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
@@ -2,7 +2,8 @@
 
 @if (Record.IsStandard)
 {
-    <div class="rc-card rc-standard">
+    <Card Compact="true" CssClass="rc-standard">
+    <div class="rc-card">
         <div class="rc-header-row">
             <div class="rc-category">@Record.WeightCategory</div>
             <div class="rc-name-col">
@@ -10,9 +11,11 @@
             </div>
         </div>
     </div>
+    </Card>
 }
 else
 {
+    <Card Compact="true">
     <div class="rc-card">
         <div class="rc-header-row">
             <a class="rc-category rc-category-link" href="@($"/records/{Record.Id}/history")">@Record.WeightCategory</a>
@@ -38,7 +41,8 @@ else
                 }
             </div>
         </div>
-</div>
+    </div>
+    </Card>
 }
 
 @code {
@@ -63,6 +67,6 @@ else
 
         parts.Add(Record.Date.ToString("dd.MM.yyyy"));
 
-        _meta = string.Join(" \u00b7 ", parts);
+        _meta = string.Join(" · ", parts);
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
@@ -2,7 +2,7 @@
 
 @if (Record.IsStandard)
 {
-    <Card Compact="true" CssClass="rc-standard">
+    <Card Compact="true" CssClass="card-spaced rc-standard">
     <div class="rc-card">
         <div class="rc-header-row">
             <div class="rc-category">@Record.WeightCategory</div>
@@ -15,7 +15,7 @@
 }
 else
 {
-    <Card Compact="true">
+    <Card Compact="true" CssClass="card-spaced">
     <div class="rc-card">
         <div class="rc-header-row">
             <a class="rc-category rc-category-link" href="@($"/records/{Record.Id}/history")">@Record.WeightCategory</a>

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor.css
@@ -1,7 +1,6 @@
 /* ===== Card — mobile-first ===== */
 
 .rc-card {
-    margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor.css
@@ -1,19 +1,10 @@
 /* ===== Card — mobile-first ===== */
 
 .rc-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    padding: 10px 14px;
     margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 8px;
-}
-
-.rc-standard {
-    border-inline-start-color: var(--color-border);
 }
 
 .rc-standard .rc-category {

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
@@ -1,7 +1,7 @@
 @using KRAFT.Results.Contracts.Records
 
-<div class="rhc-card @(Entry.IsCurrent ? "rhc-current" : null) @(Entry.IsStandard ? "rhc-standard" : null)"
-     aria-current="@(Entry.IsCurrent ? "true" : null)">
+<Card Compact="true" CssClass="@_cardCssClass">
+<div class="rhc-card" aria-current="@(Entry.IsCurrent ? "true" : null)">
 
     <div class="rhc-header-row">
         <div class="rhc-name-col">
@@ -44,15 +44,30 @@
         }
     </div>
 </div>
+</Card>
 
 @code {
     [Parameter, EditorRequired]
     public RecordHistoryEntry Entry { get; set; } = null!;
 
+    private string _cardCssClass = string.Empty;
     private string _footerMeta = string.Empty;
 
     protected override void OnParametersSet()
     {
+        if (Entry.IsCurrent)
+        {
+            _cardCssClass = "rhc-current";
+        }
+        else if (Entry.IsStandard)
+        {
+            _cardCssClass = "rhc-standard";
+        }
+        else
+        {
+            _cardCssClass = "rhc-default";
+        }
+
         string date = Entry.Date.ToString("dd.MM.yyyy");
         _footerMeta = Entry.BodyWeight.HasValue
             ? $"{date} · {Entry.BodyWeight.Value:F1} kg"

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
@@ -57,15 +57,15 @@
     {
         if (Entry.IsCurrent)
         {
-            _cardCssClass = "rhc-current";
+            _cardCssClass = "card-spaced rhc-current";
         }
         else if (Entry.IsStandard)
         {
-            _cardCssClass = "rhc-standard";
+            _cardCssClass = "card-spaced rhc-standard";
         }
         else
         {
-            _cardCssClass = "rhc-default";
+            _cardCssClass = "card-spaced rhc-default";
         }
 
         string date = Entry.Date.ToString("dd.MM.yyyy");

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
@@ -1,7 +1,6 @@
 /* ===== Record History Card — mobile-first ===== */
 
 .rhc-card {
-    margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -23,7 +22,7 @@
 .rhc-name {
     font-weight: 700;
     font-size: 17px;
-    color: var(--color-primary);
+    color: var(--rhc-text-color, var(--color-primary));
     text-decoration: none;
     white-space: nowrap;
     overflow: hidden;
@@ -58,7 +57,7 @@
 .rhc-mark {
     font-weight: 800;
     font-size: 26px;
-    color: var(--color-primary);
+    color: var(--rhc-text-color, var(--color-primary));
     font-variant-numeric: tabular-nums;
     line-height: 1;
 }

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
@@ -1,25 +1,10 @@
 /* ===== Record History Card — mobile-first ===== */
 
 .rhc-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid transparent;
-    border-radius: var(--radius-md);
-    padding: 10px 14px;
     margin-block-end: 6px;
     display: flex;
     flex-direction: column;
     gap: 4px;
-}
-
-.rhc-current {
-    border-inline-start-color: var(--color-primary);
-    background: var(--color-primary-light);
-}
-
-.rhc-standard {
-    border-inline-start-color: var(--color-border);
-    opacity: 0.65;
 }
 
 /* ── Header row ── */
@@ -76,11 +61,6 @@
     color: var(--color-primary);
     font-variant-numeric: tabular-nums;
     line-height: 1;
-}
-
-.rhc-current .rhc-mark,
-.rhc-current .rhc-name {
-    color: var(--color-primary-dark);
 }
 
 .rhc-delta {

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor
@@ -26,7 +26,7 @@
 
         @if (response.Entries.Count > 0)
         {
-            <div class="record-meta">
+            <div class="content-column record-meta">
                 <span>@response.Category</span>
                 <span class="meta-separator">&middot;</span>
                 <span>@response.WeightCategory</span>
@@ -43,7 +43,7 @@
                 }
             </div>
 
-            <div class="rhc-list">
+            <div class="content-column rhc-list">
                 @foreach (RecordHistoryEntry entry in response.Entries)
                 {
                     <RecordHistoryCard Entry="entry" />

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor.css
@@ -42,8 +42,6 @@
     background: var(--color-white);
     border-radius: var(--radius-sm);
     font-size: 0.9375rem;
-    max-width: 720px;
-    margin-inline: auto;
 }
 
 .meta-separator {
@@ -51,8 +49,6 @@
 }
 
 .rhc-list {
-    max-width: 720px;
-    margin-inline: auto;
     container-type: inline-size;
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordsPage.razor
@@ -26,7 +26,7 @@
         {
             @foreach (RecordGroup group in groups)
             {
-                <section class="record-section">
+                <section class="content-column record-section">
                     <h2>@group.Category</h2>
                     @foreach (RecordEntry record in group.Records)
                     {

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordsPage.razor.css
@@ -1,6 +1,4 @@
 .record-section {
-    max-width: 720px;
-    margin-inline: auto;
     margin-block-end: 2rem;
     container-type: inline-size;
 }

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
@@ -1,6 +1,6 @@
 @using KRAFT.Results.Contracts.TeamCompetition
 
-<Card Compact="true" CssClass="@(_isFirst ? "sc-card-first" : null)">
+<Card Compact="true" CssClass="@(_isFirst ? "card-spaced sc-card-first" : "card-spaced")">
 <div class="sc-card">
     @if (_isMedal)
     {

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
@@ -1,6 +1,7 @@
 @using KRAFT.Results.Contracts.TeamCompetition
 
-<div class="sc-card @(_isFirst ? "sc-card-first" : null)">
+<Card Compact="true" CssClass="@(_isFirst ? "sc-card-first" : null)">
+<div class="sc-card">
     @if (_isMedal)
     {
         <div class="sc-rank @_rankClass" role="img" aria-label="@_rankAriaLabel">
@@ -29,6 +30,7 @@
         @Standing.TotalPoints
     </div>
 </div>
+</Card>
 
 @code {
     [Parameter, EditorRequired]
@@ -50,9 +52,9 @@
             2 => "\U0001f948",
             3 => "\U0001f949",
             _ when Standing.Rank > 0 => Standing.Rank.ToString(),
-            _ => "\u2013",
+            _ => "–",
         };
         _rankClass = _isMedal ? "rank-medal" : string.Empty;
-        _rankAriaLabel = _isMedal ? $"{Standing.Rank}. s\u00e6ti" : string.Empty;
+        _rankAriaLabel = _isMedal ? $"{Standing.Rank}. sæti" : string.Empty;
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
@@ -1,16 +1,9 @@
 .sc-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
-    border-radius: var(--radius-md);
-    padding: 10px 14px;
     margin-block-end: 6px;
     display: flex;
     align-items: center;
     gap: 8px;
 }
-
-.sc-card-first { background: rgba(139, 26, 43, 0.06); }
 
 .sc-rank {
     width: 26px; height: 26px;

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
@@ -1,5 +1,4 @@
 .sc-card {
-    margin-block-end: 6px;
     display: flex;
     align-items: center;
     gap: 8px;

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -528,5 +528,5 @@ h1:focus {
 }
 
 /* Card state overrides — modifier classes applied via CssClass to Card's article */
-.sc-card-first { background: rgba(139, 26, 43, 0.06); }
-.rc-standard { border-inline-start-color: var(--color-border); }
+.sc-card-first { --card-bg: rgba(139, 26, 43, 0.06); }
+.rc-standard { --card-accent: var(--color-border); }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -531,16 +531,15 @@ h1:focus {
 .sc-card-first { --card-bg: rgba(139, 26, 43, 0.06); }
 .rc-standard { --card-accent: var(--color-border); }
 .rhc-default { --card-accent: transparent; }
-.rhc-current { --card-accent: var(--color-primary); --card-bg: var(--color-primary-light); }
+.rhc-current { --card-accent: var(--color-primary); --card-bg: var(--color-primary-light); --rhc-text-color: var(--color-primary-dark); }
 .rhc-standard { --card-accent: var(--color-border); opacity: 0.65; }
-.rhc-current .rhc-mark,
-.rhc-current .rhc-name { color: var(--color-primary-dark); }
 .ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .p-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
-.card-flush { --card-padding: 0; overflow: hidden; }
+.card-flush { --card-padding: 0; }
+.card-spaced { margin-block-end: 6px; }
 
 /* MeetCard state overrides */
-.meet-card--active { --card-bg: var(--color-primary-light); }
+.meet-card--active { --card-bg: var(--color-primary-light); --card-accent: var(--color-primary); }
 .meet-card--active .meet-card-count {
     color: var(--color-primary);
     font-weight: 600;

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -538,3 +538,21 @@ h1:focus {
 .ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .p-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .card-flush { --card-padding: 0; overflow: hidden; }
+
+/* MeetCard state overrides */
+.meet-card--active { --card-bg: var(--color-primary-light); }
+.meet-card--active .meet-card-count {
+    color: var(--color-primary);
+    font-weight: 600;
+}
+.meet-card--ghost {
+    --card-border: 1px dashed var(--color-border);
+    --card-border-start: 1px dashed var(--color-border);
+    --card-bg: transparent;
+    --card-shadow: none;
+    --card-accent: transparent;
+    --card-hover-transform: none;
+    --card-hover-shadow: none;
+}
+.meet-card--ghost .meet-card-title-link,
+.meet-card--ghost .meet-card-title-text { color: var(--color-text-muted); }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -536,6 +536,8 @@ h1:focus {
 .ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .p-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .card-flush { --card-padding: 0; }
+.card-half { flex: 0 0 calc(50% - 8px); min-width: 0; }
+@media (max-width: 600px) { .card-half { flex: 1 1 auto; } }
 .card-spaced { margin-block-end: 6px; }
 
 /* MeetCard state overrides */

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -536,4 +536,5 @@ h1:focus {
 .rhc-current .rhc-mark,
 .rhc-current .rhc-name { color: var(--color-primary-dark); }
 .ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
+.p-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .card-flush { --card-padding: 0; overflow: hidden; }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -536,3 +536,4 @@ h1:focus {
 .rhc-current .rhc-mark,
 .rhc-current .rhc-name { color: var(--color-primary-dark); }
 .ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
+.card-flush { --card-padding: 0; overflow: hidden; }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -540,6 +540,8 @@ h1:focus {
 @media (max-width: 600px) { .card-half { flex: 1 1 auto; } }
 .card-spaced { margin-block-end: 6px; }
 
+.meet-card { max-width: 40rem; margin-block-end: 0.75rem; margin-inline: auto; }
+
 /* MeetCard state overrides */
 .meet-card--active { --card-bg: var(--color-primary-light); --card-accent: var(--color-primary); }
 .meet-card--active .meet-card-count {

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -530,3 +530,9 @@ h1:focus {
 /* Card state overrides — modifier classes applied via CssClass to Card's article */
 .sc-card-first { --card-bg: rgba(139, 26, 43, 0.06); }
 .rc-standard { --card-accent: var(--color-border); }
+.rhc-default { --card-accent: transparent; }
+.rhc-current { --card-accent: var(--color-primary); --card-bg: var(--color-primary-light); }
+.rhc-standard { --card-accent: var(--color-border); opacity: 0.65; }
+.rhc-current .rhc-mark,
+.rhc-current .rhc-name { color: var(--color-primary-dark); }
+.ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -85,6 +85,11 @@ tbody tr:nth-child(even) {
     padding-top: 1.1rem;
 }
 
+.content-column {
+    max-width: 720px;
+    margin-inline: auto;
+}
+
 .widget-grid {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -526,3 +526,7 @@ h1:focus {
     color: var(--color-text-muted);
     font-size: 0.9375rem;
 }
+
+/* Card state overrides — modifier classes applied via CssClass to Card's article */
+.sc-card-first { background: rgba(139, 26, 43, 0.06); }
+.rc-standard { border-inline-start-color: var(--color-border); }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -540,7 +540,7 @@ h1:focus {
 @media (max-width: 600px) { .card-half { flex: 1 1 auto; } }
 .card-spaced { margin-block-end: 6px; }
 
-.meet-card { max-width: 40rem; margin-block-end: 0.75rem; margin-inline: auto; }
+.meet-card { margin-block-end: 0.75rem; }
 
 /* MeetCard state overrides */
 .meet-card--active { --card-bg: var(--color-primary-light); --card-accent: var(--color-primary); }

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/MeetCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/MeetCardTests.cs
@@ -244,7 +244,7 @@ public sealed class MeetCardTests : IDisposable
     }
 
     [Fact]
-    public void DoesNotHaveLinkedModifier_WhenZeroParticipantsAndNonAdmin()
+    public void IsNotClickable_WhenZeroParticipantsAndNonAdmin()
     {
         // Arrange
         MeetSummary meet = MakePastMeet(participantCount: 0);
@@ -256,12 +256,12 @@ public sealed class MeetCardTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.FindAll("article.meet-card--linked").Count.ShouldBe(0);
+            cut.FindAll("article.card--clickable").Count.ShouldBe(0);
         });
     }
 
     [Fact]
-    public void HasLinkedModifier_WhenParticipantCountGreaterThanZero()
+    public void IsClickable_WhenParticipantCountGreaterThanZero()
     {
         // Arrange
         MeetSummary meet = MakePastMeet(participantCount: 5);
@@ -273,12 +273,12 @@ public sealed class MeetCardTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("article.meet-card--linked").ShouldNotBeNull();
+            cut.Find("article.card--clickable").ShouldNotBeNull();
         });
     }
 
     [Fact]
-    public void HasLinkedModifier_WhenZeroParticipantsAndAdmin()
+    public void IsClickable_WhenZeroParticipantsAndAdmin()
     {
         // Arrange
         MeetSummary meet = MakePastMeet(participantCount: 0);
@@ -291,7 +291,7 @@ public sealed class MeetCardTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("article.meet-card--linked").ShouldNotBeNull();
+            cut.Find("article.card--clickable").ShouldNotBeNull();
         });
     }
 


### PR DESCRIPTION
## Summary

- Wraps all 9 feature-specific card components in the shared `<Card>` component, removing duplicated shell CSS (border, radius, shadow, background, padding) from each feature's scoped stylesheet
- Introduces CSS custom properties on Card (`--card-accent`, `--card-bg`, `--card-padding`, `--card-border`, `--card-border-start`, `--card-shadow`, `--card-hover-transform`, `--card-hover-shadow`) to enable state overrides without specificity battles
- Moves card state modifiers (ghost, active, DQ, first-place, standard, current) to global `app.css` using custom properties
- Extracts `.content-column` utility class in `app.css` to consolidate `max-width: 720px` across all single-column card list pages

## Cards migrated

| Card | Mode | State modifiers |
|---|---|---|
| RankingCard | Compact | — |
| StandingsCard | Compact | `sc-card-first` (background highlight) |
| RecordCard | Compact | `rc-standard` (border color) |
| RecordHistoryCard | Compact | `rhc-default`/`rhc-current`/`rhc-standard` (border + background) |
| AthleteParticipationCard | Compact | `ap-card-dq` (opacity + border) |
| AthletePersonalBestGroupCard | Default (flush) | `card-flush` (zero padding, overflow visible) |
| AthleteRecordGroupCard | Default (flush) | `card-flush` |
| ParticipationCard | Compact | `p-card-dq` (opacity + border) |
| MeetCard | Clickable | `meet-card--ghost`/`meet-card--active` |

## Test plan

- [x] `dotnet build` passes with 0 warnings
- [x] MeetCardTests updated and passing (linked → clickable assertion)
- [x] Visual verification: all card types at mobile and desktop breakpoints
- [x] Visual verification: consistent max-width across MeetIndex, Rankings, Records, RecordHistory, AthleteDetails
- [x] Visual verification: Dashboard multi-column layout unaffected

Closes #502