### PR TITLE
feat(web): meet photo gallery

### DIFF
--- a/src/KRAFT.Results.Contracts/Meets/MeetDetails.cs
+++ b/src/KRAFT.Results.Contracts/Meets/MeetDetails.cs
@@ -23,4 +23,5 @@ public sealed record class MeetDetails(
     bool RecordsPossible,
     bool IsClassic,
     bool ShowTeamPoints,
-    IReadOnlyList<Discipline> Disciplines);
+    IReadOnlyList<Discipline> Disciplines,
+    int PhotoCount);

--- a/src/KRAFT.Results.Contracts/Meets/MeetPhotos.cs
+++ b/src/KRAFT.Results.Contracts/Meets/MeetPhotos.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Meets;
+
+public sealed record MeetPhotos(string MeetTitle, IReadOnlyList<PhotoSummary> Photos);

--- a/src/KRAFT.Results.Contracts/Meets/PhotoSummary.cs
+++ b/src/KRAFT.Results.Contracts/Meets/PhotoSummary.cs
@@ -1,0 +1,3 @@
+namespace KRAFT.Results.Contracts.Meets;
+
+public sealed record PhotoSummary(int PhotoId, string ImageFilename, string? Photographer);

--- a/src/KRAFT.Results.Contracts/Meets/PhotoSummary.cs
+++ b/src/KRAFT.Results.Contracts/Meets/PhotoSummary.cs
@@ -1,3 +1,3 @@
 namespace KRAFT.Results.Contracts.Meets;
 
-public sealed record PhotoSummary(int PhotoId, string ImageFilename, string? Photographer);
+public sealed record PhotoSummary(string ImageFilename, string? Photographer);

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
@@ -10,8 +10,14 @@
          @ref="_backdropRef"
          @onkeydown="HandleKeyDown"
          @onclick="HandleBackdropClick">
-        <div class="lightbox-content" @onclick:stopPropagation="true">
-            <button class="lightbox-close" @onclick="HandleClose" aria-label="Loka">
+        <div class="lightbox-content"
+             @onclick:stopPropagation="true"
+             @ontouchstart="HandleTouchStart"
+             @ontouchend="HandleTouchEnd">
+            <button class="lightbox-close"
+                    @ref="_closeRef"
+                    @onclick="HandleClose"
+                    aria-label="Loka">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <line x1="18" y1="6" x2="6" y2="18" />
                     <line x1="6" y1="6" x2="18" y2="18" />
@@ -19,40 +25,71 @@
             </button>
 
             <div class="lightbox-image-area">
-                <button class="lightbox-nav lightbox-nav--prev" @onclick="PreviousPhoto" aria-label="Fyrri mynd">
+                <button class="lightbox-nav lightbox-nav--prev"
+                        @ref="_prevRef"
+                        @onclick="PreviousPhoto"
+                        aria-label="Fyrri mynd">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <polyline points="15,18 9,12 15,6" />
                     </svg>
                 </button>
 
-                <img class="lightbox-image"
-                     src="@CurrentPhoto.DisplayUrl"
-                     alt=""
-                     width="600"
-                     height="500" />
+                <div class="lightbox-image-container @(_imageLoaded ? "is-loaded" : "") @(_imageError ? "has-error" : "")">
+                    @if (_imageError)
+                    {
+                        <p class="lightbox-error-message">Ekki tókst að hlaða mynd</p>
+                    }
+                    else
+                    {
+                        <img class="lightbox-image"
+                             src="@CurrentPhoto.DisplayUrl"
+                             alt=""
+                             width="600"
+                             height="500"
+                             @onload="HandleImageLoaded"
+                             @onerror="HandleImageError" />
+                    }
+                </div>
 
-                <button class="lightbox-nav lightbox-nav--next" @onclick="NextPhoto" aria-label="Næsta mynd">
+                <button class="lightbox-nav lightbox-nav--next"
+                        @ref="_nextRef"
+                        @onclick="NextPhoto"
+                        aria-label="Næsta mynd">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <polyline points="9,18 15,12 9,6" />
                     </svg>
                 </button>
             </div>
 
-            <div class="lightbox-info">
-                <span class="lightbox-counter">@(_currentIndex + 1) / @Photos.Count</span>
-                @if (CurrentPhoto.Photographer is not null)
-                {
-                    <span class="lightbox-photographer">Mynd: @CurrentPhoto.Photographer</span>
-                }
+            <div aria-live="polite" aria-atomic="true">
+                <div class="lightbox-info">
+                    <span class="lightbox-counter">@(_currentIndex + 1) / @Photos.Count</span>
+                    @if (CurrentPhoto.Photographer is not null)
+                    {
+                        <span class="lightbox-photographer">Mynd: @CurrentPhoto.Photographer</span>
+                    }
+                </div>
             </div>
         </div>
     </div>
 }
 
 @code {
+    private const double SwipeThreshold = 50.0;
+
     private ElementReference _backdropRef;
+    private ElementReference _closeRef;
+    private ElementReference _prevRef;
+    private ElementReference _nextRef;
     private int _currentIndex;
+    private int _focusTrapIndex;
     private bool _wasOpen;
+    private bool _shouldFocus;
+    private bool _imageLoaded;
+    private bool _imageError;
+    private double _touchStartX;
+
+    private const int FocusTrapElementCount = 3;
 
     [Parameter, EditorRequired]
     public IReadOnlyList<GalleryPhoto> Photos { get; set; } = [];
@@ -73,6 +110,10 @@
         if (IsOpen && !_wasOpen)
         {
             _currentIndex = StartIndex;
+            _focusTrapIndex = 0;
+            _shouldFocus = true;
+            _imageLoaded = false;
+            _imageError = false;
         }
 
         _wasOpen = IsOpen;
@@ -80,8 +121,9 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (IsOpen && Photos.Count > 0)
+        if (_shouldFocus && IsOpen && Photos.Count > 0)
         {
+            _shouldFocus = false;
             await _backdropRef.FocusAsync();
         }
     }
@@ -94,22 +136,106 @@
                 await HandleClose();
                 break;
             case "ArrowLeft":
-                PreviousPhoto();
+                NavigatePrevious();
                 break;
             case "ArrowRight":
-                NextPhoto();
+                NavigateNext();
+                break;
+            case "Tab" when args.ShiftKey:
+                await FocusPreviousTrapElement();
+                break;
+            case "Tab":
+                await FocusNextTrapElement();
                 break;
         }
     }
 
-    private void PreviousPhoto()
+    private async Task FocusNextTrapElement()
+    {
+        _focusTrapIndex = (_focusTrapIndex + 1) % FocusTrapElementCount;
+        await FocusTrapElement(_focusTrapIndex);
+    }
+
+    private async Task FocusPreviousTrapElement()
+    {
+        _focusTrapIndex = (_focusTrapIndex - 1 + FocusTrapElementCount) % FocusTrapElementCount;
+        await FocusTrapElement(_focusTrapIndex);
+    }
+
+    private async Task FocusTrapElement(int index)
+    {
+        ElementReference target = index switch
+        {
+            0 => _closeRef,
+            1 => _prevRef,
+            _ => _nextRef,
+        };
+        await target.FocusAsync();
+    }
+
+    private void NavigatePrevious()
     {
         _currentIndex = (_currentIndex - 1 + Photos.Count) % Photos.Count;
+        ResetImageState();
+    }
+
+    private void NavigateNext()
+    {
+        _currentIndex = (_currentIndex + 1) % Photos.Count;
+        ResetImageState();
+    }
+
+    private void PreviousPhoto()
+    {
+        NavigatePrevious();
     }
 
     private void NextPhoto()
     {
-        _currentIndex = (_currentIndex + 1) % Photos.Count;
+        NavigateNext();
+    }
+
+    private void ResetImageState()
+    {
+        _imageLoaded = false;
+        _imageError = false;
+    }
+
+    private void HandleImageLoaded()
+    {
+        _imageLoaded = true;
+    }
+
+    private void HandleImageError()
+    {
+        _imageError = true;
+    }
+
+    private void HandleTouchStart(Microsoft.AspNetCore.Components.Web.TouchEventArgs args)
+    {
+        if (args.ChangedTouches.Length > 0)
+        {
+            _touchStartX = args.ChangedTouches[0].ClientX;
+        }
+    }
+
+    private void HandleTouchEnd(Microsoft.AspNetCore.Components.Web.TouchEventArgs args)
+    {
+        if (args.ChangedTouches.Length == 0)
+        {
+            return;
+        }
+
+        double deltaX = args.ChangedTouches[0].ClientX - _touchStartX;
+
+        if (deltaX < -SwipeThreshold)
+        {
+            NavigateNext();
+        }
+        else if (deltaX > SwipeThreshold)
+        {
+            NavigatePrevious();
+        }
     }
 
     private async Task HandleClose()

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
@@ -1,5 +1,18 @@
 @using KRAFT.Results.Web.Client.Features.Meets
 
+<div aria-live="polite" aria-atomic="true">
+    @if (IsOpen && Photos.Count > 0)
+    {
+        <div class="lightbox-info">
+            <span class="lightbox-counter">@(_currentIndex + 1) / @Photos.Count</span>
+            @if (CurrentPhoto.Photographer is not null)
+            {
+                <span class="lightbox-photographer">Mynd: @CurrentPhoto.Photographer</span>
+            }
+        </div>
+    }
+</div>
+
 @if (IsOpen && Photos.Count > 0)
 {
     <div class="lightbox-backdrop"
@@ -9,6 +22,7 @@
          tabindex="-1"
          @ref="_backdropRef"
          @onkeydown="HandleKeyDown"
+         @onkeydown:preventDefault="true"
          @onclick="HandleBackdropClick">
         <div class="lightbox-content"
              @onclick:stopPropagation="true"
@@ -25,14 +39,17 @@
             </button>
 
             <div class="lightbox-image-area">
-                <button class="lightbox-nav lightbox-nav--prev"
-                        @ref="_prevRef"
-                        @onclick="PreviousPhoto"
-                        aria-label="Fyrri mynd">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <polyline points="15,18 9,12 15,6" />
-                    </svg>
-                </button>
+                @if (Photos.Count > 1)
+                {
+                    <button class="lightbox-nav lightbox-nav--prev"
+                            @ref="_prevRef"
+                            @onclick="NavigatePrevious"
+                            aria-label="Fyrri mynd">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <polyline points="15,18 9,12 15,6" />
+                        </svg>
+                    </button>
+                }
 
                 <div class="lightbox-image-container @(_imageLoaded ? "is-loaded" : "") @(_imageError ? "has-error" : "")">
                     @if (_imageError)
@@ -51,24 +68,17 @@
                     }
                 </div>
 
-                <button class="lightbox-nav lightbox-nav--next"
-                        @ref="_nextRef"
-                        @onclick="NextPhoto"
-                        aria-label="Næsta mynd">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <polyline points="9,18 15,12 9,6" />
-                    </svg>
-                </button>
-            </div>
-
-            <div aria-live="polite" aria-atomic="true">
-                <div class="lightbox-info">
-                    <span class="lightbox-counter">@(_currentIndex + 1) / @Photos.Count</span>
-                    @if (CurrentPhoto.Photographer is not null)
-                    {
-                        <span class="lightbox-photographer">Mynd: @CurrentPhoto.Photographer</span>
-                    }
-                </div>
+                @if (Photos.Count > 1)
+                {
+                    <button class="lightbox-nav lightbox-nav--next"
+                            @ref="_nextRef"
+                            @onclick="NavigateNext"
+                            aria-label="Næsta mynd">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <polyline points="9,18 15,12 9,6" />
+                        </svg>
+                    </button>
+                }
             </div>
         </div>
     </div>
@@ -176,23 +186,15 @@
     private void NavigatePrevious()
     {
         _currentIndex = (_currentIndex - 1 + Photos.Count) % Photos.Count;
+        _focusTrapIndex = 0;
         ResetImageState();
     }
 
     private void NavigateNext()
     {
         _currentIndex = (_currentIndex + 1) % Photos.Count;
+        _focusTrapIndex = 0;
         ResetImageState();
-    }
-
-    private void PreviousPhoto()
-    {
-        NavigatePrevious();
-    }
-
-    private void NextPhoto()
-    {
-        NavigateNext();
     }
 
     private void ResetImageState()

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
@@ -1,0 +1,124 @@
+@using KRAFT.Results.Web.Client.Features.Meets
+
+@if (IsOpen && Photos.Count > 0)
+{
+    <div class="lightbox-backdrop"
+         role="dialog"
+         aria-modal="true"
+         aria-label="Myndayfirlit"
+         tabindex="-1"
+         @ref="_backdropRef"
+         @onkeydown="HandleKeyDown"
+         @onclick="HandleBackdropClick">
+        <div class="lightbox-content" @onclick:stopPropagation="true">
+            <button class="lightbox-close" @onclick="HandleClose" aria-label="Loka">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+            </button>
+
+            <div class="lightbox-image-area">
+                <button class="lightbox-nav lightbox-nav--prev" @onclick="PreviousPhoto" aria-label="Fyrri mynd">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <polyline points="15,18 9,12 15,6" />
+                    </svg>
+                </button>
+
+                <img class="lightbox-image"
+                     src="@CurrentPhoto.DisplayUrl"
+                     alt=""
+                     width="600"
+                     height="500" />
+
+                <button class="lightbox-nav lightbox-nav--next" @onclick="NextPhoto" aria-label="Næsta mynd">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <polyline points="9,18 15,12 9,6" />
+                    </svg>
+                </button>
+            </div>
+
+            <div class="lightbox-info">
+                <span class="lightbox-counter">@(_currentIndex + 1) / @Photos.Count</span>
+                @if (CurrentPhoto.Photographer is not null)
+                {
+                    <span class="lightbox-photographer">Mynd: @CurrentPhoto.Photographer</span>
+                }
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private ElementReference _backdropRef;
+    private int _currentIndex;
+    private bool _wasOpen;
+
+    [Parameter, EditorRequired]
+    public IReadOnlyList<GalleryPhoto> Photos { get; set; } = [];
+
+    [Parameter]
+    public int StartIndex { get; set; }
+
+    [Parameter]
+    public bool IsOpen { get; set; }
+
+    [Parameter]
+    public EventCallback OnClose { get; set; }
+
+    private GalleryPhoto CurrentPhoto => Photos[_currentIndex];
+
+    protected override void OnParametersSet()
+    {
+        if (IsOpen && !_wasOpen)
+        {
+            _currentIndex = StartIndex;
+        }
+
+        _wasOpen = IsOpen;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsOpen && Photos.Count > 0)
+        {
+            await _backdropRef.FocusAsync();
+        }
+    }
+
+    private async Task HandleKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs args)
+    {
+        switch (args.Key)
+        {
+            case "Escape":
+                await HandleClose();
+                break;
+            case "ArrowLeft":
+                PreviousPhoto();
+                break;
+            case "ArrowRight":
+                NextPhoto();
+                break;
+        }
+    }
+
+    private void PreviousPhoto()
+    {
+        _currentIndex = (_currentIndex - 1 + Photos.Count) % Photos.Count;
+    }
+
+    private void NextPhoto()
+    {
+        _currentIndex = (_currentIndex + 1) % Photos.Count;
+    }
+
+    private async Task HandleClose()
+    {
+        await OnClose.InvokeAsync();
+    }
+
+    private async Task HandleBackdropClick()
+    {
+        await HandleClose();
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
@@ -58,11 +58,10 @@
                     }
                     else
                     {
-                        <img class="lightbox-image"
-                             src="@CurrentPhoto.DisplayUrl"
+                        <img @key="CurrentImageUrl"
+                             class="lightbox-image"
+                             src="@CurrentImageUrl"
                              alt=""
-                             width="600"
-                             height="500"
                              @onload="HandleImageLoaded"
                              @onerror="HandleImageError" />
                     }
@@ -97,6 +96,7 @@
     private bool _shouldFocus;
     private bool _imageLoaded;
     private bool _imageError;
+    private bool _useFallback;
     private double _touchStartX;
 
     private int FocusTrapElementCount => Photos.Count > 1 ? 3 : 1;
@@ -115,6 +115,10 @@
 
     private GalleryPhoto CurrentPhoto => Photos[_currentIndex];
 
+    private string CurrentImageUrl => _useFallback
+        ? CurrentPhoto.ThumbnailUrl
+        : CurrentPhoto.DisplayUrl;
+
     protected override void OnParametersSet()
     {
         if (IsOpen && !_wasOpen)
@@ -124,6 +128,7 @@
             _shouldFocus = true;
             _imageLoaded = false;
             _imageError = false;
+            _useFallback = false;
         }
 
         _wasOpen = IsOpen;
@@ -202,6 +207,7 @@
     {
         _imageLoaded = false;
         _imageError = false;
+        _useFallback = false;
     }
 
     private void HandleImageLoaded()
@@ -211,6 +217,12 @@
 
     private void HandleImageError()
     {
+        if (!_useFallback)
+        {
+            _useFallback = true;
+            return;
+        }
+
         _imageError = true;
     }
 

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor
@@ -99,7 +99,7 @@
     private bool _imageError;
     private double _touchStartX;
 
-    private const int FocusTrapElementCount = 3;
+    private int FocusTrapElementCount => Photos.Count > 1 ? 3 : 1;
 
     [Parameter, EditorRequired]
     public IReadOnlyList<GalleryPhoto> Photos { get; set; } = [];
@@ -177,8 +177,9 @@
         ElementReference target = index switch
         {
             0 => _closeRef,
-            1 => _prevRef,
-            _ => _nextRef,
+            1 when Photos.Count > 1 => _prevRef,
+            _ when Photos.Count > 1 => _nextRef,
+            _ => _closeRef,
         };
         await target.FocusAsync();
     }

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
@@ -1,0 +1,145 @@
+.lightbox-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: var(--z-modal, 400);
+}
+
+.lightbox-content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    max-width: 100vw;
+    padding: 1rem;
+}
+
+.lightbox-close {
+    position: absolute;
+    top: -2.5rem;
+    right: 0;
+    background: none;
+    border: none;
+    color: var(--color-white, #ffffff);
+    cursor: pointer;
+    min-width: 44px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    border-radius: var(--radius-sm, 0.5rem);
+    transition: opacity var(--transition-fast, 150ms) ease;
+
+    & svg {
+        width: 1.5rem;
+        height: 1.5rem;
+    }
+
+    &:hover {
+        opacity: 0.75;
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-white, #ffffff);
+        outline-offset: 2px;
+    }
+}
+
+.lightbox-image-area {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.lightbox-image {
+    display: block;
+    max-width: min(600px, 90vw);
+    max-height: min(500px, 70vh);
+    object-fit: contain;
+    border-radius: var(--radius-sm, 0.5rem);
+}
+
+.lightbox-nav {
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--color-white, #ffffff);
+    cursor: pointer;
+    min-width: 44px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    border-radius: var(--radius-sm, 0.5rem);
+    flex-shrink: 0;
+    transition: background var(--transition-fast, 150ms) ease;
+
+    & svg {
+        width: 1.5rem;
+        height: 1.5rem;
+    }
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.22);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-white, #ffffff);
+        outline-offset: 2px;
+    }
+}
+
+.lightbox-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.lightbox-counter {
+    color: var(--color-white, #ffffff);
+    font-size: 0.875rem;
+    opacity: 0.85;
+}
+
+.lightbox-photographer {
+    color: var(--color-white, #ffffff);
+    font-size: 0.8125rem;
+    opacity: 0.7;
+}
+
+@media (max-width: 700px) {
+    .lightbox-image-area {
+        gap: 0;
+    }
+
+    .lightbox-nav {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        z-index: 1;
+        background: rgba(0, 0, 0, 0.45);
+        border-color: rgba(255, 255, 255, 0.15);
+    }
+
+    .lightbox-nav--prev {
+        left: 0.25rem;
+    }
+
+    .lightbox-nav--next {
+        right: 0.25rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lightbox-close,
+    .lightbox-nav {
+        transition: none;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
@@ -5,6 +5,7 @@
     --lightbox-nav-border: rgba(255, 255, 255, 0.2);
     --lightbox-nav-hover-bg: rgba(255, 255, 255, 0.22);
     --lightbox-nav-mobile-bg: rgba(0, 0, 0, 0.45);
+    --lightbox-nav-mobile-border: rgba(255, 255, 255, 0.15);
 
     position: fixed;
     inset: 0;
@@ -164,7 +165,7 @@
         transform: translateY(-50%);
         z-index: 1;
         background: var(--lightbox-nav-mobile-bg);
-        border-color: rgba(255, 255, 255, 0.15);
+        border-color: var(--lightbox-nav-mobile-border);
     }
 
     .lightbox-nav--prev {

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
@@ -19,9 +19,9 @@
 }
 
 .lightbox-close {
-    position: absolute;
-    top: -2.5rem;
-    right: 0;
+    position: fixed;
+    inset-block-start: 0.5rem;
+    inset-inline-end: 0.5rem;
     background: none;
     border: none;
     color: var(--color-white, #ffffff);
@@ -57,12 +57,40 @@
     gap: 1rem;
 }
 
+.lightbox-image-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: min(600px, 90vw);
+    min-height: min(500px, 70vh);
+    max-width: min(600px, 90vw);
+    max-height: min(500px, 70vh);
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-sm, 0.5rem);
+    overflow: hidden;
+}
+
 .lightbox-image {
     display: block;
     max-width: min(600px, 90vw);
     max-height: min(500px, 70vh);
     object-fit: contain;
     border-radius: var(--radius-sm, 0.5rem);
+    opacity: 0;
+    transition: opacity var(--transition-base, 250ms) ease;
+
+    .is-loaded & {
+        opacity: 1;
+    }
+}
+
+.lightbox-error-message {
+    color: var(--color-white, #ffffff);
+    font-size: 0.875rem;
+    opacity: 0.85;
+    text-align: center;
+    padding: 1rem;
+    margin: 0;
 }
 
 .lightbox-nav {
@@ -139,7 +167,8 @@
 
 @media (prefers-reduced-motion: reduce) {
     .lightbox-close,
-    .lightbox-nav {
+    .lightbox-nav,
+    .lightbox-image {
         transition: none;
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Lightbox.razor.css
@@ -1,11 +1,22 @@
 .lightbox-backdrop {
+    --lightbox-backdrop-bg: rgba(0, 0, 0, 0.85);
+    --lightbox-surface-subtle: rgba(255, 255, 255, 0.08);
+    --lightbox-nav-bg: rgba(255, 255, 255, 0.12);
+    --lightbox-nav-border: rgba(255, 255, 255, 0.2);
+    --lightbox-nav-hover-bg: rgba(255, 255, 255, 0.22);
+    --lightbox-nav-mobile-bg: rgba(0, 0, 0, 0.45);
+
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.85);
+    background: var(--lightbox-backdrop-bg);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: var(--z-modal, 400);
+}
+
+.lightbox-backdrop:focus-visible {
+    outline: none;
 }
 
 .lightbox-content {
@@ -65,7 +76,7 @@
     min-height: min(500px, 70vh);
     max-width: min(600px, 90vw);
     max-height: min(500px, 70vh);
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--lightbox-surface-subtle);
     border-radius: var(--radius-sm, 0.5rem);
     overflow: hidden;
 }
@@ -94,8 +105,8 @@
 }
 
 .lightbox-nav {
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: var(--lightbox-nav-bg);
+    border: 1px solid var(--lightbox-nav-border);
     color: var(--color-white, #ffffff);
     cursor: pointer;
     min-width: 44px;
@@ -114,7 +125,7 @@
     }
 
     &:hover {
-        background: rgba(255, 255, 255, 0.22);
+        background: var(--lightbox-nav-hover-bg);
     }
 
     &:focus-visible {
@@ -149,19 +160,19 @@
 
     .lightbox-nav {
         position: absolute;
-        top: 50%;
+        inset-block-start: 50%;
         transform: translateY(-50%);
         z-index: 1;
-        background: rgba(0, 0, 0, 0.45);
+        background: var(--lightbox-nav-mobile-bg);
         border-color: rgba(255, 255, 255, 0.15);
     }
 
     .lightbox-nav--prev {
-        left: 0.25rem;
+        inset-inline-start: 0.25rem;
     }
 
     .lightbox-nav--next {
-        right: 0.25rem;
+        inset-inline-end: 0.25rem;
     }
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
@@ -54,9 +54,10 @@
             return null;
         }
 
-        string imageBaseUrl = Configuration["ImageBaseUrl"] ?? string.Empty;
+        string imageBaseUrl = (Configuration["ImageBaseUrl"] ?? string.Empty).TrimEnd('/');
 
         IReadOnlyList<GalleryPhoto> galleryPhotos = meetPhotos.Photos
+            .Where(p => IsValidImageFilename(p.ImageFilename))
             .Select(p => new GalleryPhoto(
                 ThumbnailUrl: $"{imageBaseUrl}/{p.ImageFilename}{MeetPhotoSizes.Thumbnail}",
                 DisplayUrl: $"{imageBaseUrl}/{p.ImageFilename}{MeetPhotoSizes.Main}",
@@ -75,5 +76,16 @@
     private void CloseLightbox()
     {
         _lightboxOpen = false;
+    }
+
+    private static bool IsValidImageFilename(string filename)
+    {
+        return !string.IsNullOrEmpty(filename)
+            && !filename.StartsWith("//", StringComparison.Ordinal)
+            && !filename.Contains('/')
+            && !filename.Contains('\\')
+            && !filename.Contains(':')
+            && !filename.Contains('?')
+            && !filename.Contains('#');
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
@@ -21,7 +21,10 @@
                 {
                     int index = i;
                     GalleryPhoto photo = data.GalleryPhotos[i];
-                    <button class="gallery-thumb" @onclick="() => OpenLightbox(index)" aria-label="Opna mynd">
+                    <button class="gallery-thumb"
+                            @ref="_thumbRefs[index]"
+                            @onclick="() => OpenLightbox(index)"
+                            aria-label="Opna mynd">
                         <img src="@photo.ThumbnailUrl" alt="" loading="lazy" width="75" height="75" />
                     </button>
                 }
@@ -41,6 +44,7 @@
 
     private bool _lightboxOpen;
     private int _lightboxIndex;
+    private Dictionary<int, ElementReference> _thumbRefs = [];
 
     [Parameter]
     public string Slug { get; set; } = string.Empty;
@@ -64,6 +68,10 @@
                 Photographer: p.Photographer))
             .ToList();
 
+        _thumbRefs = Enumerable
+            .Range(0, galleryPhotos.Count)
+            .ToDictionary(i => i, _ => new ElementReference());
+
         return new GalleryData(meetPhotos, galleryPhotos);
     }
 
@@ -73,9 +81,14 @@
         _lightboxOpen = true;
     }
 
-    private void CloseLightbox()
+    private async Task CloseLightbox()
     {
         _lightboxOpen = false;
+
+        if (_thumbRefs.TryGetValue(_lightboxIndex, out ElementReference thumbRef))
+        {
+            await thumbRef.FocusAsync();
+        }
     }
 
     private static bool IsValidImageFilename(string filename)

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
@@ -1,0 +1,79 @@
+@page "/meets/{Slug}/gallery"
+
+@using KRAFT.Results.Contracts.Meets
+@using KRAFT.Results.Web.Client.Components
+@using Microsoft.Extensions.Configuration
+
+@inject HttpClient HttpClient
+@inject IConfiguration Configuration
+
+<DataLoader T="GalleryData" Loader="LoadAsync" Noun="myndir">
+    <ChildContent Context="data">
+        <div class="page-header">
+            <h1>@data.MeetPhotos.MeetTitle — Myndir</h1>
+            <a href="/meets/@Slug" class="btn-cancel">Til baka</a>
+        </div>
+
+        @if (data.GalleryPhotos.Count > 0)
+        {
+            <div class="gallery-grid">
+                @for (int i = 0; i < data.GalleryPhotos.Count; i++)
+                {
+                    int index = i;
+                    GalleryPhoto photo = data.GalleryPhotos[i];
+                    <button class="gallery-thumb" @onclick="() => OpenLightbox(index)" aria-label="Opna mynd">
+                        <img src="@photo.ThumbnailUrl" alt="" loading="lazy" width="75" height="75" />
+                    </button>
+                }
+            </div>
+        }
+        else
+        {
+            <EmptyState Message="Engar myndir fundust." />
+        }
+
+        @if (_lightboxOpen)
+        {
+            @* Lightbox placeholder — Lightbox component will be wired in step 6. *@
+            <div class="lightbox-placeholder" data-index="@_lightboxIndex"></div>
+        }
+    </ChildContent>
+</DataLoader>
+
+@code {
+    private sealed record GalleryData(MeetPhotos MeetPhotos, IReadOnlyList<GalleryPhoto> GalleryPhotos);
+
+    private sealed record GalleryPhoto(string ThumbnailUrl, string DisplayUrl);
+
+    private bool _lightboxOpen;
+    private int _lightboxIndex;
+
+    [Parameter]
+    public string Slug { get; set; } = string.Empty;
+
+    private async Task<GalleryData?> LoadAsync()
+    {
+        MeetPhotos? meetPhotos = await HttpClient.GetFromJsonAsync<MeetPhotos>($"/meets/{Slug}/photos");
+
+        if (meetPhotos is null)
+        {
+            return null;
+        }
+
+        string imageBaseUrl = Configuration["ImageBaseUrl"] ?? string.Empty;
+
+        IReadOnlyList<GalleryPhoto> galleryPhotos = meetPhotos.Photos
+            .Select(p => new GalleryPhoto(
+                ThumbnailUrl: $"{imageBaseUrl}/{p.ImageFilename}{MeetPhotoSizes.Thumbnail}",
+                DisplayUrl: $"{imageBaseUrl}/{p.ImageFilename}{MeetPhotoSizes.Main}"))
+            .ToList();
+
+        return new GalleryData(meetPhotos, galleryPhotos);
+    }
+
+    private void OpenLightbox(int index)
+    {
+        _lightboxIndex = index;
+        _lightboxOpen = true;
+    }
+}

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
@@ -32,18 +32,12 @@
             <EmptyState Message="Engar myndir fundust." />
         }
 
-        @if (_lightboxOpen)
-        {
-            @* Lightbox placeholder — Lightbox component will be wired in step 6. *@
-            <div class="lightbox-placeholder" data-index="@_lightboxIndex"></div>
-        }
+        <Lightbox Photos="data.GalleryPhotos" StartIndex="_lightboxIndex" IsOpen="_lightboxOpen" OnClose="CloseLightbox" />
     </ChildContent>
 </DataLoader>
 
 @code {
     private sealed record GalleryData(MeetPhotos MeetPhotos, IReadOnlyList<GalleryPhoto> GalleryPhotos);
-
-    private sealed record GalleryPhoto(string ThumbnailUrl, string DisplayUrl);
 
     private bool _lightboxOpen;
     private int _lightboxIndex;
@@ -65,7 +59,8 @@
         IReadOnlyList<GalleryPhoto> galleryPhotos = meetPhotos.Photos
             .Select(p => new GalleryPhoto(
                 ThumbnailUrl: $"{imageBaseUrl}/{p.ImageFilename}{MeetPhotoSizes.Thumbnail}",
-                DisplayUrl: $"{imageBaseUrl}/{p.ImageFilename}{MeetPhotoSizes.Main}"))
+                DisplayUrl: $"{imageBaseUrl}/{p.ImageFilename}{MeetPhotoSizes.Main}",
+                Photographer: p.Photographer))
             .ToList();
 
         return new GalleryData(meetPhotos, galleryPhotos);
@@ -75,5 +70,10 @@
     {
         _lightboxIndex = index;
         _lightboxOpen = true;
+    }
+
+    private void CloseLightbox()
+    {
+        _lightboxOpen = false;
     }
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor
@@ -24,7 +24,7 @@
                     <button class="gallery-thumb"
                             @ref="_thumbRefs[index]"
                             @onclick="() => OpenLightbox(index)"
-                            aria-label="Opna mynd">
+                            aria-label="@($"Opna mynd {index + 1} af {data.GalleryPhotos.Count}")">
                         <img src="@photo.ThumbnailUrl" alt="" loading="lazy" width="75" height="75" />
                     </button>
                 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor.css
@@ -1,0 +1,34 @@
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 75px);
+    gap: 6px;
+}
+
+@media (max-width: 400px) {
+    .gallery-grid {
+        grid-template-columns: repeat(auto-fill, minmax(75px, 1fr));
+    }
+}
+
+.gallery-thumb {
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    display: block;
+    width: 75px;
+    height: 75px;
+    overflow: hidden;
+    transition: opacity var(--transition-fast) ease;
+}
+
+.gallery-thumb:hover {
+    opacity: 0.8;
+}
+
+.gallery-thumb img {
+    width: 75px;
+    height: 75px;
+    object-fit: cover;
+    display: block;
+}

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor.css
@@ -1,12 +1,14 @@
 .gallery-grid {
+    --thumb-size: 75px;
+
     display: grid;
-    grid-template-columns: repeat(auto-fill, 75px);
+    grid-template-columns: repeat(auto-fill, var(--thumb-size));
     gap: 6px;
 }
 
 @media (max-width: 400px) {
     .gallery-grid {
-        grid-template-columns: repeat(auto-fill, minmax(75px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(var(--thumb-size), 1fr));
     }
 }
 
@@ -16,8 +18,8 @@
     background: none;
     cursor: pointer;
     display: block;
-    width: 75px;
-    height: 75px;
+    width: var(--thumb-size);
+    height: var(--thumb-size);
     overflow: hidden;
     transition: opacity var(--transition-fast) ease;
 }
@@ -26,9 +28,14 @@
     opacity: 0.8;
 }
 
+.gallery-thumb:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--color-primary);
+}
+
 .gallery-thumb img {
-    width: 75px;
-    height: 75px;
+    width: var(--thumb-size);
+    height: var(--thumb-size);
     object-fit: cover;
     display: block;
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPage.razor.css
@@ -1,9 +1,10 @@
 .gallery-grid {
     --thumb-size: 75px;
+    --gallery-gap: 6px;
 
     display: grid;
     grid-template-columns: repeat(auto-fill, var(--thumb-size));
-    gap: 6px;
+    gap: var(--gallery-gap);
 }
 
 @media (max-width: 400px) {

--- a/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPhoto.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/GalleryPhoto.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KRAFT.Results.Web.Client.Features.Meets;
+
+[SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "URLs are pre-built strings for use in Razor src attributes")]
+[SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "URLs are pre-built strings for use in Razor src attributes")]
+public sealed record GalleryPhoto(string ThumbnailUrl, string DisplayUrl, string? Photographer);

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -65,6 +65,16 @@
             }
             <br />
             @Meet?.Location<br />
+            @if (Meet?.PhotoCount > 0)
+            {
+                <a href="/meets/@Slug/gallery" class="photo-count-link" aria-label="@($"{Meet!.PhotoCount} myndir af þessu móti")">
+                    <svg class="photo-count-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/>
+                        <circle cx="12" cy="13" r="3"/>
+                    </svg>
+                    @Meet!.PhotoCount myndir
+                </a>
+            }
         </p>
 
         <AuthorizeView Roles="Admin">

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -9,7 +9,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
-    color: var(--color-text-muted);
+    color: var(--color-text);
     font-size: 0.875rem;
     transition: color var(--transition-fast) ease;
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor.css
@@ -3,6 +3,27 @@
     margin-block-end: 1rem;
 }
 
+/* ===== Photo count link ===== */
+
+.photo-count-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    transition: color var(--transition-fast) ease;
+}
+
+.photo-count-link:hover {
+    color: var(--color-primary);
+}
+
+.photo-count-icon {
+    width: 1em;
+    height: 1em;
+    flex-shrink: 0;
+}
+
 /* ===== IPF point leaders ===== */
 
 .leaders-section {

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetPhotoSizes.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetPhotoSizes.cs
@@ -3,6 +3,5 @@ namespace KRAFT.Results.Web.Client.Features.Meets;
 public static class MeetPhotoSizes
 {
     public const string Thumbnail = "?height=75&width=75&quality=60";
-    public const string Medium = "?height=125&width=125";
     public const string Main = "?width=600&height=500&quality=80";
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetPhotoSizes.cs
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetPhotoSizes.cs
@@ -1,0 +1,8 @@
+namespace KRAFT.Results.Web.Client.Features.Meets;
+
+public static class MeetPhotoSizes
+{
+    public const string Thumbnail = "?height=75&width=75&quality=60";
+    public const string Medium = "?height=125&width=125";
+    public const string Main = "?width=600&height=500&quality=80";
+}

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
@@ -61,6 +61,7 @@ internal sealed class GetMeetDetailsHandler(ResultsDbContext dbContext)
             raw.RecordsPossible,
             raw.IsRaw,
             raw.ShowTeamPoints,
-            raw.Category.GetDisciplines());
+            raw.Category.GetDisciplines(),
+            PhotoCount: 0);
     }
 }

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
@@ -1,5 +1,6 @@
 using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.Enums;
+using KRAFT.Results.WebApi.Features.Photos;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -32,6 +33,8 @@ internal sealed class GetMeetDetailsHandler(ResultsDbContext dbContext)
                 x.RecordsPossible,
                 x.IsRaw,
                 x.ShowTeamPoints,
+                PhotoCount = dbContext.Set<Photo>()
+                    .Count(p => p.Meet!.Slug == slug && p.ImageFilename != null && p.ImageFilename != string.Empty),
             })
             .FirstOrDefaultAsync(cancellationToken);
 
@@ -62,6 +65,6 @@ internal sealed class GetMeetDetailsHandler(ResultsDbContext dbContext)
             raw.IsRaw,
             raw.ShowTeamPoints,
             raw.Category.GetDisciplines(),
-            PhotoCount: 0);
+            raw.PhotoCount);
     }
 }

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetDetails/GetMeetDetailsHandler.cs
@@ -34,7 +34,9 @@ internal sealed class GetMeetDetailsHandler(ResultsDbContext dbContext)
                 x.IsRaw,
                 x.ShowTeamPoints,
                 PhotoCount = dbContext.Set<Photo>()
-                    .Count(p => p.Meet!.Slug == slug && p.ImageFilename != null && p.ImageFilename != string.Empty),
+                    .Where(p => p.Meet!.Slug == slug)
+                    .Where(p => p.ImageFilename != null)
+                    .Count(p => p.ImageFilename != string.Empty),
             })
             .FirstOrDefaultAsync(cancellationToken);
 

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetPhotos/GetMeetPhotosEndpoint.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetPhotos/GetMeetPhotosEndpoint.cs
@@ -1,0 +1,29 @@
+using KRAFT.Results.Contracts.Meets;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace KRAFT.Results.WebApi.Features.Meets.GetPhotos;
+
+internal static class GetMeetPhotosEndpoint
+{
+    internal const string Name = "GetMeetPhotos";
+
+    internal static RouteGroupBuilder MapGetMeetPhotosEndpoint(this RouteGroupBuilder endpoints)
+    {
+        endpoints.MapGet("/{slug}/photos", async Task<IResult> (
+            [FromRoute] string slug,
+            [FromServices] GetMeetPhotosHandler handler,
+            CancellationToken cancellationToken) =>
+            await handler.Handle(slug, cancellationToken) is not { } result
+                ? TypedResults.NotFound()
+                : TypedResults.Ok(result))
+        .WithName(Name)
+        .WithSummary("Gets photos for a meet")
+        .WithDescription("Gets all photos for the specified meet, ordered by creation date ascending")
+        .Produces<MeetPhotos>()
+        .ProducesProblem(StatusCodes.Status404NotFound)
+        .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+        return endpoints;
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetPhotos/GetMeetPhotosHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetPhotos/GetMeetPhotosHandler.cs
@@ -24,7 +24,7 @@ internal sealed class GetMeetPhotosHandler(ResultsDbContext dbContext)
             .Where(p => p.ImageFilename != null)
             .Where(p => p.ImageFilename != string.Empty)
             .OrderBy(p => p.CreatedOn)
-            .Select(p => new PhotoSummary(p.PhotoId, p.ImageFilename!, p.Photographer))
+            .Select(p => new PhotoSummary(p.ImageFilename!, p.Photographer))
             .ToListAsync(cancellationToken);
 
         return new MeetPhotos(meetTitle, photos);

--- a/src/KRAFT.Results.WebApi/Features/Meets/GetPhotos/GetMeetPhotosHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/GetPhotos/GetMeetPhotosHandler.cs
@@ -1,0 +1,32 @@
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.Features.Photos;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace KRAFT.Results.WebApi.Features.Meets.GetPhotos;
+
+internal sealed class GetMeetPhotosHandler(ResultsDbContext dbContext)
+{
+    public async Task<MeetPhotos?> Handle(string slug, CancellationToken cancellationToken)
+    {
+        string? meetTitle = await dbContext.Set<Meet>()
+            .Where(m => m.Slug == slug)
+            .Select(m => m.Title)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (meetTitle is null)
+        {
+            return null;
+        }
+
+        List<PhotoSummary> photos = await dbContext.Set<Photo>()
+            .Where(p => p.Meet!.Slug == slug)
+            .Where(p => p.ImageFilename != null)
+            .Where(p => p.ImageFilename != string.Empty)
+            .OrderBy(p => p.CreatedOn)
+            .Select(p => new PhotoSummary(p.PhotoId, p.ImageFilename!, p.Photographer))
+            .ToListAsync(cancellationToken);
+
+        return new MeetPhotos(meetTitle, photos);
+    }
+}

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetEndpoints.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetEndpoints.cs
@@ -6,6 +6,7 @@ using KRAFT.Results.WebApi.Features.Meets.GetDetails;
 using KRAFT.Results.WebApi.Features.Meets.GetMeetTypes;
 using KRAFT.Results.WebApi.Features.Meets.GetParticipation;
 using KRAFT.Results.WebApi.Features.Meets.GetParticipations;
+using KRAFT.Results.WebApi.Features.Meets.GetPhotos;
 using KRAFT.Results.WebApi.Features.Meets.GetRecords;
 using KRAFT.Results.WebApi.Features.Meets.GetTeamPoints;
 using KRAFT.Results.WebApi.Features.Meets.RecordAttempt;
@@ -28,6 +29,7 @@ internal static class MeetEndpoints
         group.MapGetMeetTypesEndpoint();
         group.MapGetMeetsEndpoint();
         group.MapGetMeetDetailsEndpoint();
+        group.MapGetMeetPhotosEndpoint();
         group.MapGetMeetParticipationEndpoint();
         group.MapGetMeetParticipationsEndpoint();
         group.MapGetMeetTeamPointsEndpoint();

--- a/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
+++ b/src/KRAFT.Results.WebApi/Features/Meets/MeetServices.cs
@@ -7,6 +7,7 @@ using KRAFT.Results.WebApi.Features.Meets.GetDetails;
 using KRAFT.Results.WebApi.Features.Meets.GetMeetTypes;
 using KRAFT.Results.WebApi.Features.Meets.GetParticipation;
 using KRAFT.Results.WebApi.Features.Meets.GetParticipations;
+using KRAFT.Results.WebApi.Features.Meets.GetPhotos;
 using KRAFT.Results.WebApi.Features.Meets.GetRecords;
 using KRAFT.Results.WebApi.Features.Meets.GetTeamPoints;
 using KRAFT.Results.WebApi.Features.Meets.RecordAttempt;
@@ -26,6 +27,7 @@ internal static class MeetServices
         services.AddScoped<CreateMeetHandler>();
         services.AddScoped<DeleteMeetHandler>();
         services.AddScoped<GetMeetDetailsHandler>();
+        services.AddScoped<GetMeetPhotosHandler>();
         services.AddScoped<GetMeetParticipationHandler>();
         services.AddScoped<GetMeetParticipationsHandler>();
         services.AddScoped<GetMeetRecordsHandler>();

--- a/src/KRAFT.Results.WebApi/Features/Photos/Photo.cs
+++ b/src/KRAFT.Results.WebApi/Features/Photos/Photo.cs
@@ -12,7 +12,7 @@ internal sealed class Photo
 
     public DateTime Date { get; private set; }
 
-    public string? ImageFilname { get; private set; }
+    public string? ImageFilename { get; private set; }
 
     public DateTime CreatedOn { get; private set; }
 

--- a/src/KRAFT.Results.WebApi/Features/Photos/PhotoConfiguration.cs
+++ b/src/KRAFT.Results.WebApi/Features/Photos/PhotoConfiguration.cs
@@ -19,7 +19,8 @@ internal sealed class PhotoConfiguration : IEntityTypeConfiguration<Photo>
         builder.Property(e => e.Date)
             .HasColumnType("datetime");
 
-        builder.Property(e => e.ImageFilname)
+        builder.Property(e => e.ImageFilename)
+            .HasColumnName("ImageFilname")
             .HasMaxLength(200);
 
         builder.Property(e => e.ModifiedBy)

--- a/src/KRAFT.Results.WebApi/Migrations/ResultsDbContextModelSnapshot.cs
+++ b/src/KRAFT.Results.WebApi/Migrations/ResultsDbContextModelSnapshot.cs
@@ -704,7 +704,8 @@ namespace KRAFT.Results.WebApi.Migrations
                     b.Property<DateTime>("Date")
                         .HasColumnType("datetime");
 
-                    b.Property<string>("ImageFilname")
+                    b.Property<string>("ImageFilename")
+                        .HasColumnName("ImageFilname")
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
@@ -1,0 +1,158 @@
+using Bunit;
+
+using KRAFT.Results.Web.Client.Components;
+using KRAFT.Results.Web.Client.Features.Meets;
+
+using Microsoft.AspNetCore.Components;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Components;
+
+public sealed class LightboxTests : IDisposable
+{
+    private readonly IReadOnlyList<GalleryPhoto> _twoPhotos =
+    [
+        new GalleryPhoto(
+            ThumbnailUrl: "https://example.com/thumb1.jpg",
+            DisplayUrl: "https://example.com/display1.jpg",
+            Photographer: "Jane Doe"),
+        new GalleryPhoto(
+            ThumbnailUrl: "https://example.com/thumb2.jpg",
+            DisplayUrl: "https://example.com/display2.jpg",
+            Photographer: null),
+    ];
+
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void DisplaysImageWithCorrectMainDisplayUrl()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".lightbox-image");
+        img.GetAttribute("src").ShouldBe("https://example.com/display1.jpg");
+    }
+
+    [Fact]
+    public void ShowsPhotographerAttribution_WhenPresent()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Assert
+        cut.Find(".lightbox-photographer").TextContent.ShouldContain("Jane Doe");
+    }
+
+    [Fact]
+    public void HidesPhotographerAttribution_WhenNull()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 1)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Assert
+        cut.FindAll(".lightbox-photographer").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ArrowRightKey_NavigatesToNextPhoto()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Act
+        cut.Find(".lightbox-backdrop").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "ArrowRight" });
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".lightbox-image");
+        img.GetAttribute("src").ShouldBe("https://example.com/display2.jpg");
+    }
+
+    [Fact]
+    public void ArrowLeftKey_NavigatesToPreviousPhoto_WithWrapAround()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Act
+        cut.Find(".lightbox-backdrop").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "ArrowLeft" });
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".lightbox-image");
+        img.GetAttribute("src").ShouldBe("https://example.com/display2.jpg");
+    }
+
+    [Fact]
+    public void EscapeKey_InvokesOnClose()
+    {
+        // Arrange
+        bool closeCalled = false;
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Factory.Create(this, () => closeCalled = true)));
+
+        // Act
+        cut.Find(".lightbox-backdrop").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Escape" });
+
+        // Assert
+        closeCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShowsCorrectPhotoCounter()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Assert
+        cut.Find(".lightbox-counter").TextContent.ShouldBe("1 / 2");
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
@@ -320,6 +320,31 @@ public sealed class LightboxTests : IDisposable
         cut.Find(".lightbox-image-container").ClassList.ShouldContain("is-loaded");
     }
 
+    [Fact]
+    public void TabKey_WithSinglePhoto_DoesNotThrow_AndCyclesToCloseButton()
+    {
+        // Arrange
+        IReadOnlyList<GalleryPhoto> onePhoto =
+        [
+            new GalleryPhoto(
+                ThumbnailUrl: "https://example.com/thumb1.jpg",
+                DisplayUrl: "https://example.com/display1.jpg",
+                Photographer: null),
+        ];
+
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, onePhoto)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Act & Assert — pressing Tab must not throw a JS interop exception
+        Should.NotThrow(() =>
+            cut.Find(".lightbox-backdrop").KeyDown(
+                new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Tab" }));
+    }
+
     public void Dispose()
     {
         _context.Dispose();

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
@@ -161,7 +161,7 @@ public sealed class LightboxTests : IDisposable
     }
 
     [Fact]
-    public void ShowsErrorMessage_WhenImageFailsToLoad()
+    public void FallsBackToThumbnailUrl_WhenDisplayUrlFails()
     {
         // Arrange
         IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
@@ -171,7 +171,29 @@ public sealed class LightboxTests : IDisposable
                 .Add(c => c.IsOpen, true)
                 .Add(c => c.OnClose, EventCallback.Empty));
 
+        cut.Find(".lightbox-image").GetAttribute("src").ShouldBe("https://example.com/display1.jpg");
+
         // Act
+        cut.Find(".lightbox-image").TriggerEvent("onerror", new Microsoft.AspNetCore.Components.Web.ErrorEventArgs());
+
+        // Assert
+        AngleSharp.Dom.IElement img = cut.Find(".lightbox-image");
+        img.GetAttribute("src").ShouldBe("https://example.com/thumb1.jpg");
+    }
+
+    [Fact]
+    public void ShowsErrorMessage_WhenBothDisplayAndThumbnailFail()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Act — first error triggers fallback, second error shows message
+        cut.Find(".lightbox-image").TriggerEvent("onerror", new Microsoft.AspNetCore.Components.Web.ErrorEventArgs());
         cut.Find(".lightbox-image").TriggerEvent("onerror", new Microsoft.AspNetCore.Components.Web.ErrorEventArgs());
 
         // Assert
@@ -191,6 +213,7 @@ public sealed class LightboxTests : IDisposable
                 .Add(c => c.OnClose, EventCallback.Empty));
 
         cut.Find(".lightbox-image").TriggerEvent("onerror", new Microsoft.AspNetCore.Components.Web.ErrorEventArgs());
+        cut.Find(".lightbox-image").TriggerEvent("onerror", new Microsoft.AspNetCore.Components.Web.ErrorEventArgs());
         cut.FindAll(".lightbox-image").Count.ShouldBe(0);
 
         // Act
@@ -198,6 +221,7 @@ public sealed class LightboxTests : IDisposable
 
         // Assert
         cut.FindAll(".lightbox-image").Count.ShouldBe(1);
+        cut.Find(".lightbox-image").GetAttribute("src").ShouldBe("https://example.com/display2.jpg");
         cut.FindAll(".lightbox-error-message").Count.ShouldBe(0);
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
@@ -286,7 +286,7 @@ public sealed class LightboxTests : IDisposable
     }
 
     [Fact]
-    public void ImageContainer_HasLoadingPlaceholderBackground()
+    public void WhenOpen_RendersImageContainer()
     {
         // Act
         IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
@@ -143,6 +143,183 @@ public sealed class LightboxTests : IDisposable
         cut.Find(".lightbox-counter").TextContent.ShouldBe("1 / 2");
     }
 
+    [Fact]
+    public void ShowsAriaLiveRegion_AroundPhotoInfo()
+    {
+        // Act
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Assert
+        AngleSharp.Dom.IElement liveRegion = cut.Find("[aria-live='polite']");
+        liveRegion.GetAttribute("aria-atomic").ShouldBe("true");
+        liveRegion.QuerySelector(".lightbox-info").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ShowsErrorMessage_WhenImageFailsToLoad()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Act
+        cut.Find(".lightbox-image").TriggerEvent("onerror", new Microsoft.AspNetCore.Components.Web.ErrorEventArgs());
+
+        // Assert
+        cut.FindAll(".lightbox-image").Count.ShouldBe(0);
+        cut.Find(".lightbox-error-message").TextContent.ShouldContain("Ekki tókst að hlaða mynd");
+    }
+
+    [Fact]
+    public void ResetsErrorState_WhenNavigatingToNextPhoto()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        cut.Find(".lightbox-image").TriggerEvent("onerror", new Microsoft.AspNetCore.Components.Web.ErrorEventArgs());
+        cut.FindAll(".lightbox-image").Count.ShouldBe(0);
+
+        // Act
+        cut.Find(".lightbox-backdrop").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "ArrowRight" });
+
+        // Assert
+        cut.FindAll(".lightbox-image").Count.ShouldBe(1);
+        cut.FindAll(".lightbox-error-message").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SwipeLeft_NavigatesToNextPhoto()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        Microsoft.AspNetCore.Components.Web.TouchEventArgs touchStart = new()
+        {
+            ChangedTouches = [new Microsoft.AspNetCore.Components.Web.TouchPoint { ClientX = 200 }],
+        };
+        Microsoft.AspNetCore.Components.Web.TouchEventArgs touchEnd = new()
+        {
+            ChangedTouches = [new Microsoft.AspNetCore.Components.Web.TouchPoint { ClientX = 100 }],
+        };
+
+        // Act
+        cut.Find(".lightbox-content").TriggerEvent("ontouchstart", touchStart);
+        cut.Find(".lightbox-content").TriggerEvent("ontouchend", touchEnd);
+
+        // Assert
+        cut.Find(".lightbox-image").GetAttribute("src").ShouldBe("https://example.com/display2.jpg");
+    }
+
+    [Fact]
+    public void SwipeRight_NavigatesToPreviousPhoto()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 1)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        Microsoft.AspNetCore.Components.Web.TouchEventArgs touchStart = new()
+        {
+            ChangedTouches = [new Microsoft.AspNetCore.Components.Web.TouchPoint { ClientX = 100 }],
+        };
+        Microsoft.AspNetCore.Components.Web.TouchEventArgs touchEnd = new()
+        {
+            ChangedTouches = [new Microsoft.AspNetCore.Components.Web.TouchPoint { ClientX = 200 }],
+        };
+
+        // Act
+        cut.Find(".lightbox-content").TriggerEvent("ontouchstart", touchStart);
+        cut.Find(".lightbox-content").TriggerEvent("ontouchend", touchEnd);
+
+        // Assert
+        cut.Find(".lightbox-image").GetAttribute("src").ShouldBe("https://example.com/display1.jpg");
+    }
+
+    [Fact]
+    public void ShortSwipe_DoesNotNavigate()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        Microsoft.AspNetCore.Components.Web.TouchEventArgs touchStart = new()
+        {
+            ChangedTouches = [new Microsoft.AspNetCore.Components.Web.TouchPoint { ClientX = 200 }],
+        };
+        Microsoft.AspNetCore.Components.Web.TouchEventArgs touchEnd = new()
+        {
+            ChangedTouches = [new Microsoft.AspNetCore.Components.Web.TouchPoint { ClientX = 170 }],
+        };
+
+        // Act
+        cut.Find(".lightbox-content").TriggerEvent("ontouchstart", touchStart);
+        cut.Find(".lightbox-content").TriggerEvent("ontouchend", touchEnd);
+
+        // Assert
+        cut.Find(".lightbox-image").GetAttribute("src").ShouldBe("https://example.com/display1.jpg");
+    }
+
+    [Fact]
+    public void ImageContainer_HasLoadingPlaceholderBackground()
+    {
+        // Act
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        // Assert
+        cut.Find(".lightbox-image-container").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ImageContainer_GetsLoadedClass_WhenImageLoads()
+    {
+        // Arrange
+        IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
+            p => p
+                .Add(c => c.Photos, _twoPhotos)
+                .Add(c => c.StartIndex, 0)
+                .Add(c => c.IsOpen, true)
+                .Add(c => c.OnClose, EventCallback.Empty));
+
+        cut.Find(".lightbox-image-container").ClassList.ShouldNotContain("is-loaded");
+
+        // Act
+        cut.Find(".lightbox-image").TriggerEvent("onload", new Microsoft.AspNetCore.Components.Web.ProgressEventArgs());
+
+        // Assert
+        cut.Find(".lightbox-image-container").ClassList.ShouldContain("is-loaded");
+    }
+
     public void Dispose()
     {
         _context.Dispose();

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/LightboxTests.cs
@@ -28,8 +28,6 @@ public sealed class LightboxTests : IDisposable
     [Fact]
     public void DisplaysImageWithCorrectMainDisplayUrl()
     {
-        // Arrange
-
         // Act
         IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
             p => p
@@ -46,8 +44,6 @@ public sealed class LightboxTests : IDisposable
     [Fact]
     public void ShowsPhotographerAttribution_WhenPresent()
     {
-        // Arrange
-
         // Act
         IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
             p => p
@@ -63,8 +59,6 @@ public sealed class LightboxTests : IDisposable
     [Fact]
     public void HidesPhotographerAttribution_WhenNull()
     {
-        // Arrange
-
         // Act
         IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
             p => p
@@ -137,8 +131,6 @@ public sealed class LightboxTests : IDisposable
     [Fact]
     public void ShowsCorrectPhotoCounter()
     {
-        // Arrange
-
         // Act
         IRenderedComponent<Lightbox> cut = _context.Render<Lightbox>(
             p => p

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/EditMeetPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/EditMeetPageTests.cs
@@ -140,7 +140,8 @@ public sealed class EditMeetPageTests : IDisposable
             RecordsPossible: false,
             IsClassic: false,
             ShowTeamPoints: false,
-            Disciplines: []);
+            Disciplines: [],
+            PhotoCount: 0);
 
         private readonly List<MeetTypeSummary> _meetTypes =
         [

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/GalleryPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/GalleryPageTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Bunit;
+
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.Web.Client.Features.Meets;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests.Features.Meets;
+
+public sealed class GalleryPageTests : IDisposable
+{
+    private const string ImageBaseUrl = "https://example.blob.core.windows.net/images";
+
+    private readonly BunitContext _context = new();
+
+    [Fact]
+    public void RendersThumbnailGrid_WhenPhotosExist()
+    {
+        // Arrange
+        List<PhotoSummary> photos =
+        [
+            new(PhotoId: 1, ImageFilename: "photo1.jpg", Photographer: null),
+            new(PhotoId: 2, ImageFilename: "photo2.jpg", Photographer: "Jane Doe"),
+        ];
+        RegisterHttpClient(photos);
+
+        // Act
+        IRenderedComponent<GalleryPage> cut = _context.Render<GalleryPage>(
+            p => p.Add(c => c.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".gallery-grid").ShouldNotBeNull();
+            cut.FindAll(".gallery-thumb").Count.ShouldBe(2);
+        });
+    }
+
+    [Fact]
+    public void ShowsEmptyState_WhenNoPhotos()
+    {
+        // Arrange
+        RegisterHttpClient([]);
+
+        // Act
+        IRenderedComponent<GalleryPage> cut = _context.Render<GalleryPage>(
+            p => p.Add(c => c.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".empty-state").TextContent.ShouldContain("Engar myndir fundust.");
+        });
+    }
+
+    [Fact]
+    public void ThumbnailSrcs_ContainThumbnailQueryString()
+    {
+        // Arrange
+        List<PhotoSummary> photos =
+        [
+            new(PhotoId: 1, ImageFilename: "myphoto.jpg", Photographer: null),
+        ];
+        RegisterHttpClient(photos);
+
+        // Act
+        IRenderedComponent<GalleryPage> cut = _context.Render<GalleryPage>(
+            p => p.Add(c => c.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement img = cut.Find(".gallery-thumb img");
+            img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/myphoto.jpg{MeetPhotoSizes.Thumbnail}");
+        });
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient lifetime is managed by the DI container.")]
+    private void RegisterHttpClient(List<PhotoSummary> photos)
+    {
+        GalleryPageMockHandler handler = new(photos);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
+        _context.Services.AddSingleton(httpClient);
+        RegisterConfiguration();
+        _context.AddAuthorization();
+    }
+
+    private void RegisterConfiguration()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ImageBaseUrl"] = ImageBaseUrl,
+            })
+            .Build();
+        _context.Services.AddSingleton(configuration);
+    }
+
+    private sealed class GalleryPageMockHandler(List<PhotoSummary> photos) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            MeetPhotos response = new("Test Meet", photos);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(response),
+            });
+        }
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/GalleryPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/GalleryPageTests.cs
@@ -25,8 +25,8 @@ public sealed class GalleryPageTests : IDisposable
         // Arrange
         List<PhotoSummary> photos =
         [
-            new(PhotoId: 1, ImageFilename: "photo1.jpg", Photographer: null),
-            new(PhotoId: 2, ImageFilename: "photo2.jpg", Photographer: "Jane Doe"),
+            new(ImageFilename: "photo1.jpg", Photographer: null),
+            new(ImageFilename: "photo2.jpg", Photographer: "Jane Doe"),
         ];
         RegisterHttpClient(photos);
 
@@ -65,7 +65,7 @@ public sealed class GalleryPageTests : IDisposable
         // Arrange
         List<PhotoSummary> photos =
         [
-            new(PhotoId: 1, ImageFilename: "myphoto.jpg", Photographer: null),
+            new(ImageFilename: "myphoto.jpg", Photographer: null),
         ];
         RegisterHttpClient(photos);
 
@@ -78,6 +78,35 @@ public sealed class GalleryPageTests : IDisposable
         {
             AngleSharp.Dom.IElement img = cut.Find(".gallery-thumb img");
             img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/myphoto.jpg{MeetPhotoSizes.Thumbnail}");
+        });
+    }
+
+    [Theory]
+    [InlineData("../traversal.jpg")]
+    [InlineData("//cdn.evil.com/img.jpg")]
+    [InlineData("has/slash.jpg")]
+    [InlineData("has\\backslash.jpg")]
+    [InlineData("has:colon.jpg")]
+    [InlineData("has?query.jpg")]
+    [InlineData("has#hash.jpg")]
+    public void SkipsPhotos_WithInvalidFilenames(string invalidFilename)
+    {
+        // Arrange
+        List<PhotoSummary> photos =
+        [
+            new(ImageFilename: "valid.jpg", Photographer: null),
+            new(ImageFilename: invalidFilename, Photographer: null),
+        ];
+        RegisterHttpClient(photos);
+
+        // Act
+        IRenderedComponent<GalleryPage> cut = _context.Render<GalleryPage>(
+            p => p.Add(c => c.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".gallery-thumb").Count.ShouldBe(1);
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/GalleryPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/GalleryPageTests.cs
@@ -140,6 +140,7 @@ public sealed class GalleryPageTests : IDisposable
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            request.RequestUri!.AbsolutePath.ShouldBe("/meets/test-meet/photos");
             MeetPhotos response = new("Test Meet", photos);
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetDetailsPageTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 
+using AngleSharp.Dom;
+
 using Bunit;
 
 using KRAFT.Results.Contracts;
@@ -122,6 +124,42 @@ public sealed class MeetDetailsPageTests : IDisposable
         });
     }
 
+    [Fact]
+    public void ShowsPhotoCountLink_WhenPhotoCountIsGreaterThanZero()
+    {
+        // Arrange
+        RegisterHttpClient(photoCount: 42);
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            IElement link = cut.Find(".photo-count-link");
+            link.TextContent.ShouldContain("42 myndir");
+            link.GetAttribute("href").ShouldBe("/meets/test-meet/gallery");
+        });
+    }
+
+    [Fact]
+    public void HidesPhotoCountLink_WhenPhotoCountIsZero()
+    {
+        // Arrange
+        RegisterHttpClient(photoCount: 0);
+
+        // Act
+        IRenderedComponent<MeetDetailsPage> cut = _context.Render<MeetDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-meet"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".photo-count-link").Count.ShouldBe(0);
+        });
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -151,12 +189,14 @@ public sealed class MeetDetailsPageTests : IDisposable
     private void RegisterHttpClient(
         List<MeetParticipation>? participations = null,
         bool calculatePlaces = false,
-        bool delay = false)
+        bool delay = false,
+        int photoCount = 0)
     {
         MeetDetailsPageMockHandler handler = new(
             participations ?? [],
             calculatePlaces,
-            delay);
+            delay,
+            photoCount);
 
         HttpClient httpClient = new(handler) { BaseAddress = new Uri("http://localhost") };
         _context.Services.AddSingleton(httpClient);

--- a/tests/KRAFT.Results.Web.Client.Tests/MeetDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/MeetDetailsPageMockHandler.cs
@@ -9,7 +9,8 @@ namespace KRAFT.Results.Web.Client.Tests;
 internal sealed class MeetDetailsPageMockHandler(
     List<MeetParticipation> participations,
     bool calculatePlaces = false,
-    bool delay = false) : HttpMessageHandler
+    bool delay = false,
+    int photoCount = 0) : HttpMessageHandler
 {
     private readonly MeetDetails _meet = new(
         MeetId: 1,
@@ -33,7 +34,7 @@ internal sealed class MeetDetailsPageMockHandler(
         IsClassic: true,
         ShowTeamPoints: false,
         Disciplines: [Discipline.Squat, Discipline.Bench, Discipline.Deadlift],
-        PhotoCount: 0);
+        PhotoCount: photoCount);
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {

--- a/tests/KRAFT.Results.Web.Client.Tests/MeetDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/MeetDetailsPageMockHandler.cs
@@ -32,7 +32,8 @@ internal sealed class MeetDetailsPageMockHandler(
         RecordsPossible: false,
         IsClassic: true,
         ShowTeamPoints: false,
-        Disciplines: [Discipline.Squat, Discipline.Bench, Discipline.Deadlift]);
+        Disciplines: [Discipline.Squat, Discipline.Bench, Discipline.Deadlift],
+        PhotoCount: 0);
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetDetailsTests.cs
@@ -51,7 +51,7 @@ public sealed class GetMeetDetailsTests(CollectionFixture fixture) : IAsyncLifet
     }
 
     [Fact]
-    public async Task ReturnsPhotoCount_WhenMeetHasPhotosWithValidFilenames()
+    public async Task WhenMeetHasPhotosWithValidFilenames_ReturnsPhotoCount()
     {
         // Arrange — seed three photos: two with valid filenames, one with null filename
         await fixture.ExecuteSqlAsync(
@@ -74,7 +74,7 @@ public sealed class GetMeetDetailsTests(CollectionFixture fixture) : IAsyncLifet
     }
 
     [Fact]
-    public async Task ReturnsPhotoCount_ExcludingPhotosWithEmptyFilename()
+    public async Task WhenFilenameIsEmpty_ExcludesFromPhotoCount()
     {
         // Arrange — seed two photos: one with valid filename, one with empty string
         await fixture.ExecuteSqlAsync(

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetDetailsTests.cs
@@ -1,0 +1,97 @@
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+using KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
+
+[Collection(nameof(MeetsCollection))]
+public sealed class GetMeetDetailsTests(CollectionFixture fixture) : IAsyncLifetime
+{
+    private const string BasePath = "/meets";
+
+    private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
+    private readonly HttpClient _authorizedClient = fixture.CreateAuthorizedHttpClient();
+
+    private string _meetSlug = string.Empty;
+    private int _meetId;
+
+    async ValueTask IAsyncLifetime.InitializeAsync()
+    {
+        CreateMeetCommand meetCommand = new CreateMeetCommandBuilder().Build();
+
+        HttpResponseMessage createMeetResponse = await _authorizedClient.PostAsJsonAsync(
+            "/meets",
+            meetCommand,
+            CancellationToken.None);
+
+        createMeetResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createMeetResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? meetDetails = await _authorizedClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}",
+            CancellationToken.None);
+
+        _meetId = meetDetails!.MeetId;
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_meetSlug.Length > 0)
+        {
+            await _authorizedClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+        }
+
+        _httpClient.Dispose();
+        _authorizedClient.Dispose();
+    }
+
+    [Fact]
+    public async Task ReturnsPhotoCount_WhenMeetHasPhotosWithValidFilenames()
+    {
+        // Arrange — seed three photos: two with valid filenames, one with null filename
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO dbo.Photos (MeetId, Photographer, Date, ImageFilname, CreatedOn, CreatedBy, ModifiedOn, ModifiedBy)
+            VALUES
+                ({_meetId}, NULL, GETUTCDATE(), 'photo-a.jpg', '2024-01-01', 'test-setup', '2024-01-01', 'test-setup'),
+                ({_meetId}, NULL, GETUTCDATE(), 'photo-b.jpg', '2024-01-02', 'test-setup', '2024-01-02', 'test-setup'),
+                ({_meetId}, NULL, GETUTCDATE(), NULL,          '2024-01-03', 'test-setup', '2024-01-03', 'test-setup')
+            """);
+
+        // Act
+        MeetDetails? result = await _httpClient.GetFromJsonAsync<MeetDetails>(
+            $"{BasePath}/{_meetSlug}",
+            CancellationToken.None);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.PhotoCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ReturnsPhotoCount_ExcludingPhotosWithEmptyFilename()
+    {
+        // Arrange — seed two photos: one with valid filename, one with empty string
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO dbo.Photos (MeetId, Photographer, Date, ImageFilname, CreatedOn, CreatedBy, ModifiedOn, ModifiedBy)
+            VALUES
+                ({_meetId}, NULL, GETUTCDATE(), 'valid.jpg', '2024-02-01', 'test-setup', '2024-02-01', 'test-setup'),
+                ({_meetId}, NULL, GETUTCDATE(), '',          '2024-02-02', 'test-setup', '2024-02-02', 'test-setup')
+            """);
+
+        // Act
+        MeetDetails? result = await _httpClient.GetFromJsonAsync<MeetDetails>(
+            $"{BasePath}/{_meetSlug}",
+            CancellationToken.None);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.PhotoCount.ShouldBe(1);
+    }
+}

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetPhotosTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetPhotosTests.cs
@@ -15,17 +15,16 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
     private const string BasePath = "/meets";
 
     private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
+    private readonly HttpClient _authorizedClient = fixture.CreateAuthorizedHttpClient();
 
     private string _meetSlug = string.Empty;
     private int _meetId;
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
-        HttpClient authorizedClient = fixture.CreateAuthorizedHttpClient();
-
         CreateMeetCommand meetCommand = new CreateMeetCommandBuilder().Build();
 
-        HttpResponseMessage createMeetResponse = await authorizedClient.PostAsJsonAsync(
+        HttpResponseMessage createMeetResponse = await _authorizedClient.PostAsJsonAsync(
             "/meets",
             meetCommand,
             CancellationToken.None);
@@ -34,29 +33,26 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
 
         _meetSlug = createMeetResponse.Headers.Location!.ToString().TrimStart('/');
 
-        MeetDetails? meetDetails = await authorizedClient.GetFromJsonAsync<MeetDetails>(
+        MeetDetails? meetDetails = await _authorizedClient.GetFromJsonAsync<MeetDetails>(
             $"/meets/{_meetSlug}",
             CancellationToken.None);
 
         _meetId = meetDetails!.MeetId;
-
-        authorizedClient.Dispose();
     }
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
         if (_meetSlug.Length > 0)
         {
-            HttpClient authorizedClient = fixture.CreateAuthorizedHttpClient();
-            await authorizedClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
-            authorizedClient.Dispose();
+            await _authorizedClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
         }
 
         _httpClient.Dispose();
+        _authorizedClient.Dispose();
     }
 
     [Fact]
-    public async Task ReturnsOk_WithEmptyPhotos_WhenMeetHasNoPhotos()
+    public async Task WhenMeetHasNoPhotos_ReturnsOkWithEmptyPhotos()
     {
         // Arrange & Act
         HttpResponseMessage response = await _httpClient.GetAsync(
@@ -71,7 +67,7 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
     }
 
     [Fact]
-    public async Task ReturnsNotFound_WhenMeetDoesNotExist()
+    public async Task WhenMeetDoesNotExist_ReturnsNotFound()
     {
         // Arrange & Act
         HttpResponseMessage response = await _httpClient.GetAsync(
@@ -83,7 +79,7 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
     }
 
     [Fact]
-    public async Task ReturnsOk_WithPhotos_WhenMeetHasPhotos()
+    public async Task WhenMeetHasPhotos_ReturnsOkWithPhotos()
     {
         // Arrange — seed two photos for the meet
         await fixture.ExecuteSqlAsync(
@@ -107,7 +103,7 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
     }
 
     [Fact]
-    public async Task ExcludesPhotos_WithNullOrEmptyFilename()
+    public async Task WhenFilenameIsNullOrEmpty_ExcludesPhoto()
     {
         // Arrange — seed one valid photo and one with null filename
         await fixture.ExecuteSqlAsync(
@@ -133,7 +129,7 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
     }
 
     [Fact]
-    public async Task ReturnsPhotographerName_WhenPresent_AndNullWhenAbsent()
+    public async Task WhenPhotographerIsPresent_ReturnsName_WhenAbsent_ReturnsNull()
     {
         // Arrange
         await fixture.ExecuteSqlAsync(
@@ -158,7 +154,7 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
     }
 
     [Fact]
-    public async Task ReturnsPhotos_OrderedByCreatedOnAscending()
+    public async Task WhenMultiplePhotos_ReturnsOrderedByCreatedOnAscending()
     {
         // Arrange — insert photos with explicit CreatedOn in descending order
         await fixture.ExecuteSqlAsync(
@@ -191,7 +187,7 @@ public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifeti
     }
 
     [Fact]
-    public async Task ReturnsMeetTitle_InResponse()
+    public async Task Always_ReturnsMeetTitle()
     {
         // Arrange & Act
         HttpResponseMessage response = await _httpClient.GetAsync(

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetPhotosTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Meets/GetMeetPhotosTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.IntegrationTests.Builders;
+using KRAFT.Results.WebApi.IntegrationTests.Collections;
+
+using Shouldly;
+
+namespace KRAFT.Results.WebApi.IntegrationTests.Features.Meets;
+
+[Collection(nameof(MeetsCollection))]
+public sealed class GetMeetPhotosTests(CollectionFixture fixture) : IAsyncLifetime
+{
+    private const string BasePath = "/meets";
+
+    private readonly HttpClient _httpClient = fixture.Factory!.CreateClient();
+
+    private string _meetSlug = string.Empty;
+    private int _meetId;
+
+    async ValueTask IAsyncLifetime.InitializeAsync()
+    {
+        HttpClient authorizedClient = fixture.CreateAuthorizedHttpClient();
+
+        CreateMeetCommand meetCommand = new CreateMeetCommandBuilder().Build();
+
+        HttpResponseMessage createMeetResponse = await authorizedClient.PostAsJsonAsync(
+            "/meets",
+            meetCommand,
+            CancellationToken.None);
+
+        createMeetResponse.EnsureSuccessStatusCode();
+
+        _meetSlug = createMeetResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? meetDetails = await authorizedClient.GetFromJsonAsync<MeetDetails>(
+            $"/meets/{_meetSlug}",
+            CancellationToken.None);
+
+        _meetId = meetDetails!.MeetId;
+
+        authorizedClient.Dispose();
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_meetSlug.Length > 0)
+        {
+            HttpClient authorizedClient = fixture.CreateAuthorizedHttpClient();
+            await authorizedClient.DeleteAsync($"/meets/{_meetSlug}", CancellationToken.None);
+            authorizedClient.Dispose();
+        }
+
+        _httpClient.Dispose();
+    }
+
+    [Fact]
+    public async Task ReturnsOk_WithEmptyPhotos_WhenMeetHasNoPhotos()
+    {
+        // Arrange & Act
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{BasePath}/{_meetSlug}/photos",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        MeetPhotos? result = await response.Content.ReadFromJsonAsync<MeetPhotos>(CancellationToken.None);
+        result.ShouldNotBeNull();
+        result.Photos.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenMeetDoesNotExist()
+    {
+        // Arrange & Act
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{BasePath}/non-existent-meet/photos",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReturnsOk_WithPhotos_WhenMeetHasPhotos()
+    {
+        // Arrange — seed two photos for the meet
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO dbo.Photos (MeetId, Photographer, Date, ImageFilname, CreatedOn, CreatedBy, ModifiedOn, ModifiedBy)
+            VALUES
+                ({_meetId}, 'Test Photographer', GETUTCDATE(), 'photo1.jpg', '2024-01-01', 'test-setup', '2024-01-01', 'test-setup'),
+                ({_meetId}, NULL,                 GETUTCDATE(), 'photo2.jpg', '2024-01-02', 'test-setup', '2024-01-02', 'test-setup')
+            """);
+
+        // Act
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{BasePath}/{_meetSlug}/photos",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        MeetPhotos? result = await response.Content.ReadFromJsonAsync<MeetPhotos>(CancellationToken.None);
+        result.ShouldNotBeNull();
+        result.Photos.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ExcludesPhotos_WithNullOrEmptyFilename()
+    {
+        // Arrange — seed one valid photo and one with null filename
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO dbo.Photos (MeetId, Photographer, Date, ImageFilname, CreatedOn, CreatedBy, ModifiedOn, ModifiedBy)
+            VALUES
+                ({_meetId}, 'Photographer A', GETUTCDATE(), 'valid.jpg', '2024-02-01', 'test-setup', '2024-02-01', 'test-setup'),
+                ({_meetId}, 'Photographer B', GETUTCDATE(), NULL,        '2024-02-02', 'test-setup', '2024-02-02', 'test-setup'),
+                ({_meetId}, 'Photographer C', GETUTCDATE(), '',          '2024-02-03', 'test-setup', '2024-02-03', 'test-setup')
+            """);
+
+        // Act
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{BasePath}/{_meetSlug}/photos",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        MeetPhotos? result = await response.Content.ReadFromJsonAsync<MeetPhotos>(CancellationToken.None);
+        result.ShouldNotBeNull();
+        result.Photos.ShouldContain(p => p.ImageFilename == "valid.jpg");
+        result.Photos.ShouldNotContain(p => p.ImageFilename == null || p.ImageFilename == string.Empty);
+    }
+
+    [Fact]
+    public async Task ReturnsPhotographerName_WhenPresent_AndNullWhenAbsent()
+    {
+        // Arrange
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO dbo.Photos (MeetId, Photographer, Date, ImageFilname, CreatedOn, CreatedBy, ModifiedOn, ModifiedBy)
+            VALUES
+                ({_meetId}, 'Known Photographer', GETUTCDATE(), 'with-photographer.jpg', '2024-03-01', 'test-setup', '2024-03-01', 'test-setup'),
+                ({_meetId}, NULL,                 GETUTCDATE(), 'no-photographer.jpg',   '2024-03-02', 'test-setup', '2024-03-02', 'test-setup')
+            """);
+
+        // Act
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{BasePath}/{_meetSlug}/photos",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        MeetPhotos? result = await response.Content.ReadFromJsonAsync<MeetPhotos>(CancellationToken.None);
+        result.ShouldNotBeNull();
+        result.Photos.ShouldContain(p => p.ImageFilename == "with-photographer.jpg" && p.Photographer == "Known Photographer");
+        result.Photos.ShouldContain(p => p.ImageFilename == "no-photographer.jpg" && p.Photographer == null);
+    }
+
+    [Fact]
+    public async Task ReturnsPhotos_OrderedByCreatedOnAscending()
+    {
+        // Arrange — insert photos with explicit CreatedOn in descending order
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO dbo.Photos (MeetId, Photographer, Date, ImageFilname, CreatedOn, CreatedBy, ModifiedOn, ModifiedBy)
+            VALUES
+                ({_meetId}, NULL, GETUTCDATE(), 'third.jpg',  '2024-04-03', 'test-setup', '2024-04-03', 'test-setup'),
+                ({_meetId}, NULL, GETUTCDATE(), 'first.jpg',  '2024-04-01', 'test-setup', '2024-04-01', 'test-setup'),
+                ({_meetId}, NULL, GETUTCDATE(), 'second.jpg', '2024-04-02', 'test-setup', '2024-04-02', 'test-setup')
+            """);
+
+        // Act
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{BasePath}/{_meetSlug}/photos",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        MeetPhotos? result = await response.Content.ReadFromJsonAsync<MeetPhotos>(CancellationToken.None);
+        result.ShouldNotBeNull();
+
+        List<PhotoSummary> photos = result.Photos
+            .Where(p => p.ImageFilename == "first.jpg" || p.ImageFilename == "second.jpg" || p.ImageFilename == "third.jpg")
+            .ToList();
+
+        photos.Count.ShouldBe(3);
+        photos[0].ImageFilename.ShouldBe("first.jpg");
+        photos[1].ImageFilename.ShouldBe("second.jpg");
+        photos[2].ImageFilename.ShouldBe("third.jpg");
+    }
+
+    [Fact]
+    public async Task ReturnsMeetTitle_InResponse()
+    {
+        // Arrange & Act
+        HttpResponseMessage response = await _httpClient.GetAsync(
+            $"{BasePath}/{_meetSlug}/photos",
+            CancellationToken.None);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        MeetPhotos? result = await response.Content.ReadFromJsonAsync<MeetPhotos>(CancellationToken.None);
+        result.ShouldNotBeNull();
+        result.MeetTitle.ShouldNotBeNullOrWhiteSpace();
+    }
+}


### PR DESCRIPTION
## Summary

- Add read-only photo gallery page for meets at `/meets/{slug}/gallery` with responsive thumbnail grid and pure Blazor lightbox modal
- Add `GET /meets/{slug}/photos` API endpoint returning photos with photographer attribution
- Add photo count link to meet detail page
- Fix `ImageFilname` typo on `Photo` entity (property rename with `HasColumnName` mapping)

Closes #165

## Changes

### API
- New `GetMeetPhotosHandler` + `GetMeetPhotosEndpoint` — queries photos by meet slug, ordered by `CreatedOn`, excludes null/empty filenames
- `PhotoCount` projected in `GetMeetDetailsHandler` via correlated subquery
- New `PhotoSummary` and `MeetPhotos` contracts

### Blazor
- `GalleryPage.razor` — responsive CSS Grid of 75x75 thumbnails with `DataLoader`, empty state, filename validation
- `Lightbox.razor` — full-viewport modal with keyboard navigation (Arrow/Escape/Tab), focus trap, focus restoration, swipe gesture, aria-live announcements, loading/error states
- `MeetPhotoSizes` — centralized proxy query string constants (exact strings required by live site proxy)
- Photo count link with camera icon on `MeetDetailsPage`

### Accessibility
- Focus trap cycles through close/prev/next buttons (dynamic for single-photo galleries)
- `aria-live` region for photo counter announcements
- Unique `aria-label` per thumbnail with position index
- `box-shadow` focus indicator (not clipped by `overflow: hidden`)
- 44px minimum touch targets, `prefers-reduced-motion` support
- Touch swipe navigation on mobile

## Test plan

- [ ] 7 integration tests for `GET /meets/{slug}/photos`
- [ ] 2 integration tests for `PhotoCount` in `GetMeetDetails`
- [ ] 3 bUnit tests for `GalleryPage`
- [ ] 15 bUnit tests for `Lightbox`
- [ ] 2 bUnit tests for `MeetDetailsPage` photo count link