### PR TITLE
fix(web): use uniform 128px query and enlarge small team logos

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -47,13 +47,7 @@
             _ => "team-logo--md",
         };
 
-        _sizeQuery = Size switch
-        {
-            TeamLogoSize.Small => "?width=64&height=64",
-            TeamLogoSize.Medium => "?width=128&height=128",
-            TeamLogoSize.Large => "?width=128&height=128",
-            _ => "?width=128&height=128",
-        };
+        _sizeQuery = "?width=128&height=128";
 
         _isValidFilename = Filename is not null
             && !Filename.Contains('/')

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor.css
@@ -5,8 +5,8 @@
 }
 
 .team-logo--sm {
-    width: 24px;
-    height: 24px;
+    width: 48px;
+    height: 48px;
 }
 
 .team-logo--md {

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -102,7 +102,7 @@ public sealed class TeamCompetitionIndexTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=64&height=64");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
         img.GetAttribute("alt").ShouldBe(string.Empty);
         img.GetAttribute("loading").ShouldBe("lazy");
     }


### PR DESCRIPTION
## Summary
- Simplified team logo size query to always use `?width=128&height=128` since the image proxy only supports 128px
- Enlarged small team logos from 24px to 48px — 24px was too small to be legible

## Test plan
- [x] Updated `TeamCompetitionIndexTests` assertion to match new query string