### PR TITLE
feat(web): display athlete profile images on detail page and team member cards

### DIFF
--- a/src/KRAFT.Results.Contracts/Athletes/AthleteDetails.cs
+++ b/src/KRAFT.Results.Contracts/Athletes/AthleteDetails.cs
@@ -6,4 +6,5 @@ public sealed record class AthleteDetails(
     int? YearOfBirth,
     string? Club,
     string? ClubSlug,
-    int RecordCount);
+    int RecordCount,
+    string? ProfileImageFilename);

--- a/src/KRAFT.Results.Contracts/Teams/TeamMember.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamMember.cs
@@ -1,3 +1,3 @@
 ﻿namespace KRAFT.Results.Contracts.Teams;
 
-public sealed record class TeamMember(string Slug, string Name, int? YearOfBirth, int ParticipationCount);
+public sealed record class TeamMember(string Slug, string Name, int? YearOfBirth, int ParticipationCount, string? ProfileImageFilename);

--- a/src/KRAFT.Results.Contracts/Teams/TeamMember.cs
+++ b/src/KRAFT.Results.Contracts/Teams/TeamMember.cs
@@ -1,3 +1,8 @@
 ﻿namespace KRAFT.Results.Contracts.Teams;
 
-public sealed record class TeamMember(string Slug, string Name, int? YearOfBirth, int ParticipationCount, string? ProfileImageFilename);
+public sealed record class TeamMember(
+    string Slug,
+    string Name,
+    int? YearOfBirth,
+    int ParticipationCount,
+    string? ProfileImageFilename);

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
@@ -55,6 +55,8 @@
         _isValidFilename = !string.IsNullOrEmpty(Filename)
             && !Filename.Contains('/')
             && !Filename.Contains('\\')
-            && !Filename.Contains(':');
+            && !Filename.Contains(':')
+            && !Filename.Contains('?')
+            && !Filename.Contains('#');
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
@@ -1,0 +1,60 @@
+@using Microsoft.Extensions.Configuration
+
+@inject IConfiguration Configuration
+
+<div class="athlete-photo @_sizeClass">
+    @if (_isValidFilename)
+    {
+        <img src="@($"{_imageBaseUrl}/{Filename}{_sizeQuery}")"
+             alt="@Alt"
+             loading="lazy"
+             onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
+    }
+    <div class="athlete-photo-placeholder" style="@(_isValidFilename ? "display:none" : "")" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v2.4h19.2v-2.4c0-3.2-6.4-4.8-9.6-4.8z"/>
+        </svg>
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public string? Filename { get; set; }
+
+    [Parameter]
+    public string Alt { get; set; } = "";
+
+    [Parameter, EditorRequired]
+    public AthletePhotoSize Size { get; set; }
+
+    private string _imageBaseUrl = "";
+    private string _sizeClass = "";
+    private string _sizeQuery = "";
+    private bool _isValidFilename;
+
+    protected override void OnInitialized()
+    {
+        _imageBaseUrl = Configuration["ImageBaseUrl"] ?? "";
+    }
+
+    protected override void OnParametersSet()
+    {
+        _sizeClass = Size switch
+        {
+            AthletePhotoSize.Small => "athlete-photo--sm",
+            AthletePhotoSize.Large => "athlete-photo--lg",
+            _ => "athlete-photo--sm",
+        };
+
+        _sizeQuery = Size switch
+        {
+            AthletePhotoSize.Large => "?width=300&height=200&crop=auto",
+            _ => "?width=64&height=64&crop=auto",
+        };
+
+        _isValidFilename = !string.IsNullOrEmpty(Filename)
+            && !Filename.Contains('/')
+            && !Filename.Contains('\\')
+            && !Filename.Contains(':');
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
@@ -21,7 +21,7 @@
     [Parameter]
     public string? Filename { get; set; }
 
-    [Parameter]
+    [Parameter, EditorRequired]
     public string Alt { get; set; } = "";
 
     [Parameter, EditorRequired]

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor.css
@@ -28,10 +28,10 @@
     height: 100%;
     background: color-mix(in oklch, var(--color-border), transparent 40%);
     color: var(--color-text-muted);
-    opacity: 0.4;
 }
 
 .athlete-photo-placeholder svg {
     width: 60%;
     height: 60%;
+    opacity: 0.6;
 }

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor.css
@@ -1,0 +1,37 @@
+.athlete-photo {
+    flex-shrink: 0;
+    border-radius: 50%;
+    overflow: hidden;
+}
+
+.athlete-photo--sm {
+    width: 48px;
+    height: 48px;
+}
+
+.athlete-photo--lg {
+    width: 80px;
+    height: 80px;
+}
+
+.athlete-photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.athlete-photo-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: color-mix(in oklch, var(--color-border), transparent 40%);
+    color: var(--color-text-muted);
+    opacity: 0.4;
+}
+
+.athlete-photo-placeholder svg {
+    width: 60%;
+    height: 60%;
+}

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor.css
@@ -1,6 +1,6 @@
 .athlete-photo {
     flex-shrink: 0;
-    border-radius: 50%;
+    border-radius: var(--radius-md);
     overflow: hidden;
 }
 

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhotoSize.cs
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhotoSize.cs
@@ -1,0 +1,7 @@
+namespace KRAFT.Results.Web.Client.Components;
+
+public enum AthletePhotoSize
+{
+    Small,
+    Large,
+}

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -56,6 +56,8 @@
         _isValidFilename = Filename is not null
             && !Filename.Contains('/')
             && !Filename.Contains('\\')
-            && !Filename.Contains(':');
+            && !Filename.Contains(':')
+            && !Filename.Contains('?')
+            && !Filename.Contains('#');
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -34,7 +34,7 @@
 
     protected override void OnInitialized()
     {
-        _teamLogoBaseUrl = Configuration["TeamLogoBaseUrl"] ?? "";
+        _teamLogoBaseUrl = Configuration["ImageBaseUrl"] ?? "";
     }
 
     protected override void OnParametersSet()
@@ -47,7 +47,11 @@
             _ => "team-logo--md",
         };
 
-        _sizeQuery = "?width=128&height=128";
+        _sizeQuery = Size switch
+        {
+            TeamLogoSize.Large => "?width=128&height=128",
+            _ => "?width=64&height=64&crop=auto",
+        };
 
         _isValidFilename = Filename is not null
             && !Filename.Contains('/')

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
@@ -11,7 +11,12 @@
 <DataLoader T="AthletePageData" Loader="LoadAsync" Noun="keppanda">
     <ChildContent Context="pageData">
         <div class="page-header">
-            <h1>@pageData.Athlete.Name</h1>
+            <div class="athlete-detail-header">
+                <AthletePhoto Filename="@pageData.Athlete.ProfileImageFilename"
+                              Alt="@pageData.Athlete.Name"
+                              Size="AthletePhotoSize.Large" />
+                <h1>@pageData.Athlete.Name</h1>
+            </div>
             <AuthorizeView Roles="Admin">
                 <div class="admin-actions">
                     <a href="/athletes/@Slug/edit" class="btn-action" aria-label="Breyta keppanda">

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
@@ -1,12 +1,14 @@
 .page-header {
     border-block-end: 1px solid var(--color-border);
     margin-block-end: 1rem;
+    flex-wrap: wrap;
 }
 
 .athlete-detail-header {
     display: flex;
     align-items: center;
     gap: 1rem;
+    min-width: 0;
 }
 
 .athlete-meta {

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
@@ -3,6 +3,12 @@
     margin-block-end: 1rem;
 }
 
+.athlete-detail-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
 .athlete-meta {
     display: flex;
     align-items: center;

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
@@ -45,18 +45,22 @@
                 {
                     <Card Clickable="true">
                         <a href="@($"/athletes/{member.Slug}")" aria-hidden="true" tabindex="-1"></a>
-                        <AthletePhoto Filename="@member.ProfileImageFilename"
-                                      Alt="@member.Name"
-                                      Size="AthletePhotoSize.Small" />
-                        <div class="member-name">
-                            @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
-                        </div>
-                        <div class="member-count"
-                             role="group"
-                             aria-label="@($"{member.ParticipationCount} mót")"
-                             title="Fjöldi keppnismóta">
-                            <span class="count-value">@member.ParticipationCount</span>
-                            <span class="count-label">mót</span>
+                        <div class="member-row">
+                            <AthletePhoto Filename="@member.ProfileImageFilename"
+                                          Alt="@member.Name"
+                                          Size="AthletePhotoSize.Small" />
+                            <div class="member-info">
+                                <div class="member-name">
+                                    @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
+                                </div>
+                                <div class="member-count"
+                                     role="group"
+                                     aria-label="@($"{member.ParticipationCount} mót")"
+                                     title="Fjöldi keppnismóta">
+                                    <span class="count-value">@member.ParticipationCount</span>
+                                    <span class="count-label">mót</span>
+                                </div>
+                            </div>
                         </div>
                     </Card>
                 }

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor
@@ -45,6 +45,9 @@
                 {
                     <Card Clickable="true">
                         <a href="@($"/athletes/{member.Slug}")" aria-hidden="true" tabindex="-1"></a>
+                        <AthletePhoto Filename="@member.ProfileImageFilename"
+                                      Alt="@member.Name"
+                                      Size="AthletePhotoSize.Small" />
                         <div class="member-name">
                             @(member.YearOfBirth is null ? member.Name : $"{member.Name} ({member.YearOfBirth})")
                         </div>

--- a/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Teams/TeamDetailsPage.razor.css
@@ -16,11 +16,19 @@
     color: var(--color-text);
 }
 
+.member-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.member-info {
+    display: flex;
+    flex-direction: column;
+}
+
 .member-count {
     display: flex;
     align-items: baseline;
     gap: 0.35rem;
-    margin-block-start: 0.75rem;
-    padding-block-start: 0.75rem;
-    border-block-start: 1px solid var(--color-border);
 }

--- a/src/KRAFT.Results.Web/appsettings.json
+++ b/src/KRAFT.Results.Web/appsettings.json
@@ -6,5 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-  "TeamLogoBaseUrl": "https://results.kraft.is/azure/images"
+  "ImageBaseUrl": "https://results.kraft.is/azure/images"
 }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -513,6 +513,10 @@ h1:focus {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1rem;
+
+    & > * {
+        block-size: 100%;
+    }
 }
 
 .count-value {

--- a/src/KRAFT.Results.WebApi/Features/Athletes/GetDetails/GetAthleteDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/GetDetails/GetAthleteDetailsHandler.cs
@@ -15,6 +15,7 @@ internal sealed class GetAthleteDetailsHandler(ResultsDbContext dbContext)
                 x.DateOfBirth != null && x.DateOfBirth.Value.Year > 0 ? x.DateOfBirth.Value.Year : null,
                 x.Team != null ? x.Team.TitleFull : null,
                 x.Team != null ? x.Team.Slug : null,
-                0))
+                0,
+                x.ProfileImageFilename))
             .FirstOrDefaultAsync(cancellationToken);
 }

--- a/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Teams/GetDetails/GetTeamDetailsHandler.cs
@@ -31,7 +31,8 @@ internal sealed class GetTeamDetailsHandler
                     a.Slug,
                     $"{a.Firstname} {a.Lastname}",
                     a.DateOfBirth != null && a.DateOfBirth.Value.Year > 1 ? a.DateOfBirth.Value.Year : null,
-                    a.Participations.Count))
+                    a.Participations.Count,
+                    a.ProfileImageFilename))
             .ToList()))
         .FirstOrDefaultAsync(cancellationToken);
 }

--- a/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
@@ -9,7 +9,8 @@ internal sealed class AthleteDetailsPageMockHandler(
     List<AthleteRecord> records,
     List<AthletePersonalBest> personalBests,
     List<AthleteParticipation> participations,
-    bool delay = false) : HttpMessageHandler
+    bool delay = false,
+    AthleteDetails? athlete = null) : HttpMessageHandler
 {
     private static readonly AthleteDetails DefaultAthlete = new(
         Slug: "test-athlete",
@@ -19,6 +20,17 @@ internal sealed class AthleteDetailsPageMockHandler(
         ClubSlug: "test-club",
         RecordCount: 0,
         ProfileImageFilename: null);
+
+    private AthleteDetails ResolvedAthlete => athlete ?? DefaultAthlete;
+
+    internal static AthleteDetails AthleteWithPhoto(string filename) => new(
+        Slug: "test-athlete",
+        Name: "Test Athlete",
+        YearOfBirth: 1990,
+        Club: "Test Club",
+        ClubSlug: "test-club",
+        RecordCount: 0,
+        ProfileImageFilename: filename);
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
@@ -45,7 +57,7 @@ internal sealed class AthleteDetailsPageMockHandler(
         }
         else
         {
-            response = new(HttpStatusCode.OK) { Content = JsonContent.Create(DefaultAthlete) };
+            response = new(HttpStatusCode.OK) { Content = JsonContent.Create(ResolvedAthlete) };
         }
 
         return response;

--- a/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
@@ -17,7 +17,8 @@ internal sealed class AthleteDetailsPageMockHandler(
         YearOfBirth: 1990,
         Club: "Test Club",
         ClubSlug: "test-club",
-        RecordCount: 0);
+        RecordCount: 0,
+        ProfileImageFilename: null);
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {

--- a/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
@@ -23,14 +23,8 @@ internal sealed class AthleteDetailsPageMockHandler(
 
     private AthleteDetails ResolvedAthlete => athlete ?? DefaultAthlete;
 
-    internal static AthleteDetails AthleteWithPhoto(string filename) => new(
-        Slug: "test-athlete",
-        Name: "Test Athlete",
-        YearOfBirth: 1990,
-        Club: "Test Club",
-        ClubSlug: "test-club",
-        RecordCount: 0,
-        ProfileImageFilename: filename);
+    internal static AthleteDetails AthleteWithPhoto(string filename) =>
+        DefaultAthlete with { ProfileImageFilename = filename };
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
@@ -128,7 +128,7 @@ public sealed class AthletePhotoTests : IDisposable
     [InlineData("javascript:alert(1)")]
     [InlineData("photo.png?width=999")]
     [InlineData("photo.png#section")]
-    public void ShowsPlaceholder_WhenFilenameContainsPathTraversalCharacters(string invalidFilename)
+    public void ShowsPlaceholder_WhenFilenameContainsUnsafeCharacters(string invalidFilename)
     {
         // Arrange
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
@@ -27,7 +27,9 @@ public sealed class AthletePhotoTests : IDisposable
 
         // Act
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
-            p => p.Add(c => c.Size, AthletePhotoSize.Small));
+            p => p
+                .Add(c => c.Alt, "test")
+                .Add(c => c.Size, AthletePhotoSize.Small));
 
         // Assert
         cut.Find(".athlete-photo svg").ShouldNotBeNull();
@@ -43,6 +45,7 @@ public sealed class AthletePhotoTests : IDisposable
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
             p => p
                 .Add(c => c.Filename, string.Empty)
+                .Add(c => c.Alt, "test")
                 .Add(c => c.Size, AthletePhotoSize.Small));
 
         // Assert
@@ -108,7 +111,9 @@ public sealed class AthletePhotoTests : IDisposable
 
         // Act
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
-            p => p.Add(c => c.Size, size));
+            p => p
+                .Add(c => c.Alt, "test")
+                .Add(c => c.Size, size));
 
         // Assert
         cut.Find($".athlete-photo.{expectedClass}").ShouldNotBeNull();
@@ -131,6 +136,7 @@ public sealed class AthletePhotoTests : IDisposable
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
             p => p
                 .Add(c => c.Filename, invalidFilename)
+                .Add(c => c.Alt, "test")
                 .Add(c => c.Size, AthletePhotoSize.Small));
 
         // Assert
@@ -147,6 +153,7 @@ public sealed class AthletePhotoTests : IDisposable
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
             p => p
                 .Add(c => c.Filename, "jondoe.jpg")
+                .Add(c => c.Alt, "test")
                 .Add(c => c.Size, AthletePhotoSize.Small));
 
         // Assert

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
@@ -121,6 +121,8 @@ public sealed class AthletePhotoTests : IDisposable
     [InlineData("http://evil.com/photo.png")]
     [InlineData("//evil.com/photo.png")]
     [InlineData("javascript:alert(1)")]
+    [InlineData("photo.png?width=999")]
+    [InlineData("photo.png#section")]
     public void ShowsPlaceholder_WhenFilenameContainsPathTraversalCharacters(string invalidFilename)
     {
         // Arrange

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
@@ -1,0 +1,170 @@
+using Bunit;
+
+using KRAFT.Results.Web.Client.Components;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Components;
+
+public sealed class AthletePhotoTests : IDisposable
+{
+    private const string ImageBaseUrl = "https://example.blob.core.windows.net/images";
+
+    private readonly BunitContext _context = new();
+
+    public AthletePhotoTests()
+    {
+        RegisterConfiguration();
+    }
+
+    [Fact]
+    public void RendersSvgPlaceholder_WhenFilenameIsNull()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p.Add(c => c.Size, AthletePhotoSize.Small));
+
+        // Assert
+        cut.Find(".athlete-photo svg").ShouldNotBeNull();
+        cut.FindAll(".athlete-photo img").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RendersSvgPlaceholder_WhenFilenameIsEmpty()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p
+                .Add(c => c.Filename, string.Empty)
+                .Add(c => c.Size, AthletePhotoSize.Small));
+
+        // Assert
+        cut.Find(".athlete-photo svg").ShouldNotBeNull();
+        cut.FindAll(".athlete-photo img").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RendersImg_WithSmallQueryString_WhenSizeIsSmall()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p
+                .Add(c => c.Filename, "jondoe.jpg")
+                .Add(c => c.Size, AthletePhotoSize.Small));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
+        img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/jondoe.jpg?width=64&height=64&crop=auto");
+    }
+
+    [Fact]
+    public void RendersImg_WithLargeQueryString_WhenSizeIsLarge()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p
+                .Add(c => c.Filename, "jondoe.jpg")
+                .Add(c => c.Size, AthletePhotoSize.Large));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
+        img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/jondoe.jpg?width=300&height=200&crop=auto");
+    }
+
+    [Fact]
+    public void RendersAltText_WhenAltIsProvided()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p
+                .Add(c => c.Filename, "jondoe.jpg")
+                .Add(c => c.Alt, "Jón Döe")
+                .Add(c => c.Size, AthletePhotoSize.Small));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
+        img.GetAttribute("alt").ShouldBe("Jón Döe");
+    }
+
+    [Theory]
+    [InlineData(AthletePhotoSize.Small, "athlete-photo--sm")]
+    [InlineData(AthletePhotoSize.Large, "athlete-photo--lg")]
+    public void AppliesSizeClass_ForEachSize(AthletePhotoSize size, string expectedClass)
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p.Add(c => c.Size, size));
+
+        // Assert
+        cut.Find($".athlete-photo.{expectedClass}").ShouldNotBeNull();
+    }
+
+    [Theory]
+    [InlineData("../evil.png")]
+    [InlineData("subdir/photo.png")]
+    [InlineData("C:\\photos\\evil.png")]
+    [InlineData("http://evil.com/photo.png")]
+    [InlineData("//evil.com/photo.png")]
+    [InlineData("javascript:alert(1)")]
+    public void ShowsPlaceholder_WhenFilenameContainsPathTraversalCharacters(string invalidFilename)
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p
+                .Add(c => c.Filename, invalidFilename)
+                .Add(c => c.Size, AthletePhotoSize.Small));
+
+        // Assert
+        cut.Find(".athlete-photo svg").ShouldNotBeNull();
+        cut.FindAll(".athlete-photo img").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void UsesImageBaseUrlFromConfiguration()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p
+                .Add(c => c.Filename, "jondoe.jpg")
+                .Add(c => c.Size, AthletePhotoSize.Small));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
+        img.GetAttribute("src").ShouldStartWith(ImageBaseUrl);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private void RegisterConfiguration()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ImageBaseUrl"] = ImageBaseUrl,
+            })
+            .Build();
+        _context.Services.AddSingleton(configuration);
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -47,7 +47,7 @@ public sealed class TeamLogoTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=64&height=64&crop=auto");
         img.GetAttribute("loading").ShouldBe("lazy");
     }
 
@@ -132,7 +132,7 @@ public sealed class TeamLogoTests : IDisposable
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+                ["ImageBaseUrl"] = TeamLogoBaseUrl,
             })
             .Build();
         _context.Services.AddSingleton(configuration);

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -107,6 +107,8 @@ public sealed class TeamLogoTests : IDisposable
     [InlineData("http://evil.com/logo.png")]
     [InlineData("//evil.com/logo.png")]
     [InlineData("javascript:alert(1)")]
+    [InlineData("logo.png?width=999")]
+    [InlineData("logo.png#section")]
     public void ShowsPlaceholder_WhenFilenameIsInvalid(string invalidFilename)
     {
         // Arrange

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
@@ -4,6 +4,7 @@ using KRAFT.Results.Contracts;
 using KRAFT.Results.Contracts.Athletes;
 using KRAFT.Results.Web.Client.Features.Athletes;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Shouldly;
@@ -12,6 +13,8 @@ namespace KRAFT.Results.Web.Client.Tests.Features.Athletes;
 
 public sealed class AthleteDetailsPageTests : IDisposable
 {
+    private const string ImageBaseUrl = "https://example.blob.core.windows.net/images";
+
     private readonly BunitContext _context = new();
 
     [Fact]
@@ -371,6 +374,43 @@ public sealed class AthleteDetailsPageTests : IDisposable
         });
     }
 
+    [Fact]
+    public void RendersPhotoImg_InAthleteDetailHeader_WhenAthleteHasProfileImage()
+    {
+        // Arrange
+        AthleteDetails athlete = AthleteDetailsPageMockHandler.AthleteWithPhoto("jondoe.jpg");
+        RegisterHttpClient(athlete: athlete);
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement img = cut.Find(".athlete-detail-header img");
+            img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/jondoe.jpg?width=300&height=200&crop=auto");
+        });
+    }
+
+    [Fact]
+    public void RendersSvgPlaceholder_InAthleteDetailHeader_WhenAthleteHasNoProfileImage()
+    {
+        // Arrange
+        RegisterHttpClient();
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".athlete-detail-header svg").ShouldNotBeNull();
+            cut.FindAll(".athlete-detail-header img").Count.ShouldBe(0);
+        });
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -381,17 +421,31 @@ public sealed class AthleteDetailsPageTests : IDisposable
         List<AthleteRecord>? records = null,
         List<AthletePersonalBest>? personalBests = null,
         List<AthleteParticipation>? participations = null,
-        bool delay = false)
+        bool delay = false,
+        AthleteDetails? athlete = null)
     {
         AthleteDetailsPageMockHandler handler = new(
             records ?? [],
             personalBests ?? [],
             participations ?? [],
-            delay);
+            delay,
+            athlete);
 
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
+    }
+
+    private void RegisterConfiguration()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ImageBaseUrl"] = ImageBaseUrl,
+            })
+            .Build();
+        _context.Services.AddSingleton(configuration);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
@@ -400,6 +454,7 @@ public sealed class AthleteDetailsPageTests : IDisposable
         NullAthleteHttpMessageHandler handler = new();
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
     }
 
@@ -409,6 +464,7 @@ public sealed class AthleteDetailsPageTests : IDisposable
         FailingAthleteHttpMessageHandler handler = new();
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
         _context.AddAuthorization();
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
@@ -389,7 +389,7 @@ public sealed class AthleteDetailsPageTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement img = cut.Find(".athlete-detail-header img");
-            img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/jondoe.jpg?width=300&height=200&crop=auto");
+            img.GetAttribute("src").ShouldStartWith($"{ImageBaseUrl}/jondoe.jpg");
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/TeamCompetition/TeamCompetitionIndexTests.cs
@@ -102,7 +102,7 @@ public sealed class TeamCompetitionIndexTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=64&height=64&crop=auto");
         img.GetAttribute("alt").ShouldBe(string.Empty);
         img.GetAttribute("loading").ShouldBe("lazy");
     }
@@ -133,7 +133,7 @@ public sealed class TeamCompetitionIndexTests : IDisposable
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+                ["ImageBaseUrl"] = TeamLogoBaseUrl,
             })
             .Build();
         _context.Services.AddSingleton(configuration);

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -200,7 +200,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement img = cut.Find(".card .athlete-photo img");
-            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/jon.jpg?width=64&height=64&crop=auto");
+            img.GetAttribute("src").ShouldStartWith($"{TeamLogoBaseUrl}/jon.jpg");
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -102,7 +102,7 @@ public sealed class TeamDetailsPageTests : IDisposable
             "Þór IF",
             "ISL",
             null,
-            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990, 5)]);
+            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990, 5, null)]);
         RegisterHttpClient(team);
 
         // Act

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -178,6 +178,58 @@ public sealed class TeamDetailsPageTests : IDisposable
         });
     }
 
+    [Fact]
+    public void RendersMemberPhotoImg_WhenMemberHasProfileImage()
+    {
+        // Arrange
+        TeamDetails team = new(
+            "thor",
+            "Þór IF",
+            "Þór",
+            "Þór IF",
+            "ISL",
+            null,
+            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990, 5, "jon.jpg")]);
+        RegisterHttpClient(team);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement img = cut.Find(".card .athlete-photo img");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/jon.jpg?width=64&height=64&crop=auto");
+        });
+    }
+
+    [Fact]
+    public void RendersMemberPhotoPlaceholder_WhenMemberHasNoProfileImage()
+    {
+        // Arrange
+        TeamDetails team = new(
+            "thor",
+            "Þór IF",
+            "Þór",
+            "Þór IF",
+            "ISL",
+            null,
+            [new TeamMember("jon-jonsson", "Jon Jonsson", 1990, 5, null)]);
+        RegisterHttpClient(team);
+
+        // Act
+        IRenderedComponent<TeamDetailsPage> cut = _context.Render<TeamDetailsPage>(
+            p => p.Add(c => c.Slug, "thor"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".card .athlete-photo svg").ShouldNotBeNull();
+            cut.FindAll(".card .athlete-photo img").Count.ShouldBe(0);
+        });
+    }
+
     public void Dispose()
     {
         _context.Dispose();

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -153,7 +153,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             IElement img = cut.Find(".team-logo img");
-            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
+            img.GetAttribute("src").ShouldStartWith($"{TeamLogoBaseUrl}/thor.png");
             img.GetAttribute("alt").ShouldBe("Þór IF");
             img.GetAttribute("loading").ShouldBe("lazy");
         });

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamDetailsPageTests.cs
@@ -218,7 +218,7 @@ public sealed class TeamDetailsPageTests : IDisposable
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+                ["ImageBaseUrl"] = TeamLogoBaseUrl,
             })
             .Build();
         _context.Services.AddSingleton(configuration);

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Teams/TeamsIndexTests.cs
@@ -87,7 +87,7 @@ public sealed class TeamsIndexTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
+            img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=64&height=64&crop=auto");
             img.GetAttribute("alt").ShouldBe(string.Empty);
             img.GetAttribute("loading").ShouldBe("lazy");
         });
@@ -144,7 +144,7 @@ public sealed class TeamsIndexTests : IDisposable
         IConfiguration configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["TeamLogoBaseUrl"] = TeamLogoBaseUrl,
+                ["ImageBaseUrl"] = TeamLogoBaseUrl,
             })
             .Build();
         _context.Services.AddSingleton(configuration);


### PR DESCRIPTION
## Summary

- Display athlete profile images using existing `ProfileImageFilename` data from the database and the live site's image proxy
- Circular avatar (80px) next to the h1 on athlete detail page, small thumbnail (48px) on team member cards
- SVG person silhouette placeholder when no image or broken image
- Rename config key `TeamLogoBaseUrl` → `ImageBaseUrl` (shared by both components)
- Fix `TeamLogo` to use size-specific proxy query strings
- New `AthletePhoto` component following the `TeamLogo` pattern

Closes #121

## Test plan

- [ ] Verify athlete detail page shows circular avatar for athletes with `ProfileImageFilename` in the database
- [ ] Verify SVG placeholder shown for athletes without images
- [ ] Verify team member cards show small thumbnails for members with images
- [ ] Verify team logos still render correctly after config key rename and query string changes
- [ ] Verify broken image (proxy error) falls back to placeholder via `onerror`
- [ ] Verify layout on narrow viewports (admin view with edit/delete buttons)
- [ ] Run `dotnet test` — all 324 tests pass