### PR TITLE
feat(web): display team members as athlete cards on details page

### DIFF
--- a/src/KRAFT.Results.Contracts/Teams/TeamMember.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamMember.cs
@@ -1,3 +1,3 @@
 ﻿namespace KRAFT.Results.Contracts.Teams;
 
-public sealed record class TeamMember(string Slug, string Name, int? YearOfBirth);
+public sealed record class TeamMember(string Slug, string Name, int? YearOfBirth, int ParticipationCount);

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
@@ -2,7 +2,6 @@
 
 @using KRAFT.Results.Contracts.Teams
 @using KRAFT.Results.Web.Client.Components
-@using Microsoft.AspNetCore.Components.Routing
 
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
@@ -37,26 +36,32 @@
             </AuthorizeView>
         </div>
 
-        <br/>
-
         <h2>Meðlimir</h2>
 
         @if (team.Members is { Count: > 0 } members)
         {
-            <ul class="member-list">
+            <div class="card-grid" style="grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr))">
                 @foreach (TeamMember member in members)
                 {
-                    <li>
-                        <NavLink class="nav-link" href="@($"/athletes/{member.Slug}")">
+                    <Card Clickable="true">
+                        <a href="@($"/athletes/{member.Slug}")" aria-hidden="true" tabindex="-1"></a>
+                        <div class="member-name">
                             @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
-                        </NavLink>
-                    </li>
+                        </div>
+                        <div class="member-count"
+                             role="group"
+                             aria-label="@($"{member.ParticipationCount} mót")"
+                             title="Fjöldi keppnismóta">
+                            <span class="count-value">@member.ParticipationCount</span>
+                            <span class="count-label">mót</span>
+                        </div>
+                    </Card>
                 }
-            </ul>
+            </div>
         }
         else
         {
-            <p>Engir meðlimir skráðir.</p>
+            <EmptyState Message="Engir meðlimir skráðir." />
         }
 
         <ConfirmDialog @ref="_deleteDialog"

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
@@ -8,3 +8,19 @@
     align-items: center;
     gap: 1rem;
 }
+
+.member-name {
+    font-family: var(--font-heading);
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.member-count {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    margin-block-start: 0.75rem;
+    padding-block-start: 0.75rem;
+    border-block-start: 1px solid var(--color-border);
+}

--- a/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
@@ -30,7 +30,8 @@ internal sealed class GetTeamDetailsHandler
                 .Select(a => new TeamMember(
                     a.Slug,
                     $"{a.Firstname} {a.Lastname}",
-                    a.DateOfBirth != null && a.DateOfBirth.Value.Year > 1 ? a.DateOfBirth.Value.Year : null))
+                    a.DateOfBirth != null && a.DateOfBirth.Value.Year > 1 ? a.DateOfBirth.Value.Year : null,
+                    a.Participations.Count))
             .ToList()))
         .FirstOrDefaultAsync(cancellationToken);
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -90,7 +90,7 @@ public sealed class TeamDetailsPageTests : IDisposable
     }
 
     [Fact]
-    public void ShowsMemberList_WhenTeamHasMembers()
+    public void ShowsMemberCards_WhenTeamHasMembers()
     {
         // Arrange
         TeamDetails team = new(
@@ -100,7 +100,7 @@ public sealed class TeamDetailsPageTests : IDisposable
             "Þór IF",
             "ISL",
             null,
-            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990, 0)]);
+            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990, 5)]);
         RegisterHttpClient(team);
 
         // Act
@@ -110,8 +110,11 @@ public sealed class TeamDetailsPageTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find(".member-list").ShouldNotBeNull();
-            cut.Find(".member-list").TextContent.ShouldContain("Jon Jonsson");
+            AngleSharp.Dom.IElement grid = cut.Find(".card-grid");
+            grid.ShouldNotBeNull();
+            grid.QuerySelector(".member-name")?.TextContent.ShouldContain("Jon Jonsson (1990)");
+            grid.QuerySelector(".member-count")?.TextContent.ShouldContain("5");
+            grid.QuerySelector("a")?.GetAttribute("href").ShouldBe("/athletes/jon-jonsson");
         });
     }
 
@@ -129,8 +132,8 @@ public sealed class TeamDetailsPageTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.FindAll(".member-list").Count.ShouldBe(0);
-            cut.Find("p").TextContent.ShouldContain("Engir meðlimir");
+            cut.FindAll(".card-grid").Count.ShouldBe(0);
+            cut.Find(".empty-state").TextContent.ShouldContain("Engir meðlimir");
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -100,7 +100,7 @@ public sealed class TeamDetailsPageTests : IDisposable
             "Þór IF",
             "ISL",
             null,
-            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990)]);
+            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990, 0)]);
         RegisterHttpClient(team);
 
         // Act

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -112,9 +112,9 @@ public sealed class TeamDetailsPageTests : IDisposable
         {
             AngleSharp.Dom.IElement grid = cut.Find(".card-grid");
             grid.ShouldNotBeNull();
-            grid.QuerySelector(".member-name")?.TextContent.ShouldContain("Jon Jonsson (1990)");
-            grid.QuerySelector(".member-count")?.TextContent.ShouldContain("5");
-            grid.QuerySelector("a")?.GetAttribute("href").ShouldBe("/athletes/jon-jonsson");
+            grid.QuerySelector(".member-name").ShouldNotBeNull().TextContent.ShouldContain("Jon Jonsson (1990)");
+            grid.QuerySelector(".member-count").ShouldNotBeNull().TextContent.ShouldContain("5");
+            grid.QuerySelector("a").ShouldNotBeNull().GetAttribute("href").ShouldBe("/athletes/jon-jonsson");
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 
+using AngleSharp.Dom;
+
 using Bunit;
 
 using KRAFT.Results.Contracts.Teams;
@@ -110,8 +112,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            AngleSharp.Dom.IElement grid = cut.Find(".card-grid");
-            grid.ShouldNotBeNull();
+            IElement grid = cut.Find(".card-grid");
             grid.QuerySelector(".member-name").ShouldNotBeNull().TextContent.ShouldContain("Jon Jonsson (1990)");
             grid.QuerySelector(".member-count").ShouldNotBeNull().TextContent.ShouldContain("5");
             grid.QuerySelector("a").ShouldNotBeNull().GetAttribute("href").ShouldBe("/athletes/jon-jonsson");
@@ -151,7 +152,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
+            IElement img = cut.Find(".team-logo img");
             img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
             img.GetAttribute("alt").ShouldBe("Þór IF");
             img.GetAttribute("loading").ShouldBe("lazy");

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
@@ -99,7 +99,7 @@ public sealed class GetTeamDetailsTests(CollectionFixture fixture) : IAsyncLifet
     }
 
     [Fact]
-    public async Task MemberParticipationCount_IsPopulatedFromSeedData()
+    public async Task ReturnsParticipationCount_WhenTeamHasMembers()
     {
         // Arrange
         string path = $"{BasePath}/{Constants.TestTeamSlug}";
@@ -108,8 +108,7 @@ public sealed class GetTeamDetailsTests(CollectionFixture fixture) : IAsyncLifet
         TeamDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<TeamDetails>(path, CancellationToken.None);
 
         // Assert
-        response!.Members.ShouldContain(m => m.Slug == Constants.TestAthleteSlug);
-        TeamMember member = response.Members.Single(m => m.Slug == Constants.TestAthleteSlug);
-        member.ParticipationCount.ShouldBe(3);
+        TeamMember member = response!.Members.Single(m => m.Slug == Constants.TestAthleteSlug);
+        member.ParticipationCount.ShouldBe(3); // BaseSeedSql seeds 3 participations for the test athlete
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
@@ -97,4 +97,19 @@ public sealed class GetTeamDetailsTests(CollectionFixture fixture) : IAsyncLifet
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
+
+    [Fact]
+    public async Task MemberParticipationCount_IsPopulatedFromSeedData()
+    {
+        // Arrange
+        string path = $"{BasePath}/{Constants.TestTeamSlug}";
+
+        // Act
+        TeamDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<TeamDetails>(path, CancellationToken.None);
+
+        // Assert
+        response!.Members.ShouldContain(m => m.Slug == Constants.TestAthleteSlug);
+        TeamMember member = response.Members.Single(m => m.Slug == Constants.TestAthleteSlug);
+        member.ParticipationCount.ShouldBe(3);
+    }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Teams/GetTeamDetailsTests.cs
@@ -102,13 +102,15 @@ public sealed class GetTeamDetailsTests(CollectionFixture fixture) : IAsyncLifet
     public async Task ReturnsParticipationCount_WhenTeamHasMembers()
     {
         // Arrange
+        // Uses the shared seed team which has a pre-seeded athlete with participations
         string path = $"{BasePath}/{Constants.TestTeamSlug}";
 
         // Act
         TeamDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<TeamDetails>(path, CancellationToken.None);
 
         // Assert
-        TeamMember member = response!.Members.Single(m => m.Slug == Constants.TestAthleteSlug);
+        TeamDetails details = response.ShouldNotBeNull();
+        TeamMember member = details.Members.Single(m => m.Slug == Constants.TestAthleteSlug);
         member.ParticipationCount.ShouldBe(3); // BaseSeedSql seeds 3 participations for the test athlete
     }
 }


### PR DESCRIPTION
## Summary
- Add `ParticipationCount` to `TeamMember` DTO, projected via `a.Participations.Count` in the EF Core query
- Replace the plain `<ul>` member list on the team details page with clickable `Card` components in a responsive grid
- Each card shows athlete name, year of birth (when available), and participation count — matching the athletes index pattern

Closes #515

## Test plan
- [x] Integration test asserts `ParticipationCount` is populated from database
- [x] bUnit tests assert card grid markup, member name, count badge, and navigation links
- [x] Empty state ("Engir meðlimir skráðir.") still renders when team has no members
- [x] Visual check: cards reflow responsively at different viewport widths