### PR TITLE
refactor(web): use shared Card component for dashboard and leaders section

### DIFF
--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -46,7 +46,7 @@
         </section>
 
         <div class="widget-grid">
-        <div class="widget">
+        <Card CssClass="card-flush card-plain">
             <div class="widget-header">
                 <h2 class="widget-title">Mót</h2>
                 <NavLink class="widget-link" href="/meets">Mótaskrá →</NavLink>
@@ -85,9 +85,9 @@
                     }
                 </div>
             </div>
-        </div>
+        </Card>
 
-        <div class="widget">
+        <Card CssClass="card-flush card-plain">
             <div class="widget-header">
                 <h2 class="widget-title">Stigatafla @_year — Klassík</h2>
                 <NavLink class="widget-link" href="/rankings">Allt →</NavLink>
@@ -126,9 +126,9 @@
                     }
                 </div>
             </div>
-        </div>
+        </Card>
 
-        <div class="widget">
+        <Card CssClass="card-flush card-plain">
             <div class="widget-header">
                 <h2 class="widget-title">Nýjustu met</h2>
                 <NavLink class="widget-link" href="/records">Allt →</NavLink>
@@ -195,11 +195,11 @@
                     }
                 </div>
             </div>
-        </div>
+        </Card>
 
         @if (context.TeamStandingsMen.Count > 0 || context.TeamStandingsWomen.Count > 0)
         {
-            <div class="widget">
+            <Card CssClass="card-flush card-plain">
                 <div class="widget-header">
                     <h2 class="widget-title">Liðakeppni @_year</h2>
                     <NavLink class="widget-link" href="/team-competition">Allt →</NavLink>
@@ -224,7 +224,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
+            </Card>
         }
         </div>
     </ChildContent>

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -18,22 +18,30 @@
         <section class="season-stats" aria-label="Tölur ársins @_year">
             <h2 class="section-label">Tölur ársins @_year</h2>
             <div class="stat-bar">
-                <div class="stat-card">
-                    <span class="stat-number">@context.SeasonStats.Meets</span>
-                    <span class="stat-label">Mót</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-number">@context.SeasonStats.Athletes</span>
-                    <span class="stat-label">Keppendur</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-number">@context.SeasonStats.Records</span>
-                    <span class="stat-label">Met</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-number">@context.SeasonStats.Clubs</span>
-                    <span class="stat-label">Félög</span>
-                </div>
+                <Card Compact="true" CssClass="card-plain">
+                    <div class="stat-inner">
+                        <span class="stat-number">@context.SeasonStats.Meets</span>
+                        <span class="stat-label">Mót</span>
+                    </div>
+                </Card>
+                <Card Compact="true" CssClass="card-plain">
+                    <div class="stat-inner">
+                        <span class="stat-number">@context.SeasonStats.Athletes</span>
+                        <span class="stat-label">Keppendur</span>
+                    </div>
+                </Card>
+                <Card Compact="true" CssClass="card-plain">
+                    <div class="stat-inner">
+                        <span class="stat-number">@context.SeasonStats.Records</span>
+                        <span class="stat-label">Met</span>
+                    </div>
+                </Card>
+                <Card Compact="true" CssClass="card-plain">
+                    <div class="stat-inner">
+                        <span class="stat-number">@context.SeasonStats.Clubs</span>
+                        <span class="stat-label">Félög</span>
+                    </div>
+                </Card>
             </div>
         </section>
 

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -20,26 +20,26 @@
             <div class="stat-bar">
                 <Card Compact="true" CssClass="card-plain">
                     <div class="stat-inner">
-                        <span class="stat-number">@context.SeasonStats.Meets</span>
                         <span class="stat-label">Mót</span>
+                        <span class="stat-number">@context.SeasonStats.Meets</span>
                     </div>
                 </Card>
                 <Card Compact="true" CssClass="card-plain">
                     <div class="stat-inner">
-                        <span class="stat-number">@context.SeasonStats.Athletes</span>
                         <span class="stat-label">Keppendur</span>
+                        <span class="stat-number">@context.SeasonStats.Athletes</span>
                     </div>
                 </Card>
                 <Card Compact="true" CssClass="card-plain">
                     <div class="stat-inner">
-                        <span class="stat-number">@context.SeasonStats.Records</span>
                         <span class="stat-label">Met</span>
+                        <span class="stat-number">@context.SeasonStats.Records</span>
                     </div>
                 </Card>
                 <Card Compact="true" CssClass="card-plain">
                     <div class="stat-inner">
-                        <span class="stat-number">@context.SeasonStats.Clubs</span>
                         <span class="stat-label">Félög</span>
+                        <span class="stat-number">@context.SeasonStats.Clubs</span>
                     </div>
                 </Card>
             </div>

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
@@ -14,13 +14,8 @@
     margin-bottom: 1.5rem;
 }
 
-.stat-card {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    padding: 0.875rem 1rem;
+.stat-inner {
     text-align: center;
-    box-shadow: var(--shadow-sm);
     display: flex;
     flex-direction: column;
     gap: 0.25rem;

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
@@ -27,6 +27,7 @@
     font-weight: 700;
     color: var(--color-text);
     line-height: 1;
+    order: -1;
 }
 
 .stat-label {

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
@@ -35,15 +35,6 @@
 }
 
 /* Shared widget */
-.widget {
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-sm);
-    overflow: hidden;
-    margin-bottom: 1.25rem;
-}
-
 .widget-header {
     padding: 0.75rem 1rem;
     border-bottom: 1px solid var(--color-border);
@@ -80,7 +71,7 @@
 
 .split-col-header {
     padding: 0.5rem 1rem;
-    background: #f9fafb;
+    background: var(--color-bg);
     border-bottom: 1px solid var(--color-border);
     font-family: var(--font-heading);
     font-size: 0.75rem;

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -85,22 +85,26 @@
                     @foreach (IGrouping<string, MeetParticipation> gender in Participations.GroupBy(x => x.Gender).OrderByDescending(x => x.Key))
                     {
                         <div class="leaders-gender-col">
-                            <h3 class="leaders-gender-heading">@gender.Key</h3>
-                            @foreach (var leader in gender.OrderByDescending(x => x.IpfPoints).Take(3).Select((x, i) => (Participation: x, Index: i)))
-                            {
-                                <div class="leader-row">
-                                    <span class="leader-medal" aria-hidden="true">
-                                        @((leader.Index + 1) switch { 1 => "🥇", 2 => "🥈", _ => "🥉" })
-                                    </span>
-                                    <div class="leader-info">
-                                        <NavLink class="leader-name" href="@($"/athletes/{leader.Participation.AthleteSlug}")">@leader.Participation.Athlete</NavLink>
-                                        <span class="leader-meta">
-                                            @leader.Participation.YearOfBirth@(!string.IsNullOrWhiteSpace(leader.Participation.Club) ? $" · {leader.Participation.Club}" : string.Empty) · @($"{leader.Participation.BodyWeight:F2}") kg
-                                        </span>
-                                    </div>
-                                    <span class="leader-pts">@($"{leader.Participation.IpfPoints:F2}")</span>
+                            <Card CssClass="card-flush">
+                                <h3 class="leaders-gender-heading">@gender.Key</h3>
+                                <div class="leaders-card-body">
+                                    @foreach (var leader in gender.OrderByDescending(x => x.IpfPoints).Take(3).Select((x, i) => (Participation: x, Index: i)))
+                                    {
+                                        <div class="leader-row">
+                                            <span class="leader-medal" aria-hidden="true">
+                                                @((leader.Index + 1) switch { 1 => "🥇", 2 => "🥈", _ => "🥉" })
+                                            </span>
+                                            <div class="leader-info">
+                                                <NavLink class="leader-name" href="@($"/athletes/{leader.Participation.AthleteSlug}")">@leader.Participation.Athlete</NavLink>
+                                                <span class="leader-meta">
+                                                    @leader.Participation.YearOfBirth@(!string.IsNullOrWhiteSpace(leader.Participation.Club) ? $" · {leader.Participation.Club}" : string.Empty) · @($"{leader.Participation.BodyWeight:F2}") kg
+                                                </span>
+                                            </div>
+                                            <span class="leader-pts">@($"{leader.Participation.IpfPoints:F2}")</span>
+                                        </div>
+                                    }
                                 </div>
-                            }
+                            </Card>
                         </div>
                     }
                 </div>

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -18,9 +18,9 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--color-text);
-    margin-block: 0 0.375rem;
+    margin-block: 0;
     border-block-end: 1px solid var(--color-border);
-    padding-block-end: 0.25rem;
+    padding: 12px 14px 10px;
 }
 
 .leaders-grid {
@@ -32,7 +32,7 @@
 .leaders-gender-col {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 0;
 }
 
 @container (min-width: 600px) {
@@ -46,9 +46,15 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.5rem 0.75rem;
-    background: var(--color-white);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.leader-row:last-child {
+    border-bottom: none;
+}
+
+.leaders-card-body {
+    padding: 4px 0;
 }
 
 .leader-medal {

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor
@@ -1,7 +1,7 @@
 @using System.Globalization
 @using KRAFT.Results.Contracts.Meets
 
-<section class="mr-section">
+<section class="mr-section content-column">
     <h2 id="met">Met sett á mótinu (@Records.Count)</h2>
 
     <div class="mr-container">

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor.css
@@ -9,7 +9,7 @@
 }
 
 .mr-card {
-    flex: 0 0 calc(50% - 8px);
+    flex: 1 1 auto;
     min-width: 0;
     background: var(--color-white);
     border: 1px solid var(--color-border);

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -101,7 +101,7 @@ tbody tr:nth-child(even) {
         grid-template-columns: 1fr 1fr;
     }
 
-    .widget-grid .widget {
+    .widget-grid > .card {
         margin-bottom: 0;
     }
 }
@@ -540,7 +540,7 @@ h1:focus {
 .rhc-standard { --card-accent: var(--color-border); opacity: 0.65; }
 .ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .p-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
-.card-flush { --card-padding: 0; }
+.card-flush { --card-padding: 0; overflow: hidden; }
 .card-plain { --card-border-start: none; }
 .card-half { flex: 0 0 calc(50% - 8px); min-width: 0; }
 @media (max-width: 600px) { .card-half { flex: 1 1 auto; } }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -532,6 +532,17 @@ h1:focus {
     font-size: 0.9375rem;
 }
 
+/* Card defaults — each Card resets its own variables so nested Cards do not inherit parent overrides */
+.card {
+    --card-padding: 1.25rem 1.5rem;
+    --card-border-start: 4px solid var(--card-accent, var(--color-primary));
+    --card-bg: var(--color-white);
+    --card-shadow: var(--shadow-sm);
+    --card-border: 1px solid var(--color-border);
+    --card-hover-transform: translateY(-4px);
+    --card-hover-shadow: var(--shadow-lg);
+}
+
 /* Card state overrides — modifier classes applied via CssClass to Card's article */
 .sc-card-first { --card-bg: rgba(139, 26, 43, 0.06); }
 .rc-standard { --card-accent: var(--color-border); }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -541,6 +541,7 @@ h1:focus {
 .ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .p-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
 .card-flush { --card-padding: 0; }
+.card-plain { --card-border-start: none; }
 .card-half { flex: 0 0 calc(50% - 8px); min-width: 0; }
 @media (max-width: 600px) { .card-half { flex: 1 1 auto; } }
 .card-spaced { margin-block-end: 6px; }


### PR DESCRIPTION
## Summary

- Refactored dashboard stat cards to use `<Card Compact="true" CssClass="card-plain">` with inner `.stat-inner` layout div
- Refactored dashboard widgets to use `<Card CssClass="card-flush card-plain">`, removing redundant `.widget` shell CSS
- Wrapped MeetDetailsPage leaders gender columns in `<Card CssClass="card-flush">` with flat row separators
- Added `.card-plain` utility class to suppress left accent border where not desired
- Added `overflow: hidden` to `.card-flush` for border-radius clipping
- Updated `.widget-grid > .card` selector for 1800px+ breakpoint
- Replaced hardcoded `#f9fafb` with `var(--color-bg)` in split-col-header
- Fixed screen reader order: stat card labels now precede numbers in DOM with CSS `order: -1` for visual preservation
- Added explicit Card CSS custom property defaults on `.card` to prevent inheritance into nested Card components (e.g. MeetCard inside dashboard widgets)

Closes #503