### PR TITLE
refactor(web): replace users admin table with cards

### DIFF
--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor.css
@@ -151,17 +151,6 @@
     margin-top: 0.25rem;
 }
 
-.badge {
-    display: inline-block;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    padding: 0.1rem 0.375rem;
-    border-radius: 3px;
-    background: #f3f4f6;
-    color: var(--color-text-muted);
-    line-height: 1.4;
-}
-
 .badge--classic  { background: #eff6ff; color: #2563eb; }
 .badge--equipped { background: #fef3c7; color: #d97706; }
 

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
@@ -8,74 +8,52 @@
 @using KRAFT.Results.Web.Client.Components
 
 @inject HttpClient HttpClient;
-@inject NavigationManager NavigationManager;
 
-<div class="page-header">
-    <h3>Notendur</h3>
-    <button class="btn-action" @onclick="NavigateToCreate">
-        <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-            <path fill-rule="evenodd" d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2" />
-        </svg>
-        Stofna notanda
-    </button>
-</div>
+<PageHeader Title="Notendur" ActionHref="/users/create" ActionLabel="Stofna notanda" />
 
 <DataLoader T="IReadOnlyCollection<UserSummary>" Loader="LoadAsync" Noun="notendur">
     <ChildContent Context="context">
-        <table>
-            <thead>
-                <tr>
-                    <th>Nafn</th>
-                    <th>Tölvupóstfang</th>
-                    <th>Hlutverk</th>
-                    <th>Stofnaður</th>
-                    <th><span class="visually-hidden">Aðgerðir</span></th>
-                </tr>
-            </thead>
-
-            <tbody>
-                @if (!context.Any())
+        @if (context.Any())
+        {
+            <div class="card-grid">
+                @foreach (UserSummary user in context)
                 {
-                    <tr>
-                        <td colspan="5">Engir notendur fundust.</td>
-                    </tr>
+                    <Card>
+                        <div class="user-name">@user.Name</div>
+                        @if (user.Email is not null)
+                        {
+                            <div class="user-email">@user.Email</div>
+                        }
+                        @if (user.Roles.Count > 0)
+                        {
+                            <div class="user-roles">
+                                @foreach (string role in user.Roles)
+                                {
+                                    <span class="badge">@role</span>
+                                }
+                            </div>
+                        }
+                        <div class="user-footer">
+                            <span class="user-date">@user.CreatedOn.ToString("d. MMM yyyy")</span>
+                            <a href="@($"/users/{user.UserId}/edit")" class="btn-edit" aria-label="@($"Breyta {user.Name}")">
+                                <svg class="btn-edit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/>
+                                </svg>
+                                <span>Breyta</span>
+                            </a>
+                        </div>
+                    </Card>
                 }
-                else
-                {
-                    @foreach (UserSummary User in context)
-                    {
-                        <tr>
-                            <td>@User.Name</td>
-                            <td>@User.Email</td>
-                            <td>@string.Join(", ", User.Roles)</td>
-                            <td>@User.CreatedOn.ToShortDateString()</td>
-                            <td>
-                                <button type="button" class="btn-edit" @onclick="@(() => NavigateToEdit(User.UserId))" aria-label="@($"Breyta {User.Name}")">
-                                    <svg class="btn-edit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                        <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/>
-                                    </svg>
-                                    <span>Breyta</span>
-                                </button>
-                            </td>
-                        </tr>
-                    }
-                }
-            </tbody>
-        </table>
+            </div>
+        }
+        else
+        {
+            <EmptyState Message="Engir notendur fundust." />
+        }
     </ChildContent>
 </DataLoader>
 
 @code {
-    private void NavigateToCreate()
-    {
-        NavigationManager.NavigateTo("/users/create");
-    }
-
-    private void NavigateToEdit(int userId)
-    {
-        NavigationManager.NavigateTo($"/users/{userId}/edit");
-    }
-
     private async Task<IReadOnlyCollection<UserSummary>?> LoadAsync()
     {
         return await HttpClient.GetFromJsonAsync<IReadOnlyCollection<UserSummary>>("/users");

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
@@ -20,14 +20,14 @@
                 @foreach (UserSummary user in context)
                 {
                     <Card>
-                        <h2 class="user-name">@user.Name</h2>
+                        <div class="user-name">@user.Name</div>
                         @if (user.Email is not null)
                         {
                             <div class="user-email">@user.Email</div>
                         }
                         @if (user.Roles.Count > 0)
                         {
-                            <div class="user-roles" aria-label="Hlutverk">
+                            <div class="user-roles" role="group" aria-label="Hlutverk">
                                 @foreach (string role in user.Roles)
                                 {
                                     <span class="badge">@role</span>

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
@@ -4,6 +4,7 @@
 
 @attribute [Authorize(Roles = "Admin")]
 
+@using System.Globalization
 @using KRAFT.Results.Contracts.Users
 @using KRAFT.Results.Web.Client.Components
 
@@ -19,14 +20,14 @@
                 @foreach (UserSummary user in context)
                 {
                     <Card>
-                        <div class="user-name">@user.Name</div>
+                        <h2 class="user-name">@user.Name</h2>
                         @if (user.Email is not null)
                         {
                             <div class="user-email">@user.Email</div>
                         }
                         @if (user.Roles.Count > 0)
                         {
-                            <div class="user-roles">
+                            <div class="user-roles" aria-label="Hlutverk">
                                 @foreach (string role in user.Roles)
                                 {
                                     <span class="badge">@role</span>
@@ -34,7 +35,7 @@
                             </div>
                         }
                         <div class="user-footer">
-                            <span class="user-date">@user.CreatedOn.ToString("d. MMM yyyy")</span>
+                            <span class="user-date">@user.CreatedOn.ToString("d. MMM yyyy", new CultureInfo("is-IS"))</span>
                             <a href="@($"/users/{user.UserId}/edit")" class="btn-edit" aria-label="@($"Breyta {user.Name}")">
                                 <svg class="btn-edit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                     <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z"/>
@@ -48,7 +49,7 @@
         }
         else
         {
-            <EmptyState Message="Engir notendur fundust." />
+            <EmptyState Message="Engir notendur eru skráðir." />
         }
     </ChildContent>
 </DataLoader>

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor
@@ -19,21 +19,23 @@
             <div class="card-grid">
                 @foreach (UserSummary user in context)
                 {
-                    <Card>
-                        <div class="user-name">@user.Name</div>
-                        @if (user.Email is not null)
-                        {
-                            <div class="user-email">@user.Email</div>
-                        }
-                        @if (user.Roles.Count > 0)
-                        {
-                            <div class="user-roles" role="group" aria-label="Hlutverk">
-                                @foreach (string role in user.Roles)
-                                {
-                                    <span class="badge">@role</span>
-                                }
-                            </div>
-                        }
+                    <Card CssClass="user-card">
+                        <div class="user-body">
+                            <div class="user-name">@user.Name</div>
+                            @if (user.Email is not null)
+                            {
+                                <div class="user-email">@user.Email</div>
+                            }
+                            @if (user.Roles.Count > 0)
+                            {
+                                <div class="user-roles" role="group" aria-label="Hlutverk">
+                                    @foreach (string role in user.Roles)
+                                    {
+                                        <span class="badge">@role</span>
+                                    }
+                                </div>
+                            }
+                        </div>
                         <div class="user-footer">
                             <span class="user-date">@user.CreatedOn.ToString("d. MMM yyyy", new CultureInfo("is-IS"))</span>
                             <a href="@($"/users/{user.UserId}/edit")" class="btn-edit" aria-label="@($"Breyta {user.Name}")">

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
@@ -1,3 +1,37 @@
+.user-name {
+    font-family: var(--font-heading);
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.user-email {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+
+.user-roles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    margin-block-start: 0.5rem;
+}
+
+.user-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-block-start: 0.75rem;
+    padding-block-start: 0.75rem;
+    border-block-start: 1px solid var(--color-border);
+}
+
+.user-date {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
 .btn-edit {
     display: inline-flex;
     align-items: center;

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
@@ -3,6 +3,7 @@
     font-size: 1.05rem;
     font-weight: 700;
     color: var(--color-text);
+    margin: 0;
 }
 
 .user-email {
@@ -36,7 +37,8 @@
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    padding: 0.25rem 0.625rem;
+    padding: 0.625rem 0.75rem;
+    min-height: 2.75rem;
     font-family: var(--font-body);
     font-size: 0.8125rem;
     font-weight: 500;
@@ -69,7 +71,7 @@
 }
 
 .btn-edit:active {
-    background: #f8dde1;
+    background: var(--color-primary-light);
     color: var(--color-primary-dark);
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
@@ -3,7 +3,6 @@
     font-size: 1.05rem;
     font-weight: 700;
     color: var(--color-text);
-    margin: 0;
 }
 
 .user-email {

--- a/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Users/UserIndex.razor.css
@@ -1,3 +1,12 @@
+::deep .user-card {
+    display: flex;
+    flex-direction: column;
+}
+
+.user-body {
+    flex: 1;
+}
+
 .user-name {
     font-family: var(--font-heading);
     font-size: 1.05rem;
@@ -22,7 +31,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
-    margin-block-start: 0.75rem;
+    margin-block-start: auto;
     padding-block-start: 0.75rem;
     border-block-start: 1px solid var(--color-border);
 }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -57,30 +57,6 @@ a:hover {
     color: var(--color-primary-dark);
 }
 
-table {
-    border-collapse: collapse;
-    width: 100%;
-}
-
-th, td {
-    padding: 0.75rem 1rem;
-    text-align: left;
-}
-
-th {
-    background-color: var(--color-text);
-    color: var(--color-white);
-    font-family: var(--font-heading);
-    font-weight: 500;
-    font-size: 0.8125rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-tbody tr:nth-child(even) {
-    background-color: var(--color-primary-light);
-}
-
 .content {
     padding-top: 1.1rem;
 }
@@ -549,6 +525,18 @@ h1:focus {
 .count-label {
     font-size: 0.8rem;
     color: var(--color-text-muted);
+}
+
+/* Badge — shared pill label used across Dashboard records and User roles */
+.badge {
+    display: inline-block;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    padding: 0.1rem 0.375rem;
+    border-radius: 3px;
+    background: #f3f4f6;
+    color: var(--color-text-muted);
+    line-height: 1.4;
 }
 
 /* Card defaults — each Card resets its own variables so nested Cards do not inherit parent overrides */

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Users/UserIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Users/UserIndexTests.cs
@@ -56,12 +56,12 @@ public sealed class UserIndexTests : IDisposable
         IRenderedComponent<UserIndex> cut = _context.Render<UserIndex>();
 
         // Assert
-        cut.Find("button.btn-action").ShouldNotBeNull();
-        cut.Find("button.btn-action").TextContent.ShouldContain("Stofna notanda");
+        cut.Find("a.btn-action").ShouldNotBeNull();
+        cut.Find("a.btn-action").TextContent.ShouldContain("Stofna notanda");
     }
 
     [Fact]
-    public void ShowsUserTable_WhenUsersAreLoaded()
+    public void ShowsUserCards_WhenUsersAreLoaded()
     {
         // Arrange
         List<UserSummary> users =
@@ -77,7 +77,7 @@ public sealed class UserIndexTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.FindAll("table tbody tr").Count.ShouldBe(2);
+            cut.FindAll(".card-grid .card").Count.ShouldBe(2);
         });
     }
 
@@ -92,7 +92,7 @@ public sealed class UserIndexTests : IDisposable
         MockHttpMessageHandler<UserSummary> handler = new(users);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
-        _context.AddAuthorization();
+        _context.AddAuthorization().SetRoles("Admin");
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
@@ -101,6 +101,6 @@ public sealed class UserIndexTests : IDisposable
         FailingHttpMessageHandler handler = new();
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
-        _context.AddAuthorization();
+        _context.AddAuthorization().SetRoles("Admin");
     }
 }

--- a/tests/KRAFT.Results.Web.E2ETests/Features/Users/UserIndexTests.cs
+++ b/tests/KRAFT.Results.Web.E2ETests/Features/Users/UserIndexTests.cs
@@ -9,7 +9,7 @@ public class UserIndexTests(PlaywrightFixture fixture)
     private readonly PlaywrightFixture _fixture = fixture;
 
     [Fact]
-    public async Task DisplaysUserList_WhenLoggedIn()
+    public async Task DisplaysUserCards_WhenLoggedIn()
     {
         // Arrange
         (IBrowserContext context, IPage page) = await _fixture.NewPageAsync();
@@ -26,9 +26,9 @@ public class UserIndexTests(PlaywrightFixture fixture)
         // Assert
         await Expect(heading).ToBeVisibleAsync();
 
-        ILocator tableRows = page.Locator("table tbody tr");
-        await Expect(tableRows.First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = PageConstants.DefaultTimeoutMs });
+        ILocator userCards = page.Locator(".card-grid .card");
+        await Expect(userCards.First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = PageConstants.DefaultTimeoutMs });
 
-        await Expect(tableRows).Not.ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = PageConstants.DefaultTimeoutMs });
+        await Expect(userCards).Not.ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = PageConstants.DefaultTimeoutMs });
     }
 }


### PR DESCRIPTION
## Summary

- Replace the admin Users page HTML table with card-based display using the shared `Card` component
- Adopt `PageHeader` component, replacing manual page-header div + button
- Display user roles as badges with proper accessibility (`role="group"` + `aria-label`)
- Edit action uses semantic `<a>` link instead of button + `NavigationManager`
- Extract `.badge` base class from `DashboardPage.razor.css` to `app.css` (shared by Dashboard + Users)
- Remove all global table styles from `app.css` (last table consumer removed)
- Anchor card footer (date + edit button) to bottom of card for consistent alignment

## Test plan

- [ ] Load `/users` as admin — verify cards display with name, email, role badges, created date
- [ ] Click "Breyta" edit link — verify navigation to edit page
- [ ] Verify empty state renders when no users exist
- [ ] Verify Dashboard page still renders badges correctly (classic/equipped modifiers)
- [ ] Inspect `app.css` — confirm no table styles remain
- [ ] Verify no visual regressions on Athletes, Teams, and other card-based pages
- [ ] Test on mobile — verify tap target on edit button is at least 44px
- [ ] Screen reader: verify role badges are announced with "Hlutverk" group label

Closes #505