### PR TITLE
feat(web): display team logo images on cards and detail pages

### DIFF
--- a/src/KRAFT.Results.Contracts/Teams/TeamDetails.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamDetails.cs
@@ -6,4 +6,5 @@ public sealed record class TeamDetails(
     string ShortTitle,
     string FullTitle,
     string CountryCode,
+    string? LogoImageFilename,
     IReadOnlyList<TeamMember> Members);

--- a/src/KRAFT.Results.Contracts/Teams/TeamSummary.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamSummary.cs
@@ -1,3 +1,3 @@
 ﻿namespace KRAFT.Results.Contracts.Teams;
 
-public sealed record class TeamSummary(string Slug, string Title, string ShortTitle, int AthleteCount);
+public sealed record class TeamSummary(string Slug, string Title, string ShortTitle, string? LogoImageFilename, int AthleteCount);

--- a/src/KRAFT.Results.Contracts/Teams/TeamSummary.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamSummary.cs
@@ -1,3 +1,8 @@
 ﻿namespace KRAFT.Results.Contracts.Teams;
 
-public sealed record class TeamSummary(string Slug, string Title, string ShortTitle, string? LogoImageFilename, int AthleteCount);
+public sealed record class TeamSummary(
+    string Slug,
+    string Title,
+    string ShortTitle,
+    string? LogoImageFilename,
+    int AthleteCount);

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -9,20 +9,12 @@
              alt="@Alt"
              loading="lazy"
              onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
-        <div class="team-logo-placeholder" style="display:none">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-            </svg>
-        </div>
     }
-    else
-    {
-        <div class="team-logo-placeholder">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-            </svg>
-        </div>
-    }
+    <div class="team-logo-placeholder" style="@(_isValidFilename ? "display:none" : "")" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+        </svg>
+    </div>
 </div>
 
 @code {
@@ -55,7 +47,8 @@
         };
 
         _isValidFilename = Filename is not null
-            && Filename == Path.GetFileName(Filename)
+            && !Filename.Contains('/')
+            && !Filename.Contains('\\')
             && !Filename.Contains(':');
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -1,0 +1,61 @@
+﻿@using Microsoft.Extensions.Configuration
+
+@inject IConfiguration Configuration
+
+<div class="team-logo @_sizeClass">
+    @if (_isValidFilename)
+    {
+        <img src="@($"{_teamLogoBaseUrl}/{Filename}")"
+             alt="@Alt"
+             loading="lazy"
+             onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
+        <div class="team-logo-placeholder" style="display:none">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+            </svg>
+        </div>
+    }
+    else
+    {
+        <div class="team-logo-placeholder">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+            </svg>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public string? Filename { get; set; }
+
+    [Parameter]
+    public string Alt { get; set; } = "";
+
+    [Parameter, EditorRequired]
+    public TeamLogoSize Size { get; set; }
+
+    private string _teamLogoBaseUrl = "";
+    private string _sizeClass = "";
+    private bool _isValidFilename;
+
+    protected override void OnInitialized()
+    {
+        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
+    }
+
+    protected override void OnParametersSet()
+    {
+        _sizeClass = Size switch
+        {
+            TeamLogoSize.Small => "team-logo--sm",
+            TeamLogoSize.Medium => "team-logo--md",
+            TeamLogoSize.Large => "team-logo--lg",
+            _ => "team-logo--md",
+        };
+
+        _isValidFilename = Filename is not null
+            && Filename == Path.GetFileName(Filename)
+            && !Filename.Contains(':');
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -5,7 +5,7 @@
 <div class="team-logo @_sizeClass">
     @if (_isValidFilename)
     {
-        <img src="@($"{_teamLogoBaseUrl}/{Filename}")"
+        <img src="@($"{_teamLogoBaseUrl}/{Filename}{_sizeQuery}")"
              alt="@Alt"
              loading="lazy"
              onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
@@ -29,6 +29,7 @@
 
     private string _teamLogoBaseUrl = "";
     private string _sizeClass = "";
+    private string _sizeQuery = "";
     private bool _isValidFilename;
 
     protected override void OnInitialized()
@@ -44,6 +45,14 @@
             TeamLogoSize.Medium => "team-logo--md",
             TeamLogoSize.Large => "team-logo--lg",
             _ => "team-logo--md",
+        };
+
+        _sizeQuery = Size switch
+        {
+            TeamLogoSize.Small => "?width=48&height=48",
+            TeamLogoSize.Medium => "?width=96&height=96",
+            TeamLogoSize.Large => "?width=160&height=160",
+            _ => "?width=96&height=96",
         };
 
         _isValidFilename = Filename is not null

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -49,10 +49,10 @@
 
         _sizeQuery = Size switch
         {
-            TeamLogoSize.Small => "?width=48&height=48",
-            TeamLogoSize.Medium => "?width=96&height=96",
-            TeamLogoSize.Large => "?width=160&height=160",
-            _ => "?width=96&height=96",
+            TeamLogoSize.Small => "?width=64&height=64",
+            TeamLogoSize.Medium => "?width=128&height=128",
+            TeamLogoSize.Large => "?width=128&height=128",
+            _ => "?width=128&height=128",
         };
 
         _isValidFilename = Filename is not null

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor.css
@@ -1,0 +1,42 @@
+﻿.team-logo {
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.team-logo--sm {
+    width: 24px;
+    height: 24px;
+}
+
+.team-logo--md {
+    width: 48px;
+    height: 48px;
+}
+
+.team-logo--lg {
+    width: 80px;
+    height: 80px;
+}
+
+.team-logo img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.team-logo-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: color-mix(in oklch, var(--color-border), transparent 40%);
+    color: var(--color-text-muted);
+    opacity: 0.4;
+}
+
+.team-logo-placeholder svg {
+    width: 60%;
+    height: 60%;
+}

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogoSize.cs
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogoSize.cs
@@ -1,0 +1,8 @@
+﻿namespace KRAFT.Results.Web.Client.Components;
+
+public enum TeamLogoSize
+{
+    Small,
+    Medium,
+    Large,
+}

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
@@ -1,4 +1,7 @@
 @using KRAFT.Results.Contracts.TeamCompetition
+@using Microsoft.Extensions.Configuration
+
+@inject IConfiguration Configuration
 
 <Card Compact="true" CssClass="@(_isFirst ? "card-spaced sc-card-first" : "card-spaced")">
 <div class="sc-card">
@@ -14,6 +17,28 @@
             @_rankDisplay
         </div>
     }
+    <div class="team-logo team-logo--sm">
+        @if (Standing.LogoImageFilename is not null)
+        {
+            <img src="@($"{_teamLogoBaseUrl}/{Standing.LogoImageFilename}")"
+                 alt="@($"{Standing.TeamName} logo")"
+                 loading="lazy"
+                 onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
+            <div class="team-logo-placeholder" style="display:none">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+                </svg>
+            </div>
+        }
+        else
+        {
+            <div class="team-logo-placeholder">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+                </svg>
+            </div>
+        }
+    </div>
     <div class="sc-name-col">
         @if (!string.IsNullOrEmpty(Standing.TeamSlug))
         {
@@ -41,6 +66,12 @@
     private string _rankDisplay = string.Empty;
     private string _rankClass = string.Empty;
     private string _rankAriaLabel = string.Empty;
+    private string _teamLogoBaseUrl = "";
+
+    protected override void OnInitialized()
+    {
+        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
+    }
 
     protected override void OnParametersSet()
     {

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor
@@ -1,7 +1,5 @@
 @using KRAFT.Results.Contracts.TeamCompetition
-@using Microsoft.Extensions.Configuration
-
-@inject IConfiguration Configuration
+@using KRAFT.Results.Web.Client.Components
 
 <Card Compact="true" CssClass="@(_isFirst ? "card-spaced sc-card-first" : "card-spaced")">
 <div class="sc-card">
@@ -17,28 +15,7 @@
             @_rankDisplay
         </div>
     }
-    <div class="team-logo team-logo--sm">
-        @if (Standing.LogoImageFilename is not null)
-        {
-            <img src="@($"{_teamLogoBaseUrl}/{Standing.LogoImageFilename}")"
-                 alt="@($"{Standing.TeamName} logo")"
-                 loading="lazy"
-                 onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
-            <div class="team-logo-placeholder" style="display:none">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-                </svg>
-            </div>
-        }
-        else
-        {
-            <div class="team-logo-placeholder">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-                </svg>
-            </div>
-        }
-    </div>
+    <TeamLogo Filename="@Standing.LogoImageFilename" Size="TeamLogoSize.Small" />
     <div class="sc-name-col">
         @if (!string.IsNullOrEmpty(Standing.TeamSlug))
         {
@@ -66,12 +43,6 @@
     private string _rankDisplay = string.Empty;
     private string _rankClass = string.Empty;
     private string _rankAriaLabel = string.Empty;
-    private string _teamLogoBaseUrl = "";
-
-    protected override void OnInitialized()
-    {
-        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
-    }
 
     protected override void OnParametersSet()
     {

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
@@ -16,6 +16,39 @@
 
 .rank-medal { background: transparent; font-size: 22px; width: auto; min-width: 26px; }
 
+.team-logo {
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.team-logo--sm {
+    width: 24px;
+    height: 24px;
+}
+
+.team-logo img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.team-logo-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: color-mix(in oklch, var(--color-border), transparent 40%);
+    color: var(--color-text-muted);
+    opacity: 0.4;
+}
+
+.team-logo-placeholder svg {
+    width: 60%;
+    height: 60%;
+}
+
 .sc-name-col { display: flex; flex-direction: column; min-width: 0; flex: 1; }
 
 .sc-team-abbr {

--- a/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/TeamCompetition/StandingsCard.razor.css
@@ -16,39 +16,6 @@
 
 .rank-medal { background: transparent; font-size: 22px; width: auto; min-width: 26px; }
 
-.team-logo {
-    flex-shrink: 0;
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-}
-
-.team-logo--sm {
-    width: 24px;
-    height: 24px;
-}
-
-.team-logo img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-}
-
-.team-logo-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    background: color-mix(in oklch, var(--color-border), transparent 40%);
-    color: var(--color-text-muted);
-    opacity: 0.4;
-}
-
-.team-logo-placeholder svg {
-    width: 60%;
-    height: 60%;
-}
-
 .sc-name-col { display: flex; flex-direction: column; min-width: 0; flex: 1; }
 
 .sc-team-abbr {

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
@@ -3,14 +3,40 @@
 @using KRAFT.Results.Contracts.Teams
 @using KRAFT.Results.Web.Client.Components
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.Extensions.Configuration
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
+@inject IConfiguration Configuration
 
 <DataLoader T="TeamDetails" Loader="LoadAsync" Noun="félag">
     <ChildContent Context="team">
         <div class="page-header">
-            <h1>@team.FullTitle (@team.ShortTitle)</h1>
+            <div class="team-detail-header">
+                <div class="team-logo team-logo--lg">
+                    @if (team.LogoImageFilename is not null)
+                    {
+                        <img src="@($"{_teamLogoBaseUrl}/{team.LogoImageFilename}")"
+                             alt="@($"{team.FullTitle} logo")"
+                             loading="lazy"
+                             onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
+                        <div class="team-logo-placeholder" style="display:none">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+                            </svg>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="team-logo-placeholder">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+                            </svg>
+                        </div>
+                    }
+                </div>
+                <h1>@team.FullTitle (@team.ShortTitle)</h1>
+            </div>
             <AuthorizeView Roles="Admin">
                 <div class="admin-actions">
                     <a href="/teams/@Slug/edit" class="btn-action" aria-label="Breyta félagi">
@@ -68,12 +94,18 @@
 </DataLoader>
 
 @code {
+    private string _teamLogoBaseUrl = "";
     private ConfirmDialog _deleteDialog = null!;
     private bool _isDeleting;
     private string? _deleteErrorMessage;
 
     [Parameter]
     public string Slug { get; set; } = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
+    }
 
     private async Task<TeamDetails?> LoadAsync()
     {

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
@@ -3,38 +3,15 @@
 @using KRAFT.Results.Contracts.Teams
 @using KRAFT.Results.Web.Client.Components
 @using Microsoft.AspNetCore.Components.Routing
-@using Microsoft.Extensions.Configuration
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
-@inject IConfiguration Configuration
 
 <DataLoader T="TeamDetails" Loader="LoadAsync" Noun="félag">
     <ChildContent Context="team">
         <div class="page-header">
             <div class="team-detail-header">
-                <div class="team-logo team-logo--lg">
-                    @if (team.LogoImageFilename is not null)
-                    {
-                        <img src="@($"{_teamLogoBaseUrl}/{team.LogoImageFilename}")"
-                             alt="@($"{team.FullTitle} logo")"
-                             loading="lazy"
-                             onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
-                        <div class="team-logo-placeholder" style="display:none">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-                            </svg>
-                        </div>
-                    }
-                    else
-                    {
-                        <div class="team-logo-placeholder">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-                            </svg>
-                        </div>
-                    }
-                </div>
+                <TeamLogo Filename="@team.LogoImageFilename" Alt="@team.FullTitle" Size="TeamLogoSize.Large" />
                 <h1>@team.FullTitle (@team.ShortTitle)</h1>
             </div>
             <AuthorizeView Roles="Admin">
@@ -94,18 +71,12 @@
 </DataLoader>
 
 @code {
-    private string _teamLogoBaseUrl = "";
     private ConfirmDialog _deleteDialog = null!;
     private bool _isDeleting;
     private string? _deleteErrorMessage;
 
     [Parameter]
     public string Slug { get; set; } = string.Empty;
-
-    protected override void OnInitialized()
-    {
-        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
-    }
 
     private async Task<TeamDetails?> LoadAsync()
     {

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
@@ -8,36 +8,3 @@
     align-items: center;
     gap: 1rem;
 }
-
-.team-logo {
-    flex-shrink: 0;
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-}
-
-.team-logo--lg {
-    width: 80px;
-    height: 80px;
-}
-
-.team-logo img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-}
-
-.team-logo-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    background: color-mix(in oklch, var(--color-border), transparent 40%);
-    color: var(--color-text-muted);
-    opacity: 0.4;
-}
-
-.team-logo-placeholder svg {
-    width: 60%;
-    height: 60%;
-}

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
@@ -2,3 +2,42 @@
     border-block-end: 1px solid var(--color-border);
     margin-block-end: 1rem;
 }
+
+.team-detail-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.team-logo {
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.team-logo--lg {
+    width: 80px;
+    height: 80px;
+}
+
+.team-logo img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.team-logo-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: color-mix(in oklch, var(--color-border), transparent 40%);
+    color: var(--color-text-muted);
+    opacity: 0.4;
+}
+
+.team-logo-placeholder svg {
+    width: 60%;
+    height: 60%;
+}

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
@@ -3,9 +3,11 @@
 @using KRAFT.Results.Contracts.Teams
 @using KRAFT.Results.Web.Client.Components
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.Extensions.Configuration
 
 @inject HttpClient HttpClient;
 @inject NavigationManager NavigationManager;
+@inject IConfiguration Configuration;
 
 <PageHeader Title="Félög" ActionHref="/teams/create" ActionLabel="Stofna félag" />
 
@@ -16,11 +18,37 @@
             {
                 <Card Clickable="true">
                     <a href="@($"/teams/{team.Slug}")" aria-label="@team.Title"></a>
-                    <div class="team-name">@team.Title</div>
-                    <div class="team-short">@team.ShortTitle</div>
-                    <div class="team-count">
-                        <span class="count-value">@team.AthleteCount</span>
-                        <span class="count-label">meðlimir</span>
+                    <div class="team-card-content">
+                        <div class="team-logo team-logo--md">
+                            @if (team.LogoImageFilename is not null)
+                            {
+                                <img src="@($"{_teamLogoBaseUrl}/{team.LogoImageFilename}")"
+                                     alt="@($"{team.Title} logo")"
+                                     loading="lazy"
+                                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
+                                <div class="team-logo-placeholder" style="display:none">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                        <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+                                    </svg>
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="team-logo-placeholder">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                        <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
+                                    </svg>
+                                </div>
+                            }
+                        </div>
+                        <div class="team-card-text">
+                            <div class="team-name">@team.Title</div>
+                            <div class="team-short">@team.ShortTitle</div>
+                            <div class="team-count">
+                                <span class="count-value">@team.AthleteCount</span>
+                                <span class="count-label">meðlimir</span>
+                            </div>
+                        </div>
                     </div>
                 </Card>
             }
@@ -29,6 +57,13 @@
 </DataLoader>
 
 @code {
+    private string _teamLogoBaseUrl = "";
+
+    protected override void OnInitialized()
+    {
+        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
+    }
+
     private async Task<IReadOnlyCollection<TeamSummary>?> LoadAsync()
     {
         return await HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamSummary>>("/teams");

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
@@ -3,11 +3,9 @@
 @using KRAFT.Results.Contracts.Teams
 @using KRAFT.Results.Web.Client.Components
 @using Microsoft.AspNetCore.Components.Routing
-@using Microsoft.Extensions.Configuration
 
 @inject HttpClient HttpClient;
 @inject NavigationManager NavigationManager;
-@inject IConfiguration Configuration;
 
 <PageHeader Title="Félög" ActionHref="/teams/create" ActionLabel="Stofna félag" />
 
@@ -19,28 +17,7 @@
                 <Card Clickable="true">
                     <a href="@($"/teams/{team.Slug}")" aria-label="@team.Title"></a>
                     <div class="team-card-content">
-                        <div class="team-logo team-logo--md">
-                            @if (team.LogoImageFilename is not null)
-                            {
-                                <img src="@($"{_teamLogoBaseUrl}/{team.LogoImageFilename}")"
-                                     alt="@($"{team.Title} logo")"
-                                     loading="lazy"
-                                     onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
-                                <div class="team-logo-placeholder" style="display:none">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                        <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-                                    </svg>
-                                </div>
-                            }
-                            else
-                            {
-                                <div class="team-logo-placeholder">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                        <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 2.18l7 3.12v4.7c0 4.83-3.13 9.37-7 10.82-3.87-1.45-7-5.99-7-10.82V6.3l7-3.12z" />
-                                    </svg>
-                                </div>
-                            }
-                        </div>
+                        <TeamLogo Filename="@team.LogoImageFilename" Size="TeamLogoSize.Medium" />
                         <div class="team-card-text">
                             <div class="team-name">@team.Title</div>
                             <div class="team-short">@team.ShortTitle</div>
@@ -57,13 +34,6 @@
 </DataLoader>
 
 @code {
-    private string _teamLogoBaseUrl = "";
-
-    protected override void OnInitialized()
-    {
-        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
-    }
-
     private async Task<IReadOnlyCollection<TeamSummary>?> LoadAsync()
     {
         return await HttpClient.GetFromJsonAsync<IReadOnlyCollection<TeamSummary>>("/teams");

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor
@@ -11,7 +11,7 @@
 
 <DataLoader T="IReadOnlyCollection<TeamSummary>" Loader="LoadAsync" Noun="félög">
     <ChildContent Context="context">
-        <div class="card-grid">
+        <div class="card-grid" style="grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr))">
             @foreach (TeamSummary team in context)
             {
                 <Card Clickable="true">

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
@@ -9,39 +9,6 @@
     align-items: flex-start;
 }
 
-.team-logo {
-    flex-shrink: 0;
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-}
-
-.team-logo--md {
-    width: 48px;
-    height: 48px;
-}
-
-.team-logo img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-}
-
-.team-logo-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    background: color-mix(in oklch, var(--color-border), transparent 40%);
-    color: var(--color-text-muted);
-    opacity: 0.4;
-}
-
-.team-logo-placeholder svg {
-    width: 60%;
-    height: 60%;
-}
-
 .team-card-text {
     flex: 1;
     min-width: 0;

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
@@ -1,8 +1,60 @@
+::deep .card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+.team-card-content {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.team-logo {
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.team-logo--md {
+    width: 48px;
+    height: 48px;
+}
+
+.team-logo img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.team-logo-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: color-mix(in oklch, var(--color-border), transparent 40%);
+    color: var(--color-text-muted);
+    opacity: 0.4;
+}
+
+.team-logo-placeholder svg {
+    width: 60%;
+    height: 60%;
+}
+
+.team-card-text {
+    flex: 1;
+    min-width: 0;
+}
+
 .team-name {
     font-family: var(--font-heading);
     font-size: 1.05rem;
     font-weight: 700;
     color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .team-short {

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamsIndex.razor.css
@@ -1,6 +1,3 @@
-::deep .card-grid {
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-}
 
 .team-card-content {
     display: flex;

--- a/src/KRAFT.Results.Web/appsettings.json
+++ b/src/KRAFT.Results.Web/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "TeamLogoBaseUrl": "https://resultskraftis.blob.core.windows.net/images"
 }

--- a/src/KRAFT.Results.Web/appsettings.json
+++ b/src/KRAFT.Results.Web/appsettings.json
@@ -6,5 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-  "TeamLogoBaseUrl": "https://resultskraftis.blob.core.windows.net/images"
+  "TeamLogoBaseUrl": "https://results.kraft.is/azure/images"
 }

--- a/src/KRAFT.Results.WebApi/Features/Teams/Get/GetTeamsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/Get/GetTeamsHandler.cs
@@ -22,6 +22,7 @@ internal sealed class GetTeamsHandler
             x.Slug,
             x.Title,
             x.TitleShort,
+            x.LogoImageFilename,
             x.Athletes.Count))
         .ToListAsync(cancellationToken);
 }

--- a/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
@@ -22,6 +22,7 @@ internal sealed class GetTeamDetailsHandler
             x.TitleShort,
             x.TitleFull,
             x.Country.Value,
+            x.LogoImageFilename,
             x.Athletes
                 .OrderBy(x => x.Firstname)
                 .ThenBy(x => x.Lastname)

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -47,7 +47,7 @@ public sealed class TeamLogoTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=96&height=96");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
         img.GetAttribute("loading").ShouldBe("lazy");
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -1,0 +1,141 @@
+﻿using Bunit;
+
+using KRAFT.Results.Web.Client.Components;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Components;
+
+public sealed class TeamLogoTests : IDisposable
+{
+    private const string TeamLogoBaseUrl = "https://example.blob.core.windows.net/images";
+
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void RendersSvgPlaceholder_WhenFilenameIsNull()
+    {
+        // Arrange
+        RegisterConfiguration();
+
+        // Act
+        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
+            p => p.Add(c => c.Size, TeamLogoSize.Medium));
+
+        // Assert
+        cut.Find(".team-logo svg").ShouldNotBeNull();
+        cut.FindAll(".team-logo img").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RendersImg_WhenFilenameIsProvided()
+    {
+        // Arrange
+        RegisterConfiguration();
+
+        // Act
+        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
+            p => p
+                .Add(c => c.Filename, "thor.png")
+                .Add(c => c.Size, TeamLogoSize.Medium));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+        img.GetAttribute("loading").ShouldBe("lazy");
+    }
+
+    [Fact]
+    public void AltDefaultsToEmpty_ForDecorativeUse()
+    {
+        // Arrange
+        RegisterConfiguration();
+
+        // Act
+        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
+            p => p
+                .Add(c => c.Filename, "thor.png")
+                .Add(c => c.Size, TeamLogoSize.Medium));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
+        img.GetAttribute("alt").ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void RendersAltText_WhenAltIsProvided()
+    {
+        // Arrange
+        RegisterConfiguration();
+
+        // Act
+        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
+            p => p
+                .Add(c => c.Filename, "thor.png")
+                .Add(c => c.Alt, "Þór IF")
+                .Add(c => c.Size, TeamLogoSize.Large));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
+        img.GetAttribute("alt").ShouldBe("Þór IF");
+    }
+
+    [Theory]
+    [InlineData(TeamLogoSize.Small, "team-logo--sm")]
+    [InlineData(TeamLogoSize.Medium, "team-logo--md")]
+    [InlineData(TeamLogoSize.Large, "team-logo--lg")]
+    public void AppliesSizeClass_ForEachSize(TeamLogoSize size, string expectedClass)
+    {
+        // Arrange
+        RegisterConfiguration();
+
+        // Act
+        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
+            p => p.Add(c => c.Size, size));
+
+        // Assert
+        cut.Find($".team-logo.{expectedClass}").ShouldNotBeNull();
+    }
+
+    [Theory]
+    [InlineData("../evil.png")]
+    [InlineData("subdir/logo.png")]
+    [InlineData("C:\\logos\\evil.png")]
+    [InlineData("http://evil.com/logo.png")]
+    [InlineData("//evil.com/logo.png")]
+    [InlineData("javascript:alert(1)")]
+    public void ShowsPlaceholder_WhenFilenameIsInvalid(string invalidFilename)
+    {
+        // Arrange
+        RegisterConfiguration();
+
+        // Act
+        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
+            p => p
+                .Add(c => c.Filename, invalidFilename)
+                .Add(c => c.Size, TeamLogoSize.Medium));
+
+        // Assert
+        cut.Find(".team-logo svg").ShouldNotBeNull();
+        cut.FindAll(".team-logo img").Count.ShouldBe(0);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private void RegisterConfiguration()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+            })
+            .Build();
+        _context.Services.AddSingleton(configuration);
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -15,11 +15,15 @@ public sealed class TeamLogoTests : IDisposable
 
     private readonly BunitContext _context = new();
 
+    public TeamLogoTests()
+    {
+        RegisterConfiguration();
+    }
+
     [Fact]
     public void RendersSvgPlaceholder_WhenFilenameIsNull()
     {
         // Arrange
-        RegisterConfiguration();
 
         // Act
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
@@ -34,7 +38,6 @@ public sealed class TeamLogoTests : IDisposable
     public void RendersImg_WhenFilenameIsProvided()
     {
         // Arrange
-        RegisterConfiguration();
 
         // Act
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
@@ -52,7 +55,6 @@ public sealed class TeamLogoTests : IDisposable
     public void AltDefaultsToEmpty_ForDecorativeUse()
     {
         // Arrange
-        RegisterConfiguration();
 
         // Act
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
@@ -69,7 +71,6 @@ public sealed class TeamLogoTests : IDisposable
     public void RendersAltText_WhenAltIsProvided()
     {
         // Arrange
-        RegisterConfiguration();
 
         // Act
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
@@ -90,7 +91,6 @@ public sealed class TeamLogoTests : IDisposable
     public void AppliesSizeClass_ForEachSize(TeamLogoSize size, string expectedClass)
     {
         // Arrange
-        RegisterConfiguration();
 
         // Act
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
@@ -110,7 +110,6 @@ public sealed class TeamLogoTests : IDisposable
     public void ShowsPlaceholder_WhenFilenameIsInvalid(string invalidFilename)
     {
         // Arrange
-        RegisterConfiguration();
 
         // Act
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -47,7 +47,7 @@ public sealed class TeamLogoTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=96&height=96");
         img.GetAttribute("loading").ShouldBe("lazy");
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -125,6 +125,11 @@ public sealed class TeamCompetitionIndexTests : IDisposable
 
     private void RegisterConfiguration()
     {
+        if (_context.Services.Any(s => s.ServiceType == typeof(IConfiguration)))
+        {
+            return;
+        }
+
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -6,6 +6,7 @@ using Bunit;
 using KRAFT.Results.Contracts.TeamCompetition;
 using KRAFT.Results.Web.Client.Features.TeamCompetition;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Shouldly;
@@ -14,6 +15,8 @@ namespace KRAFT.Results.Web.Client.Tests.Features.TeamCompetition;
 
 public sealed class TeamCompetitionIndexTests : IDisposable
 {
+    private const string TeamLogoBaseUrl = "https://example.blob.core.windows.net/images";
+
     private readonly BunitContext _context = new();
 
     [Fact]
@@ -85,6 +88,25 @@ public sealed class TeamCompetitionIndexTests : IDisposable
         cut.Find(".year-nav").ShouldNotBeNull();
     }
 
+    [Fact]
+    public void RendersLogoImg_WhenStandingHasLogoImageFilename()
+    {
+        // Arrange
+        TeamCompetitionStanding standing = new(1, "Þór IF", "Þór", "thor", "thor.png", 100);
+        RegisterConfiguration();
+        _context.AddAuthorization();
+
+        // Act
+        IRenderedComponent<StandingsCard> cut = _context.Render<StandingsCard>(
+            parameters => parameters.Add(p => p.Standing, standing));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+        img.GetAttribute("alt").ShouldBe("Þór IF logo");
+        img.GetAttribute("loading").ShouldBe("lazy");
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -101,12 +123,24 @@ public sealed class TeamCompetitionIndexTests : IDisposable
             Men: men ?? [],
             Combined: combined ?? []);
 
+    private void RegisterConfiguration()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+            })
+            .Build();
+        _context.Services.AddSingleton(configuration);
+    }
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
     private void RegisterHttpClient(TeamCompetitionResponse response, bool delay = false)
     {
         TeamCompetitionMockHandler handler = new(response, delay);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
     }
 
@@ -116,6 +150,7 @@ public sealed class TeamCompetitionIndexTests : IDisposable
         FailingHttpMessageHandler handler = new();
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -103,7 +103,7 @@ public sealed class TeamCompetitionIndexTests : IDisposable
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
         img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
-        img.GetAttribute("alt").ShouldBe("Þór IF logo");
+        img.GetAttribute("alt").ShouldBe(string.Empty);
         img.GetAttribute("loading").ShouldBe("lazy");
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -102,7 +102,7 @@ public sealed class TeamCompetitionIndexTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=48&height=48");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=64&height=64");
         img.GetAttribute("alt").ShouldBe(string.Empty);
         img.GetAttribute("loading").ShouldBe("lazy");
     }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -102,7 +102,7 @@ public sealed class TeamCompetitionIndexTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=48&height=48");
         img.GetAttribute("alt").ShouldBe(string.Empty);
         img.GetAttribute("loading").ShouldBe("lazy");
     }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/EditTeamPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/EditTeamPageTests.cs
@@ -119,7 +119,7 @@ public sealed class EditTeamPageTests : IDisposable
 
     private sealed class EditTeamPageMockHandler(bool delay = false) : HttpMessageHandler
     {
-        private readonly TeamDetails _team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", []);
+        private readonly TeamDetails _team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", null, []);
 
         private readonly List<CountrySummary> _countries = [new("ISL", "Iceland")];
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -150,7 +150,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         {
             AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
             img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
-            img.GetAttribute("alt").ShouldBe("Þór IF logo");
+            img.GetAttribute("alt").ShouldBe("Þór IF");
             img.GetAttribute("loading").ShouldBe("lazy");
         });
     }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -149,7 +149,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=160&height=160");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
             img.GetAttribute("alt").ShouldBe("Þór IF");
             img.GetAttribute("loading").ShouldBe("lazy");
         });

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -139,7 +139,7 @@ public sealed class TeamDetailsPageTests : IDisposable
     {
         // Arrange
         TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", "thor.png", []);
-        RegisterHttpClientWithConfig(team);
+        RegisterHttpClient(team);
 
         // Act
         IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
@@ -160,7 +160,7 @@ public sealed class TeamDetailsPageTests : IDisposable
     {
         // Arrange
         TeamDetails team = new("kr", "KR", "KR", "Kraftlyftingafélag Reykjavíkur", "ISL", null, []);
-        RegisterHttpClientWithConfig(team);
+        RegisterHttpClient(team);
 
         // Act
         IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
@@ -183,16 +183,6 @@ public sealed class TeamDetailsPageTests : IDisposable
     private void RegisterHttpClient(TeamDetails team, bool delay = false)
     {
         TeamDetailsPageMockHandler handler = new(team, delay);
-        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
-        _context.Services.AddSingleton(httpClient);
-        RegisterConfiguration();
-        _context.AddAuthorization();
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
-    private void RegisterHttpClientWithConfig(TeamDetails team)
-    {
-        TeamDetailsPageMockHandler handler = new(team);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
         RegisterConfiguration();

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -20,7 +20,7 @@ public sealed class TeamDetailsPageTests : IDisposable
     public void ShowsLoadingStateInitially()
     {
         // Arrange
-        RegisterHttpClient(new TeamDetails("thor", "Þór", "Þór", "Þór IF", "ISL", []), delay: true);
+        RegisterHttpClient(new TeamDetails("thor", "Þór", "Þór", "Þór IF", "ISL", null, []), delay: true);
 
         // Act
         IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
@@ -72,7 +72,7 @@ public sealed class TeamDetailsPageTests : IDisposable
     public void ShowsTeamTitle_WhenLoaded()
     {
         // Arrange
-        TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", []);
+        TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", null, []);
         RegisterHttpClient(team);
 
         // Act
@@ -96,6 +96,7 @@ public sealed class TeamDetailsPageTests : IDisposable
             "Þór",
             "Þór IF",
             "ISL",
+            null,
             [new TeamMember("jon-jonsson", "Jon Jonsson", 1990)]);
         RegisterHttpClient(team);
 
@@ -115,7 +116,7 @@ public sealed class TeamDetailsPageTests : IDisposable
     public void ShowsEmptyMembersMessage_WhenTeamHasNoMembers()
     {
         // Arrange
-        TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", []);
+        TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", null, []);
         RegisterHttpClient(team);
 
         // Act

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -6,6 +6,7 @@ using Bunit;
 using KRAFT.Results.Contracts.Teams;
 using KRAFT.Results.Web.Client.Features.Teams;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Shouldly;
@@ -14,6 +15,8 @@ namespace KRAFT.Results.Web.Client.Tests.Features.Teams;
 
 public sealed class TeamDetailsPageTests : IDisposable
 {
+    private const string TeamLogoBaseUrl = "https://example.blob.core.windows.net/images";
+
     private readonly BunitContext _context = new();
 
     [Fact]
@@ -131,6 +134,46 @@ public sealed class TeamDetailsPageTests : IDisposable
         });
     }
 
+    [Fact]
+    public void RendersLogoImg_WhenTeamHasLogo()
+    {
+        // Arrange
+        TeamDetails team = new("thor", "Þór IF", "Þór", "Þór IF", "ISL", "thor.png", []);
+        RegisterHttpClientWithConfig(team);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+            img.GetAttribute("alt").ShouldBe("Þór IF logo");
+            img.GetAttribute("loading").ShouldBe("lazy");
+        });
+    }
+
+    [Fact]
+    public void RendersSvgPlaceholder_WhenTeamHasNoLogo()
+    {
+        // Arrange
+        TeamDetails team = new("kr", "KR", "KR", "Kraftlyftingafélag Reykjavíkur", "ISL", null, []);
+        RegisterHttpClientWithConfig(team);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "kr"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".team-logo svg").ShouldNotBeNull();
+            cut.FindAll(".team-logo img").Count.ShouldBe(0);
+        });
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -142,6 +185,17 @@ public sealed class TeamDetailsPageTests : IDisposable
         TeamDetailsPageMockHandler handler = new(team, delay);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClientWithConfig(TeamDetails team)
+    {
+        TeamDetailsPageMockHandler handler = new(team);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
     }
 
@@ -151,6 +205,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         NullTeamHttpMessageHandler handler = new();
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
     }
 
@@ -160,7 +215,19 @@ public sealed class TeamDetailsPageTests : IDisposable
         FailingHttpMessageHandler handler = new();
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
+    }
+
+    private void RegisterConfiguration()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+            })
+            .Build();
+        _context.Services.AddSingleton(configuration);
     }
 
     private sealed class TeamDetailsPageMockHandler(TeamDetails team, bool delay = false) : HttpMessageHandler

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -149,7 +149,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=160&height=160");
             img.GetAttribute("alt").ShouldBe("Þór IF");
             img.GetAttribute("loading").ShouldBe("lazy");
         });

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -87,7 +87,7 @@ public sealed class TeamsIndexTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=96&height=96");
             img.GetAttribute("alt").ShouldBe(string.Empty);
             img.GetAttribute("loading").ShouldBe("lazy");
         });

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -88,7 +88,7 @@ public sealed class TeamsIndexTests : IDisposable
         {
             AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
             img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
-            img.GetAttribute("alt").ShouldBe("Þór logo");
+            img.GetAttribute("alt").ShouldBe(string.Empty);
             img.GetAttribute("loading").ShouldBe("lazy");
         });
     }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -87,7 +87,7 @@ public sealed class TeamsIndexTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=96&height=96");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
             img.GetAttribute("alt").ShouldBe(string.Empty);
             img.GetAttribute("loading").ShouldBe("lazy");
         });

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -52,8 +52,8 @@ public sealed class TeamsIndexTests : IDisposable
         // Arrange
         List<TeamSummary> teams =
         [
-            new("thor", "Þór", "Þór", 12),
-            new("kr", "Kraftlyftingafélag Reykjavíkur", "KR", 5),
+            new("thor", "Þór", "Þór", "thor.png", 12),
+            new("kr", "Kraftlyftingafélag Reykjavíkur", "KR", null, 5),
         ];
         RegisterHttpClient(teams);
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -5,6 +5,7 @@ using Bunit;
 using KRAFT.Results.Contracts.Teams;
 using KRAFT.Results.Web.Client.Features.Teams;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Shouldly;
@@ -13,6 +14,8 @@ namespace KRAFT.Results.Web.Client.Tests.Features.Teams;
 
 public sealed class TeamsIndexTests : IDisposable
 {
+    private const string TeamLogoBaseUrl = "https://example.blob.core.windows.net/images";
+
     private readonly BunitContext _context = new();
 
     [Fact]
@@ -67,6 +70,50 @@ public sealed class TeamsIndexTests : IDisposable
         });
     }
 
+    [Fact]
+    public void RendersLogoImg_WhenTeamHasLogoImageFilename()
+    {
+        // Arrange
+        List<TeamSummary> teams =
+        [
+            new("thor", "Þór", "Þór", "thor.png", 12),
+        ];
+        RegisterHttpClientWithConfig(teams);
+
+        // Act
+        IRenderedComponent<TeamsIndex> cut = _context.Render<TeamsIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png");
+            img.GetAttribute("alt").ShouldBe("Þór logo");
+            img.GetAttribute("loading").ShouldBe("lazy");
+        });
+    }
+
+    [Fact]
+    public void RendersSvgPlaceholder_WhenTeamHasNoLogoImageFilename()
+    {
+        // Arrange
+        List<TeamSummary> teams =
+        [
+            new("kr", "KR", "KR", null, 5),
+        ];
+        RegisterHttpClientWithConfig(teams);
+
+        // Act
+        IRenderedComponent<TeamsIndex> cut = _context.Render<TeamsIndex>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".team-logo svg").ShouldNotBeNull();
+            cut.FindAll(".team-logo img").Count.ShouldBe(0);
+        });
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -78,6 +125,17 @@ public sealed class TeamsIndexTests : IDisposable
         MockHttpMessageHandler<TeamSummary> handler = new(teams, delay);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
+        _context.AddAuthorization();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClientWithConfig(List<TeamSummary> teams)
+    {
+        MockHttpMessageHandler<TeamSummary> handler = new(teams);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
     }
 
@@ -87,6 +145,18 @@ public sealed class TeamsIndexTests : IDisposable
         FailingHttpMessageHandler handler = new();
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
+    }
+
+    private void RegisterConfiguration()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+            })
+            .Build();
+        _context.Services.AddSingleton(configuration);
     }
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -78,7 +78,7 @@ public sealed class TeamsIndexTests : IDisposable
         [
             new("thor", "Þór", "Þór", "thor.png", 12),
         ];
-        RegisterHttpClientWithConfig(teams);
+        RegisterHttpClient(teams);
 
         // Act
         IRenderedComponent<TeamsIndex> cut = _context.Render<TeamsIndex>();
@@ -101,7 +101,7 @@ public sealed class TeamsIndexTests : IDisposable
         [
             new("kr", "KR", "KR", null, 5),
         ];
-        RegisterHttpClientWithConfig(teams);
+        RegisterHttpClient(teams);
 
         // Act
         IRenderedComponent<TeamsIndex> cut = _context.Render<TeamsIndex>();
@@ -123,16 +123,6 @@ public sealed class TeamsIndexTests : IDisposable
     private void RegisterHttpClient(List<TeamSummary> teams, bool delay = false)
     {
         MockHttpMessageHandler<TeamSummary> handler = new(teams, delay);
-        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
-        _context.Services.AddSingleton(httpClient);
-        RegisterConfiguration();
-        _context.AddAuthorization();
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
-    private void RegisterHttpClientWithConfig(List<TeamSummary> teams)
-    {
-        MockHttpMessageHandler<TeamSummary> handler = new(teams);
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
         RegisterConfiguration();


### PR DESCRIPTION
## Summary

- Expose existing `LogoImageFilename` from Team entity through `TeamSummary` and `TeamDetails` API contracts
- Display team logos on the teams index page (48px), team detail page header (80px), and team competition standings card (24px)
- SVG shield placeholder when no logo exists; `onerror` fallback for broken images
- Shared `TeamLogo.razor` component with size enum, alt text parameter, and filename sanitization
- Image base URL configured via `TeamLogoBaseUrl` in `appsettings.json` (Azure Blob Storage)

Closes #120

## Test plan

- [ ] Verify team logos render on the teams index page for teams with `LogoImageFilename` in the database
- [ ] Verify SVG shield placeholder appears for teams without a logo
- [ ] Verify 80px logo renders in the team detail page header
- [ ] Verify 24px logo renders on the team competition standings card
- [ ] Verify broken image URLs fall back to the placeholder
- [ ] Verify card grid width accommodates the horizontal logo + text layout (~280px min)
- [ ] Run `dotnet test` — all 149 tests pass