### PR TITLE
ci: cache Playwright browsers between workflow runs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,6 +40,13 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
+    - name: Cache Playwright browsers
+      if: github.event_name == 'push' || steps.ui-changes.outputs.ui == 'true'
+      id: playwright-cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ hashFiles('Directory.Packages.props') }}
     - name: Install Playwright browsers
       if: github.event_name == 'push' || steps.ui-changes.outputs.ui == 'true'
       run: pwsh tests/KRAFT.Results.Web.E2ETests/bin/Debug/net10.0/playwright.ps1 install --with-deps


### PR DESCRIPTION
## Summary
- Cache Playwright browser binaries (~300MB) using `actions/cache` keyed on `Directory.Packages.props` hash
- On cache hit, `playwright install --with-deps` skips browser downloads and only installs OS-level apt packages
- Cache auto-invalidates when the Playwright NuGet version changes

## Test plan
- [x] First run populates the cache (cold start — same duration as before)
- [ ] Subsequent runs restore from cache — browser install step should drop from ~10-16 min to ~1-2 min
- [ ] Bumping `Microsoft.Playwright` version in `Directory.Packages.props` invalidates the cache