### PR TITLE
refactor(web): revise tracked-out uppercase labels and generic font pairing

### DIFF
--- a/src/KRAFT.Results.Web/Components/App.razor
+++ b/src/KRAFT.Results.Web/Components/App.razor
@@ -9,7 +9,7 @@
     <base href="/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Source+Sans+3:wght@400;600&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap" />
     <ResourcePreloader />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["KRAFT.Results.Web.styles.css"]" />

--- a/src/KRAFT.Results.Web/Components/App.razor
+++ b/src/KRAFT.Results.Web/Components/App.razor
@@ -9,7 +9,7 @@
     <base href="/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600;700&display=swap" />
     <ResourcePreloader />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["KRAFT.Results.Web.styles.css"]" />

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -10,8 +10,8 @@
     --color-success: #16a34a;
     --color-danger: #dc2626;
 
-    --font-heading: "DM Sans", system-ui, -apple-system, sans-serif;
-    --font-body: "Source Sans 3", system-ui, -apple-system, sans-serif;
+    --font-heading: "Space Grotesk", system-ui, -apple-system, sans-serif;
+    --font-body: "Inter", system-ui, -apple-system, sans-serif;
 
     --radius-sm: 0.5rem;
     --radius-md: 0.75rem;
@@ -267,10 +267,8 @@ h1:focus {
     display: block;
     font-family: var(--font-body);
     font-size: 0.8125rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--color-text-muted);
+    font-weight: 600;
+    color: var(--color-text);
     margin-block-end: 0.25rem;
 }
 
@@ -351,11 +349,10 @@ h1:focus {
 .form-section-title {
     display: block;
     font-family: var(--font-heading);
-    font-size: 0.875rem;
+    font-size: 0.9375rem;
     font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--color-text-muted);
+    letter-spacing: -0.01em;
+    color: var(--color-text);
     margin-block-end: 1rem;
     padding-block-end: 0.5rem;
     border-bottom: 1px solid var(--color-border);
@@ -523,6 +520,7 @@ h1:focus {
     font-family: var(--font-heading);
     font-size: 1.25rem;
     font-weight: 700;
+    font-feature-settings: "tnum" 1, "zero" 1;
     color: var(--color-primary);
 }
 
@@ -539,7 +537,7 @@ h1:focus {
     padding: 0.1rem 0.375rem;
     border-radius: 3px;
     background: #f3f4f6;
-    color: var(--color-text-muted);
+    color: #4b5563;
     line-height: 1.4;
 }
 

--- a/src/KRAFT.Results.Web/wwwroot/app.css
+++ b/src/KRAFT.Results.Web/wwwroot/app.css
@@ -6,6 +6,7 @@
     --color-bg: #fafafa;
     --color-text: #1a1a2e;
     --color-text-muted: #6b7280;
+    --color-text-secondary: #4b5563;
     --color-border: #e5e7eb;
     --color-success: #16a34a;
     --color-danger: #dc2626;
@@ -520,7 +521,7 @@ h1:focus {
     font-family: var(--font-heading);
     font-size: 1.25rem;
     font-weight: 700;
-    font-feature-settings: "tnum" 1, "zero" 1;
+    font-variant-numeric: tabular-nums slashed-zero;
     color: var(--color-primary);
 }
 
@@ -537,7 +538,7 @@ h1:focus {
     padding: 0.1rem 0.375rem;
     border-radius: 3px;
     background: #f3f4f6;
-    color: #4b5563;
+    color: var(--color-text-secondary);
     line-height: 1.4;
 }
 


### PR DESCRIPTION
## Summary

Revises two secondary "AI-design tells" outside the card system: the "tracked-out" uppercase micro-labels and the generic DM Sans + Source Sans 3 Google-Fonts pairing, for a less templated typographic identity grounded in the federation's brand (KRAFT — "Pure Power" — deep crimson palette, numeric/tabular results domain).

## Changes

**Typeface pairing (replaced, justified against brand):** `--font-heading` → **Space Grotesk** (mono-influenced geometric grotesque echoing the compact "KRAFT" wordmark and strength-sport register), `--font-body` → **Inter** (true tabular figures + slashed-zero — decisive for a kg/totals/points results app). `system-ui` fallback chain retained. Google Fonts link updated in `App.razor` (only the weights actually used: Space Grotesk 600/700, Inter 400/500/600/700).

**Micro-labels (de-tracked):** `.form-label` and `.form-section-title` drop `text-transform: uppercase` + `letter-spacing: 0.05em` in favour of sentence case with heavier weight (600) and darker colour (`--color-text`); `.form-section-title` keeps its bottom border and gains `-0.01em` tracking. Sentence case also reads better with Icelandic diacritics.

**Accessibility:** `.badge` text darkened `#6b7280` → `#4b5563` (new `--color-text-secondary` token), correcting a pre-existing WCAG AA failure on the grey chip (4.39:1 → 6.87:1).

**Numerics:** `.count-value` gains `font-variant-numeric: tabular-nums slashed-zero` to switch on Inter's tabular figures.

The card system (`.card`, `.form-card`, `.meet-card`, all `--card-*`) is untouched — tracked separately.

## Review
Design pass (designer), then security / code-quality / UX review gate. Three code-quality findings fixed; informational items (font SRI/CSP hardening, pre-existing 11px badge size, faux-bold 800 weights) noted as follow-up candidates. See issue comments for the full design spec and review summary.

Closes #560
