### PR TITLE
feat(webapi): replace athletes search table with cards showing participation count and team

### DIFF
--- a/src/KRAFT.Results.Contracts/Athletes/AthleteSummary.cs
+++ b/src/KRAFT.Results.Contracts/Athletes/AthleteSummary.cs
@@ -1,3 +1,10 @@
 namespace KRAFT.Results.Contracts.Athletes;
 
-public sealed record class AthleteSummary(string? Slug, string Name, int? YearOfBirth, string? Gender, IReadOnlyList<string> EligibleAgeCategorySlugs, int ParticipationCount, string? Team);
+public sealed record class AthleteSummary(
+    string? Slug,
+    string Name,
+    int? YearOfBirth,
+    string? Gender,
+    IReadOnlyList<string> EligibleAgeCategorySlugs,
+    int ParticipationCount,
+    string? Team);

--- a/src/KRAFT.Results.Contracts/Athletes/AthleteSummary.cs
+++ b/src/KRAFT.Results.Contracts/Athletes/AthleteSummary.cs
@@ -1,3 +1,3 @@
 namespace KRAFT.Results.Contracts.Athletes;
 
-public sealed record class AthleteSummary(string? Slug, string Name, int? YearOfBirth, string? Gender, IReadOnlyList<string> EligibleAgeCategorySlugs);
+public sealed record class AthleteSummary(string? Slug, string Name, int? YearOfBirth, string? Gender, IReadOnlyList<string> EligibleAgeCategorySlugs, int ParticipationCount, string? Team);

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
@@ -26,26 +26,25 @@
 
         @if (_filteredAthletes.Count > 0)
         {
-            <table>
-                <thead>
-                    <tr>
-                        <th>Nafn</th>
-                    </tr>
-                </thead>
-
-                <tbody>
-                    @foreach (AthleteSummary athlete in _filteredAthletes)
-                    {
-                        <tr>
-                            <td>
-                                <NavLink class="nav-link" href="@($"/athletes/{athlete.Slug}")">
-                                    @(athlete.YearOfBirth is null ? athlete.Name : $"{athlete.Name} ({athlete.YearOfBirth})")
-                                </NavLink>
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
+            <div class="card-grid">
+                @foreach (AthleteSummary athlete in _filteredAthletes)
+                {
+                    <Card Clickable="true">
+                        <a href="@($"/athletes/{athlete.Slug}")" aria-label="@athlete.Name"></a>
+                        <div class="athlete-name">
+                            @(athlete.YearOfBirth is null ? athlete.Name : $"{athlete.Name} ({athlete.YearOfBirth})")
+                        </div>
+                        @if (athlete.Team is not null)
+                        {
+                            <div class="athlete-team">@athlete.Team</div>
+                        }
+                        <div class="athlete-count">
+                            <span class="count-value">@athlete.ParticipationCount</span>
+                            <span class="count-label">mót</span>
+                        </div>
+                    </Card>
+                }
+            </div>
         }
 
         @if (_filteredAthletes.Count == 0 && _athletes.Count > 0)

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
@@ -30,7 +30,7 @@
                 @foreach (AthleteSummary athlete in _filteredAthletes)
                 {
                     <Card Clickable="true">
-                        <a href="@($"/athletes/{athlete.Slug}")" aria-label="@athlete.Name"></a>
+                        <a href="@($"/athletes/{athlete.Slug}")" aria-hidden="true" tabindex="-1"></a>
                         <div class="athlete-name">
                             @(athlete.YearOfBirth is null ? athlete.Name : $"{athlete.Name} ({athlete.YearOfBirth})")
                         </div>
@@ -38,7 +38,9 @@
                         {
                             <div class="athlete-team">@athlete.Team</div>
                         }
-                        <div class="athlete-count">
+                        <div class="athlete-count"
+                             aria-label="@($"{athlete.ParticipationCount} mót")"
+                             title="Fjöldi keppnismóta">
                             <span class="count-value">@athlete.ParticipationCount</span>
                             <span class="count-label">mót</span>
                         </div>

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor
@@ -39,6 +39,7 @@
                             <div class="athlete-team">@athlete.Team</div>
                         }
                         <div class="athlete-count"
+                             role="group"
                              aria-label="@($"{athlete.ParticipationCount} mót")"
                              title="Fjöldi keppnismóta">
                             <span class="count-value">@athlete.ParticipationCount</span>

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
@@ -22,7 +22,7 @@
 
 .card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 250px));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1rem;
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
@@ -19,3 +19,42 @@
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
 }
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 250px));
+    gap: 1rem;
+}
+
+.athlete-name {
+    font-family: var(--font-heading);
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.athlete-team {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    margin-block-end: 0.75rem;
+}
+
+.athlete-count {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    padding-block-start: 0.75rem;
+    border-block-start: 1px solid var(--color-border);
+}
+
+.count-value {
+    font-family: var(--font-heading);
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.count-label {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
@@ -20,12 +20,6 @@
     outline-offset: 2px;
 }
 
-.card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 1rem;
-}
-
 .athlete-name {
     font-family: var(--font-heading);
     font-size: 1.05rem;
@@ -45,16 +39,4 @@
     margin-block-start: 0.75rem;
     padding-block-start: 0.75rem;
     border-block-start: 1px solid var(--color-border);
-}
-
-.count-value {
-    font-family: var(--font-heading);
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-primary);
-}
-
-.count-label {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
 }

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthletesIndex.razor.css
@@ -36,13 +36,13 @@
 .athlete-team {
     font-size: 0.85rem;
     color: var(--color-text-muted);
-    margin-block-end: 0.75rem;
 }
 
 .athlete-count {
     display: flex;
     align-items: baseline;
     gap: 0.35rem;
+    margin-block-start: 0.75rem;
     padding-block-start: 0.75rem;
     border-block-start: 1px solid var(--color-border);
 }

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
@@ -1,9 +1,3 @@
-.card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 250px));
-    gap: 1rem;
-}
-
 .team-name {
     font-family: var(--font-heading);
     font-size: 1.05rem;
@@ -23,16 +17,4 @@
     gap: 0.35rem;
     padding-block-start: 0.75rem;
     border-block-start: 1px solid var(--color-border);
-}
-
-.count-value {
-    font-family: var(--font-heading);
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-primary);
-}
-
-.count-label {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
 }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -532,6 +532,25 @@ h1:focus {
     font-size: 0.9375rem;
 }
 
+/* Card grid — shared layout for card-based index pages */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.count-value {
+    font-family: var(--font-heading);
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.count-label {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
 /* Card defaults — each Card resets its own variables so nested Cards do not inherit parent overrides */
 .card {
     --card-padding: 1.25rem 1.5rem;

--- a/src/KRAFT.Results.WebApi/Features/Athletes/Get/GetAthletesHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/Get/GetAthletesHandler.cs
@@ -32,7 +32,9 @@ internal sealed class GetAthletesHandler
                 x.Firstname + " " + x.Lastname,
                 x.DateOfBirth != null && x.DateOfBirth.Value.Year > 1 ? (int?)x.DateOfBirth.Value.Year : null,
                 x.DateOfBirth != null && x.DateOfBirth.Value.Year > 1 ? x.DateOfBirth : null,
-                x.Gender == "f" ? "f" : "m"))
+                x.Gender == "f" ? "f" : "m",
+                x.Participations.Count,
+                x.Team != null ? x.Team.Title : null))
             .ToListAsync(cancellationToken);
 
         return rows
@@ -41,7 +43,9 @@ internal sealed class GetAthletesHandler
                 x.Name,
                 x.YearOfBirth,
                 x.Gender,
-                ResolveEligibleSlugs(x.DateOfBirth, meetDate)))
+                ResolveEligibleSlugs(x.DateOfBirth, meetDate),
+                x.ParticipationCount,
+                x.Team))
             .ToList();
     }
 
@@ -52,5 +56,5 @@ internal sealed class GetAthletesHandler
             : ["open"];
     }
 
-    private sealed record AthleteRow(string? Slug, string Name, int? YearOfBirth, DateOnly? DateOfBirth, string Gender);
+    private sealed record AthleteRow(string? Slug, string Name, int? YearOfBirth, DateOnly? DateOfBirth, string Gender, int ParticipationCount, string? Team);
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
@@ -69,7 +69,7 @@ public sealed class AthletesIndexTests : IDisposable
     }
 
     [Fact]
-    public void HidesTableWhenNoAthletes()
+    public void HidesCardGridWhenNoAthletes()
     {
         // Arrange
         RegisterHttpClient([]);
@@ -78,7 +78,7 @@ public sealed class AthletesIndexTests : IDisposable
         IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
 
         // Assert
-        cut.FindAll("table").Count.ShouldBe(0);
+        cut.FindAll(".card-grid").Count.ShouldBe(0);
     }
 
     [Fact]
@@ -162,8 +162,6 @@ public sealed class AthletesIndexTests : IDisposable
         {
             string countText = cut.Find(".card-grid .card .athlete-count .count-value").TextContent.Trim();
             countText.ShouldBe("5");
-            string labelText = cut.Find(".card-grid .card .athlete-count .count-label").TextContent.Trim();
-            labelText.ShouldBe("mót");
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
@@ -87,9 +87,9 @@ public sealed class AthletesIndexTests : IDisposable
         // Arrange
         List<AthleteSummary> athletes =
         [
-            new("jon-jonsson", "Jon Jonsson", 1990, null, []),
-            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, []),
-            new("gudrun-sigurdardottir", "Gudrun Sigurdardottir", 1992, null, []),
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, [], 0, null),
+            new("gudrun-sigurdardottir", "Gudrun Sigurdardottir", 1992, null, [], 0, null),
         ];
         RegisterHttpClient(athletes);
 
@@ -116,8 +116,8 @@ public sealed class AthletesIndexTests : IDisposable
         // Arrange
         List<AthleteSummary> athletes =
         [
-            new("jon-jonsson", "Jon Jonsson", 1990, null, []),
-            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, []),
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, [], 0, null),
         ];
         RegisterHttpClient(athletes);
 
@@ -144,8 +144,8 @@ public sealed class AthletesIndexTests : IDisposable
         // Arrange
         List<AthleteSummary> athletes =
         [
-            new("jon-jonsson", "Jon Jonsson", 1990, null, []),
-            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, []),
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, [], 0, null),
         ];
         RegisterHttpClient(athletes);
 
@@ -172,9 +172,9 @@ public sealed class AthletesIndexTests : IDisposable
         // Arrange
         List<AthleteSummary> athletes =
         [
-            new("jon-jonsson", "Jon Jonsson", 1990, null, []),
-            new("jonas-karlsson", "Jonas Karlsson", 1985, null, []),
-            new("anna-karlsdottir", "Anna Karlsdottir", 1992, null, []),
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+            new("jonas-karlsson", "Jonas Karlsson", 1985, null, [], 0, null),
+            new("anna-karlsdottir", "Anna Karlsdottir", 1992, null, [], 0, null),
         ];
         RegisterHttpClient(athletes);
 
@@ -200,8 +200,8 @@ public sealed class AthletesIndexTests : IDisposable
         // Arrange
         List<AthleteSummary> athletes =
         [
-            new("jon-jonsson", "Jon Jonsson", 1990, null, []),
-            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, []),
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, [], 0, null),
         ];
         RegisterHttpClient(athletes);
 
@@ -230,7 +230,7 @@ public sealed class AthletesIndexTests : IDisposable
         // Arrange
         List<AthleteSummary> athletes =
         [
-            new("jon-jonsson", "Jon Jonsson", 1990, null, []),
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
         ];
         RegisterHttpClient(athletes);
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletesIndexTests.cs
@@ -82,6 +82,175 @@ public sealed class AthletesIndexTests : IDisposable
     }
 
     [Fact]
+    public void RendersAthleteCards_WhenAthletesAreLoaded()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+            new("anna-karlsdottir", "Anna Karlsdottir", 1985, null, [], 0, null),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".card-grid .card").Count.ShouldBe(2);
+        });
+    }
+
+    [Fact]
+    public void CardShowsNameWithBirthYear_WhenYearIsPresent()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            string nameText = cut.Find(".card-grid .card .athlete-name").TextContent.Trim();
+            nameText.ShouldBe("Jon Jonsson (1990)");
+        });
+    }
+
+    [Fact]
+    public void CardShowsNameOnly_WhenBirthYearIsAbsent()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", null, null, [], 0, null),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            string nameText = cut.Find(".card-grid .card .athlete-name").TextContent.Trim();
+            nameText.ShouldBe("Jon Jonsson");
+        });
+    }
+
+    [Fact]
+    public void CardShowsParticipationCount()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 5, null),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            string countText = cut.Find(".card-grid .card .athlete-count .count-value").TextContent.Trim();
+            countText.ShouldBe("5");
+            string labelText = cut.Find(".card-grid .card .athlete-count .count-label").TextContent.Trim();
+            labelText.ShouldBe("mót");
+        });
+    }
+
+    [Fact]
+    public void CardLinksToAthleteDetailPage()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            string href = cut.Find(".card-grid .card a").GetAttribute("href") ?? string.Empty;
+            href.ShouldBe("/athletes/jon-jonsson");
+        });
+    }
+
+    [Fact]
+    public void CardShowsTeam_WhenAthleteHasTeam()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, "Þór"),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            string teamText = cut.Find(".card-grid .card .athlete-team").TextContent.Trim();
+            teamText.ShouldBe("Þór");
+        });
+    }
+
+    [Fact]
+    public void CardOmitsTeamLine_WhenAthleteHasNoTeam()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".card-grid .card .athlete-team").Count.ShouldBe(0);
+        });
+    }
+
+    [Fact]
+    public void CardShowsZeroParticipations_WhenAthleteHasNone()
+    {
+        // Arrange
+        List<AthleteSummary> athletes =
+        [
+            new("jon-jonsson", "Jon Jonsson", 1990, null, [], 0, null),
+        ];
+        RegisterHttpClient(athletes);
+
+        // Act
+        IRenderedComponent<AthletesIndex> cut = _context.Render<AthletesIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            string countText = cut.Find(".card-grid .card .athlete-count .count-value").TextContent.Trim();
+            countText.ShouldBe("0");
+        });
+    }
+
+    [Fact]
     public void FiltersAthletesByFirstName()
     {
         // Arrange
@@ -101,7 +270,7 @@ public sealed class AthletesIndexTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            List<string> visibleNames = cut.FindAll("table tbody tr td a")
+            List<string> visibleNames = cut.FindAll(".card-grid .card .athlete-name")
                 .Select(e => e.TextContent.Trim())
                 .ToList();
 
@@ -129,7 +298,7 @@ public sealed class AthletesIndexTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            List<string> visibleNames = cut.FindAll("table tbody tr td a")
+            List<string> visibleNames = cut.FindAll(".card-grid .card .athlete-name")
                 .Select(e => e.TextContent.Trim())
                 .ToList();
 
@@ -157,7 +326,7 @@ public sealed class AthletesIndexTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            List<string> visibleNames = cut.FindAll("table tbody tr td a")
+            List<string> visibleNames = cut.FindAll(".card-grid .card .athlete-name")
                 .Select(e => e.TextContent.Trim())
                 .ToList();
 
@@ -186,7 +355,7 @@ public sealed class AthletesIndexTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            List<string> visibleNames = cut.FindAll("table tbody tr td a")
+            List<string> visibleNames = cut.FindAll(".card-grid .card .athlete-name")
                 .Select(e => e.TextContent.Trim())
                 .ToList();
 
@@ -210,7 +379,7 @@ public sealed class AthletesIndexTests : IDisposable
 
         cut.WaitForAssertion(() =>
         {
-            cut.FindAll("table tbody tr").Count.ShouldBe(1);
+            cut.FindAll(".card-grid .card").Count.ShouldBe(1);
         });
 
         // Act
@@ -219,7 +388,7 @@ public sealed class AthletesIndexTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            int visibleCount = cut.FindAll("table tbody tr").Count;
+            int visibleCount = cut.FindAll(".card-grid .card").Count;
             visibleCount.ShouldBe(2);
         });
     }
@@ -242,7 +411,7 @@ public sealed class AthletesIndexTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.FindAll("table").Count.ShouldBe(0);
+            cut.FindAll(".card-grid").Count.ShouldBe(0);
             cut.Find(".empty-state").ShouldNotBeNull();
         });
     }

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Athletes/AthletesIndexTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Athletes/AthletesIndexTests.cs
@@ -28,8 +28,8 @@ public class AthletesIndexTests(PlaywrightFixture fixture)
 
         await Expect(searchInput).ToBeVisibleAsync();
 
-        ILocator athleteRows = page.Locator("table tbody tr");
-        await Expect(athleteRows).Not.ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = PageConstants.DefaultTimeoutMs });
+        ILocator athleteCards = page.Locator(".card-grid .card");
+        await Expect(athleteCards).Not.ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = PageConstants.DefaultTimeoutMs });
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class AthletesIndexTests(PlaywrightFixture fixture)
         ILocator searchInput = page.Locator("input.search-input");
         await Expect(searchInput).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
-        ILocator athleteRows = page.Locator("table tbody tr");
-        await Expect(athleteRows.First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = PageConstants.DefaultTimeoutMs });
+        ILocator athleteCards = page.Locator(".card-grid .card");
+        await Expect(athleteCards.First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
         // Wait for the Blazor circuit to finish initializing — AthletesIndex.OnAfterRenderAsync
         // focuses the search input after OnInitializedAsync completes. Filling before this
@@ -55,6 +55,6 @@ public class AthletesIndexTests(PlaywrightFixture fixture)
         await searchInput.FillAsync("zzzznonexistent");
 
         // Assert
-        await Expect(athleteRows).ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = PageConstants.DefaultTimeoutMs });
+        await Expect(athleteCards).ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = PageConstants.DefaultTimeoutMs });
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/CollectionFixture.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Collections/CollectionFixture.cs
@@ -165,6 +165,8 @@ public sealed class CollectionFixture : IAsyncLifetime
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedWeightCategories());
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedEras());
         await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedEraWeightCategories());
+        await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedMeet());
+        await dbContext.Database.ExecuteSqlRawAsync(BaseSeedSql.SeedBaseParticipations());
     }
 
     private static async Task SeedIntegrationRolesAsync(ResultsDbContext dbContext)

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthletesTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthletesTests.cs
@@ -111,7 +111,7 @@ public sealed class GetAthletesTests(CollectionFixture fixture) : IAsyncLifetime
     }
 
     [Fact]
-    public async Task SeededAthleteReturnsParticipationCountAndTeam()
+    public async Task SeededAthlete_ReturnsParticipationCount()
     {
         // Arrange
 
@@ -122,11 +122,24 @@ public sealed class GetAthletesTests(CollectionFixture fixture) : IAsyncLifetime
         AthleteSummary? seededAthlete = response!.FirstOrDefault(x => x.Slug == TestSeedConstants.Athlete.Slug);
         seededAthlete.ShouldNotBeNull();
         seededAthlete.ParticipationCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task SeededAthlete_ReturnsTeam()
+    {
+        // Arrange
+
+        // Act
+        IReadOnlyList<AthleteSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<AthleteSummary>>(Path, CancellationToken.None);
+
+        // Assert
+        AthleteSummary? seededAthlete = response!.FirstOrDefault(x => x.Slug == TestSeedConstants.Athlete.Slug);
+        seededAthlete.ShouldNotBeNull();
         seededAthlete.Team.ShouldBe(TestSeedConstants.Team.Title);
     }
 
     [Fact]
-    public async Task NewAthleteReturnsZeroParticipationCountAndNullTeam()
+    public async Task NewAthlete_ReturnsZeroParticipationCount()
     {
         // Arrange
 
@@ -137,6 +150,19 @@ public sealed class GetAthletesTests(CollectionFixture fixture) : IAsyncLifetime
         AthleteSummary? newAthlete = response!.FirstOrDefault(x => x.Slug == _slug);
         newAthlete.ShouldNotBeNull();
         newAthlete.ParticipationCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task NewAthlete_ReturnsNullTeam()
+    {
+        // Arrange
+
+        // Act
+        IReadOnlyList<AthleteSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<AthleteSummary>>(Path, CancellationToken.None);
+
+        // Assert
+        AthleteSummary? newAthlete = response!.FirstOrDefault(x => x.Slug == _slug);
+        newAthlete.ShouldNotBeNull();
         newAthlete.Team.ShouldBeNull();
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthletesTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthletesTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Tests.Shared;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
@@ -107,5 +108,35 @@ public sealed class GetAthletesTests(CollectionFixture fixture) : IAsyncLifetime
 
         // Assert
         response![0].Name.ShouldBe("0 0");
+    }
+
+    [Fact]
+    public async Task SeededAthleteReturnsParticipationCountAndTeam()
+    {
+        // Arrange
+
+        // Act
+        IReadOnlyList<AthleteSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<AthleteSummary>>(Path, CancellationToken.None);
+
+        // Assert
+        AthleteSummary? seededAthlete = response!.FirstOrDefault(x => x.Slug == TestSeedConstants.Athlete.Slug);
+        seededAthlete.ShouldNotBeNull();
+        seededAthlete.ParticipationCount.ShouldBe(3);
+        seededAthlete.Team.ShouldBe(TestSeedConstants.Team.Title);
+    }
+
+    [Fact]
+    public async Task NewAthleteReturnsZeroParticipationCountAndNullTeam()
+    {
+        // Arrange
+
+        // Act
+        IReadOnlyList<AthleteSummary>? response = await _authorizedHttpClient.GetFromJsonAsync<IReadOnlyList<AthleteSummary>>(Path, CancellationToken.None);
+
+        // Assert
+        AthleteSummary? newAthlete = response!.FirstOrDefault(x => x.Slug == _slug);
+        newAthlete.ShouldNotBeNull();
+        newAthlete.ParticipationCount.ShouldBe(0);
+        newAthlete.Team.ShouldBeNull();
     }
 }


### PR DESCRIPTION
## Summary

- Added `ParticipationCount` (int) and `Team` (string?) to `AthleteSummary` DTO, projected via EF Core correlated subquery and optional navigation
- Replaced the athletes search page HTML table with a card-based layout using the shared `Card` component
- Each card shows athlete name, birth year, participation count ("X mót"), and optional team
- Fixed accessibility: `aria-hidden` overlay anchor, `role="group"` with `aria-label` on count, `title` tooltip for label context

## Test plan

- [x] Integration tests verify seeded athlete returns ParticipationCount=3 and Team="Test team"
- [x] Integration tests verify new athlete returns ParticipationCount=0 and Team=null
- [x] bUnit tests verify card rendering, navigation, team display/omission, count display
- [x] bUnit tests verify search filter and empty state work with card layout
- [x] E2E test locators updated from table to card selectors
- [ ] Manual: verify card layout on narrow screens and with screen reader

Closes #504