### PR TITLE
refactor(web.client): redesign card system to remove AI-generated visual tells

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -15,7 +15,7 @@
     &:hover,
     &:focus-within {
         border-color: var(--color-primary);
-        background: rgba(139, 26, 43, 0.06);
+        background: var(--card-hover-bg, color-mix(in oklch, var(--color-primary) 6%, transparent));
     }
 
     &:has(:focus-visible) {

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -5,16 +5,16 @@
     padding: var(--card-padding, 1.25rem 1.5rem);
     background: var(--card-bg, var(--color-white));
     box-shadow: var(--card-shadow, var(--shadow-sm));
-    transition: border-color var(--transition-base) ease,
-                background-color var(--transition-base) ease;
 }
 
 .card--clickable {
     cursor: pointer;
+    transition: border-color var(--transition-base) ease,
+                background-color var(--transition-base) ease;
 
     &:hover,
     &:focus-within {
-        border-color: var(--color-primary);
+        border-color: var(--card-hover-border-color, var(--color-primary));
         background: var(--card-hover-bg, color-mix(in oklch, var(--color-primary) 6%, transparent));
     }
 
@@ -39,7 +39,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .card {
+    .card--clickable {
         transition: none;
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/Card.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Card.razor.css
@@ -2,21 +2,20 @@
     position: relative;
     border: var(--card-border, 1px solid var(--color-border));
     border-radius: var(--radius-md);
-    border-inline-start: var(--card-border-start, 4px solid var(--card-accent, var(--color-primary)));
     padding: var(--card-padding, 1.25rem 1.5rem);
     background: var(--card-bg, var(--color-white));
     box-shadow: var(--card-shadow, var(--shadow-sm));
+    transition: border-color var(--transition-base) ease,
+                background-color var(--transition-base) ease;
 }
 
 .card--clickable {
     cursor: pointer;
-    transition: transform var(--transition-base) ease,
-                box-shadow var(--transition-base) ease;
 
     &:hover,
     &:focus-within {
-        transform: var(--card-hover-transform, translateY(-4px));
-        box-shadow: var(--card-hover-shadow, var(--shadow-lg));
+        border-color: var(--color-primary);
+        background: rgba(139, 26, 43, 0.06);
     }
 
     &:has(:focus-visible) {
@@ -40,12 +39,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .card--clickable {
+    .card {
         transition: none;
-
-        &:hover,
-        &:focus-within {
-            transform: none;
-        }
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/MeetCard.razor
+++ b/src/KRAFT.Results.Web.Client/Components/MeetCard.razor
@@ -12,6 +12,14 @@
         <div class="meet-card-pills">
             <span class="pill pill-discipline">@Meet.Discipline</span>
             <span class="pill @(Meet.IsClassic ? "pill-classic" : "pill-equipped")">@DisplayNames.EquipmentType(Meet.IsClassic)</span>
+            @if (_variant == "meet-card--active")
+            {
+                <span class="card-status card-status--active">Skráning opin</span>
+            }
+            else if (_variant == "meet-card--ghost")
+            {
+                <span class="card-status">Væntanlegt</span>
+            }
         </div>
     </div>
 

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteParticipationCard.razor
@@ -8,6 +8,10 @@
         <div class="ap-rank @_rankClass">@_rankDisplay</div>
         <div class="ap-name-col">
             <NavLink class="ap-meet" href="@($"/meets/{Participation.MeetSlug}")">@Participation.Meet</NavLink>
+            @if (Participation.IsDisqualified)
+            {
+                <span class="card-status">Úr leik</span>
+            }
             <span class="ap-meta">@_metaLine</span>
         </div>
     </div>

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardPage.razor
@@ -18,25 +18,25 @@
         <section class="season-stats" aria-label="Tölur ársins @_year">
             <h2 class="section-label">Tölur ársins @_year</h2>
             <div class="stat-bar">
-                <Card Compact="true" CssClass="card-plain">
+                <Card Compact="true">
                     <div class="stat-inner">
                         <span class="stat-label">Mót</span>
                         <span class="stat-number">@context.SeasonStats.Meets</span>
                     </div>
                 </Card>
-                <Card Compact="true" CssClass="card-plain">
+                <Card Compact="true">
                     <div class="stat-inner">
                         <span class="stat-label">Keppendur</span>
                         <span class="stat-number">@context.SeasonStats.Athletes</span>
                     </div>
                 </Card>
-                <Card Compact="true" CssClass="card-plain">
+                <Card Compact="true">
                     <div class="stat-inner">
                         <span class="stat-label">Met</span>
                         <span class="stat-number">@context.SeasonStats.Records</span>
                     </div>
                 </Card>
-                <Card Compact="true" CssClass="card-plain">
+                <Card Compact="true">
                     <div class="stat-inner">
                         <span class="stat-label">Félög</span>
                         <span class="stat-number">@context.SeasonStats.Clubs</span>
@@ -46,7 +46,7 @@
         </section>
 
         <div class="widget-grid">
-        <Card CssClass="card-flush card-plain">
+        <Card CssClass="card-flush">
             <div class="widget-header">
                 <h2 class="widget-title">Mót</h2>
                 <NavLink class="widget-link" href="/meets">Mótaskrá →</NavLink>
@@ -87,7 +87,7 @@
             </div>
         </Card>
 
-        <Card CssClass="card-flush card-plain">
+        <Card CssClass="card-flush">
             <div class="widget-header">
                 <h2 class="widget-title">Stigatafla @_year — Klassík</h2>
                 <NavLink class="widget-link" href="/rankings">Allt →</NavLink>
@@ -128,7 +128,7 @@
             </div>
         </Card>
 
-        <Card CssClass="card-flush card-plain">
+        <Card CssClass="card-flush">
             <div class="widget-header">
                 <h2 class="widget-title">Nýjustu met</h2>
                 <NavLink class="widget-link" href="/records">Allt →</NavLink>
@@ -199,7 +199,7 @@
 
         @if (context.TeamStandingsMen.Count > 0 || context.TeamStandingsWomen.Count > 0)
         {
-            <Card CssClass="card-flush card-plain">
+            <Card CssClass="card-flush">
                 <div class="widget-header">
                     <h2 class="widget-title">Liðakeppni @_year</h2>
                     <NavLink class="widget-link" href="/team-competition">Allt →</NavLink>

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor.css
@@ -13,7 +13,6 @@
     min-width: 0;
     background: var(--color-white);
     border: 1px solid var(--color-border);
-    border-inline-start: 4px solid var(--color-primary);
     border-radius: var(--radius-md);
     overflow: hidden;
 }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
@@ -17,6 +17,10 @@
         </div>
         <div class="p-name-col">
             <NavLink class="p-name" href="@($"/athletes/{Participation.AthleteSlug}")">@Participation.Athlete</NavLink>
+            @if (Participation.Disqualified)
+            {
+                <span class="card-status">Úr leik</span>
+            }
             <span class="p-meta">
                 @_metaLine
                 <AuthorizeView Roles="Admin">

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
@@ -37,6 +37,7 @@
 .p-name-col {
     display: flex;
     flex-direction: column;
+    gap: 2px;
     min-width: 0;
     flex: 1;
 }

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
@@ -2,7 +2,7 @@
 
 @if (Record.IsStandard)
 {
-    <Card Compact="true" CssClass="card-spaced rc-standard">
+    <Card Compact="true" CssClass="card-spaced">
     <div class="rc-card">
         <div class="rc-header-row">
             <div class="rc-category">@Record.WeightCategory</div>

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor.css
@@ -6,10 +6,6 @@
     gap: 8px;
 }
 
-.rc-standard .rc-category {
-    opacity: 0.4;
-}
-
 /* ── Header row ── */
 
 .rc-header-row {

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
@@ -5,6 +5,10 @@
 
     <div class="rhc-header-row">
         <div class="rhc-name-col">
+            @if (Entry.IsCurrent)
+            {
+                <span class="card-status card-status--active">Núverandi met</span>
+            }
             @if (Entry.IsStandard)
             {
                 <span class="rhc-standard-text">Íslenski staðallinn</span>

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
@@ -63,13 +63,9 @@
         {
             _cardCssClass = "card-spaced rhc-current";
         }
-        else if (Entry.IsStandard)
-        {
-            _cardCssClass = "card-spaced rhc-standard";
-        }
         else
         {
-            _cardCssClass = "card-spaced rhc-default";
+            _cardCssClass = "card-spaced";
         }
 
         string date = Entry.Date.ToString("dd.MM.yyyy");

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
@@ -17,6 +17,9 @@
 .rhc-name-col {
     flex: 1;
     min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
 }
 
 .rhc-name {

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor.css
@@ -68,7 +68,7 @@
 .rhc-delta {
     font-size: 13px;
     font-weight: 700;
-    color: #1a8a3c;
+    color: #15803d;
     font-variant-numeric: tabular-nums;
 }
 

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryPage.razor.css
@@ -38,7 +38,6 @@
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     margin-block-end: 1.5rem;
-    border-inline-start: 4px solid var(--color-primary);
     background: var(--color-white);
     border-radius: var(--radius-sm);
     font-size: 0.9375rem;

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -552,10 +552,10 @@ h1:focus {
 }
 
 /* Card state overrides — modifier classes applied via CssClass to Card's article */
-.sc-card-first { --card-bg: rgba(139, 26, 43, 0.06); }
-.rhc-current { --card-bg: rgba(139, 26, 43, 0.06); --rhc-text-color: var(--color-primary-dark); }
-.ap-card-dq { --card-bg: rgba(107, 114, 128, 0.08); }
-.p-card-dq { --card-bg: rgba(107, 114, 128, 0.08); }
+.sc-card-first { --card-bg: color-mix(in oklch, var(--color-primary) 6%, transparent); }
+.rhc-current { --card-bg: color-mix(in oklch, var(--color-primary) 6%, transparent); --rhc-text-color: var(--color-primary-dark); }
+.ap-card-dq { --card-bg: color-mix(in oklch, var(--color-text-muted) 8%, transparent); }
+.p-card-dq { --card-bg: color-mix(in oklch, var(--color-text-muted) 8%, transparent); }
 .card-flush { --card-padding: 0; overflow: hidden; }
 .card-half { flex: 0 0 calc(50% - 8px); min-width: 0; }
 @media (max-width: 600px) { .card-half { flex: 1 1 auto; } }
@@ -563,7 +563,7 @@ h1:focus {
 
 .meet-card { margin-block-end: 0.75rem; }
 
-.meet-card--active { --card-bg: rgba(139, 26, 43, 0.06); }
+.meet-card--active { --card-bg: color-mix(in oklch, var(--color-primary) 6%, transparent); }
 .meet-card--active .meet-card-count {
     color: var(--color-primary);
     font-weight: 600;
@@ -572,6 +572,7 @@ h1:focus {
     --card-border: 1px dashed var(--color-border);
     --card-bg: transparent;
     --card-shadow: none;
+    --card-hover-bg: transparent;
 }
 .meet-card--ghost .meet-card-title-link,
 .meet-card--ghost .meet-card-title-text { color: var(--color-text-muted); }
@@ -590,11 +591,10 @@ h1:focus {
     letter-spacing: 0.02em;
     text-transform: uppercase;
     white-space: nowrap;
-    color: var(--color-text-muted);
-    background: color-mix(in srgb, currentColor 12%, transparent);
+    color: var(--color-text);
+    background: color-mix(in oklch, currentColor 12%, transparent);
 }
 
 .card-status--active {
     color: var(--color-primary);
-    background: color-mix(in srgb, currentColor 12%, transparent);
 }

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -546,44 +546,55 @@ h1:focus {
 /* Card defaults — each Card resets its own variables so nested Cards do not inherit parent overrides */
 .card {
     --card-padding: 1.25rem 1.5rem;
-    --card-border-start: 4px solid var(--card-accent, var(--color-primary));
     --card-bg: var(--color-white);
     --card-shadow: var(--shadow-sm);
     --card-border: 1px solid var(--color-border);
-    --card-hover-transform: translateY(-4px);
-    --card-hover-shadow: var(--shadow-lg);
 }
 
 /* Card state overrides — modifier classes applied via CssClass to Card's article */
 .sc-card-first { --card-bg: rgba(139, 26, 43, 0.06); }
-.rc-standard { --card-accent: var(--color-border); }
-.rhc-default { --card-accent: transparent; }
-.rhc-current { --card-accent: var(--color-primary); --card-bg: var(--color-primary-light); --rhc-text-color: var(--color-primary-dark); }
-.rhc-standard { --card-accent: var(--color-border); opacity: 0.65; }
-.ap-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
-.p-card-dq { --card-accent: #9ca3af; opacity: 0.7; }
+.rhc-current { --card-bg: rgba(139, 26, 43, 0.06); --rhc-text-color: var(--color-primary-dark); }
+.ap-card-dq { --card-bg: rgba(107, 114, 128, 0.08); }
+.p-card-dq { --card-bg: rgba(107, 114, 128, 0.08); }
 .card-flush { --card-padding: 0; overflow: hidden; }
-.card-plain { --card-border-start: none; }
 .card-half { flex: 0 0 calc(50% - 8px); min-width: 0; }
 @media (max-width: 600px) { .card-half { flex: 1 1 auto; } }
 .card-spaced { margin-block-end: 6px; }
 
 .meet-card { margin-block-end: 0.75rem; }
 
-/* MeetCard state overrides */
-.meet-card--active { --card-bg: var(--color-primary-light); --card-accent: var(--color-primary); }
+.meet-card--active { --card-bg: rgba(139, 26, 43, 0.06); }
 .meet-card--active .meet-card-count {
     color: var(--color-primary);
     font-weight: 600;
 }
 .meet-card--ghost {
     --card-border: 1px dashed var(--color-border);
-    --card-border-start: 1px dashed var(--color-border);
     --card-bg: transparent;
     --card-shadow: none;
-    --card-accent: transparent;
-    --card-hover-transform: none;
-    --card-hover-shadow: none;
 }
 .meet-card--ghost .meet-card-title-link,
 .meet-card--ghost .meet-card-title-text { color: var(--color-text-muted); }
+
+/* Status pill — shared across card components; must be global (not scoped) */
+.card-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding-block: 0.0625rem;
+    padding-inline: 0.4375rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: var(--color-text-muted);
+    background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.card-status--active {
+    color: var(--color-primary);
+    background: color-mix(in srgb, currentColor 12%, transparent);
+}

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -573,6 +573,7 @@ h1:focus {
     --card-bg: transparent;
     --card-shadow: none;
     --card-hover-bg: transparent;
+    --card-hover-border-color: transparent;
 }
 .meet-card--ghost .meet-card-title-link,
 .meet-card--ghost .meet-card-title-text { color: var(--color-text-muted); }


### PR DESCRIPTION
## Summary

Reworks the shared card system to remove three AI-generated visual tells while keeping cards as bordered, single-shadow containers:

- Removes the default maroon `border-inline-start` accent spine.
- Removes the `translateY(-4px)` hover lift — clickable feedback is now a border-color + subtle background change (no motion).
- Collapses the graduated `--shadow-sm/md/lg` elevation ladder to a single restrained card shadow (`--shadow-md/lg` remain in `:root` for `.form-card`).

Every stateful card now conveys state via a subtle full-background tint **plus** an explicit text label (a shared `.card-status` pill) — never a colored spine, never color alone. All cues are dark-mode-safe (translucent `color-mix` tints + text labels; no whole-card `opacity` dimming), so #377 can adopt them without rework.

## Changes

- **`Card.razor.css`** — flat silhouette (no spine), single shadow, no transform; hover reads through `--card-hover-bg` / `--card-hover-border-color`; anchor overlay + `:has(:focus-visible)` outline retained; transition + reduced-motion scoped to `.card--clickable`.
- **`app.css`** — card token defaults trimmed; state modifiers repointed to `color-mix(in oklch, …)` tints; shared `.card-status` / `.card-status--active` pill; dead `--card-accent`/`--card-border-start`/`--card-hover-*` tokens and `.card-plain`/`.rc-standard`/`.rhc-standard`/`.rhc-default` rules removed.
- **Status-label markup** — `Úr leik` (DQ), `Skráning opin` (active meet), `Væntanlegt` (ghost), `Núverandi met` (current record); standard keeps "Íslenski staðallinn".
- **Spine removal** — `MeetRecordsSection.razor.css` (`.mr-card`) and `RecordHistoryPage.razor.css` (`.record-meta`).
- **A11y** — pill/label contrast ≥ WCAG AA; `rhc-delta` green fixed to pass AA.

Purely presentational — no API, data, or logic changes. `NavMenu` active-link border and typeahead highlight left untouched (conventional indicators, out of scope). Reviewed by security, code-quality, and UX gates (clean after two fix iterations).

Closes #559
