### PR TITLE
feat(webapi): only show past meets with actual results on the dashboard

### DIFF
--- a/src/KRAFT.Results.WebApi/Features/Dashboard/GetDashboard/GetDashboardHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Dashboard/GetDashboard/GetDashboardHandler.cs
@@ -26,6 +26,7 @@ internal sealed class GetDashboardHandler(ResultsDbContext dbContext)
             dbContext.Set<Meet>()
                 .Where(m => m.PublishedResults)
                 .Where(m => m.StartDate <= today)
+                .Where(m => m.Participations.Any(p => p.Attempts.Count > 0))
                 .OrderByDescending(m => m.StartDate)
                 .Take(3),
             cancellationToken);

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
@@ -17,13 +17,11 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
 {
     private const string Path = "/dashboard";
     private const string MeetsPath = "/meets";
-    private const string AthletesPath = "/athletes";
 
     private readonly HttpClient _client = fixture.Factory!.CreateClient();
     private readonly HttpClient _authorizedClient = fixture.CreateAuthorizedHttpClient();
     private readonly List<string> _meetSlugs = [];
     private readonly List<(int MeetId, int ParticipationId)> _participations = [];
-    private readonly List<string> _athleteSlugs = [];
     private string _recentMeetSlug = string.Empty;
     private string _upcomingMeetSlug = string.Empty;
     private string _attemptlessMeetSlug = string.Empty;
@@ -128,11 +126,6 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
         foreach (string slug in _meetSlugs)
         {
             await _authorizedClient.DeleteAsync($"{MeetsPath}/{slug}", CancellationToken.None);
-        }
-
-        foreach (string slug in _athleteSlugs)
-        {
-            await _authorizedClient.DeleteAsync($"{AthletesPath}/{slug}", CancellationToken.None);
         }
 
         _client.Dispose();
@@ -286,6 +279,9 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
         recentMeets.ShouldContain(m => m.Slug == slug3);
         recentMeets.ShouldContain(m => m.Slug == slug2);
         recentMeets.ShouldNotContain(m => m.Slug == slug1);
+        recentMeets
+            .Select(m => m.StartDate)
+            .ShouldBeInOrder(SortDirection.Descending);
     }
 
     private async Task<string> CreateMeetSlugAsync(DateOnly startDate)

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using KRAFT.Results.Contracts;
 using KRAFT.Results.Contracts.Dashboard;
 using KRAFT.Results.Contracts.Meets;
+using KRAFT.Results.WebApi.Features.Records.ComputeRecords;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
@@ -16,17 +17,25 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
 {
     private const string Path = "/dashboard";
     private const string MeetsPath = "/meets";
+    private const string AthletesPath = "/athletes";
 
     private readonly HttpClient _client = fixture.Factory!.CreateClient();
     private readonly HttpClient _authorizedClient = fixture.CreateAuthorizedHttpClient();
+    private readonly List<string> _meetSlugs = [];
+    private readonly List<(int MeetId, int ParticipationId)> _participations = [];
+    private readonly List<string> _athleteSlugs = [];
     private string _recentMeetSlug = string.Empty;
     private string _upcomingMeetSlug = string.Empty;
     private string _attemptlessMeetSlug = string.Empty;
     private int _recentMeetId;
     private int _recentParticipationId;
+    private HttpClient _recordClient = null!;
+    private RecordComputationChannel _channel = null!;
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
+        (_recordClient, _channel) = fixture.CreateAuthorizedHttpClientWithRecordComputation();
+
         CreateMeetCommand recentCommand = new CreateMeetCommandBuilder()
             .WithStartDate(new DateOnly(2020, 1, 1))
             .WithMeetTypeId(1)
@@ -55,11 +64,12 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
         RecordAttemptCommand recordAttemptCommand = new RecordAttemptCommandBuilder()
             .WithWeight(100.0m)
             .Build();
-        HttpResponseMessage attemptResponse = await _authorizedClient.PutAsJsonAsync(
+        HttpResponseMessage attemptResponse = await _recordClient.PutAsJsonAsync(
             $"{MeetsPath}/{_recentMeetId}/participants/{_recentParticipationId}/attempts/{(int)Discipline.Squat}/1",
             recordAttemptCommand,
             CancellationToken.None);
         attemptResponse.EnsureSuccessStatusCode();
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
 
         CreateMeetCommand attemptlessCommand = new CreateMeetCommandBuilder()
             .WithStartDate(new DateOnly(2020, 2, 1))
@@ -94,6 +104,12 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
                 $"{MeetsPath}/{_recentMeetId}/participants/{_recentParticipationId}", CancellationToken.None);
         }
 
+        foreach ((int meetId, int participationId) in _participations)
+        {
+            await _authorizedClient.DeleteAsync(
+                $"{MeetsPath}/{meetId}/participants/{participationId}", CancellationToken.None);
+        }
+
         if (!string.IsNullOrEmpty(_recentMeetSlug))
         {
             await _authorizedClient.DeleteAsync($"{MeetsPath}/{_recentMeetSlug}", CancellationToken.None);
@@ -109,8 +125,19 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
             await _authorizedClient.DeleteAsync($"{MeetsPath}/{_upcomingMeetSlug}", CancellationToken.None);
         }
 
+        foreach (string slug in _meetSlugs)
+        {
+            await _authorizedClient.DeleteAsync($"{MeetsPath}/{slug}", CancellationToken.None);
+        }
+
+        foreach (string slug in _athleteSlugs)
+        {
+            await _authorizedClient.DeleteAsync($"{AthletesPath}/{slug}", CancellationToken.None);
+        }
+
         _client.Dispose();
         _authorizedClient.Dispose();
+        _recordClient.Dispose();
     }
 
     [Fact]
@@ -204,5 +231,114 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
             () => meet.Discipline.ShouldBe(KRAFT.Results.Contracts.Constants.Powerlifting),
             () => meet.IsClassic.ShouldBeTrue(),
             () => meet.ParticipantCount.ShouldBe(0));
+    }
+
+    [Fact]
+    public async Task WhenAllAttemptsAreNoGood_MeetStillAppearsInRecentMeets()
+    {
+        // Arrange
+        string meetSlug = await CreateMeetSlugAsync(new DateOnly(2021, 3, 1));
+        int meetId = await GetMeetIdAsync(meetSlug);
+        int participationId = await AddParticipantAsync(meetId);
+        _participations.Add((meetId, participationId));
+
+        RecordAttemptCommand noGoodAttempt = new RecordAttemptCommandBuilder()
+            .WithWeight(100.0m)
+            .WithGood(false)
+            .Build();
+
+        HttpResponseMessage attemptResponse = await _recordClient.PutAsJsonAsync(
+            $"{MeetsPath}/{meetId}/participants/{participationId}/attempts/{(int)Discipline.Squat}/1",
+            noGoodAttempt,
+            CancellationToken.None);
+        attemptResponse.EnsureSuccessStatusCode();
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        DashboardSummary? result = await _client.GetFromJsonAsync<DashboardSummary>(Path, CancellationToken.None);
+
+        // Assert
+        DashboardSummary dashboard = result.ShouldNotBeNull();
+        dashboard.RecentMeets.ShouldContain(m => m.Slug == meetSlug);
+    }
+
+    [Fact]
+    public async Task WhenMoreThanThreeQualifyingMeetsExist_ReturnsThreeMostRecentByStartDate()
+    {
+        // Arrange — seed 4 past meets with distinct StartDates, all with attempts, all PublishedResults
+        string slug1 = await CreateMeetSlugAsync(new DateOnly(2022, 1, 1));
+        string slug2 = await CreateMeetSlugAsync(new DateOnly(2022, 4, 1));
+        string slug3 = await CreateMeetSlugAsync(new DateOnly(2022, 7, 1));
+        string slug4 = await CreateMeetSlugAsync(new DateOnly(2022, 10, 1));
+
+        await RecordOneAttemptAsync(await GetMeetIdAsync(slug1));
+        await RecordOneAttemptAsync(await GetMeetIdAsync(slug2));
+        await RecordOneAttemptAsync(await GetMeetIdAsync(slug3));
+        await RecordOneAttemptAsync(await GetMeetIdAsync(slug4));
+
+        // Act
+        DashboardSummary? result = await _client.GetFromJsonAsync<DashboardSummary>(Path, CancellationToken.None);
+
+        // Assert — the 3 newest slugs appear; the oldest (slug1) does not
+        DashboardSummary dashboard = result.ShouldNotBeNull();
+        IReadOnlyList<MeetSummary> recentMeets = dashboard.RecentMeets;
+        recentMeets.ShouldContain(m => m.Slug == slug4);
+        recentMeets.ShouldContain(m => m.Slug == slug3);
+        recentMeets.ShouldContain(m => m.Slug == slug2);
+        recentMeets.ShouldNotContain(m => m.Slug == slug1);
+    }
+
+    private async Task<string> CreateMeetSlugAsync(DateOnly startDate)
+    {
+        CreateMeetCommand command = new CreateMeetCommandBuilder()
+            .WithStartDate(startDate)
+            .WithMeetTypeId(1)
+            .WithIsRaw(true)
+            .WithPublishedResults(true)
+            .WithPublishedInCalendar(false)
+            .Build();
+
+        HttpResponseMessage response = await _authorizedClient.PostAsJsonAsync(MeetsPath, command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        string slug = response.Headers.Location!.ToString().TrimStart('/');
+        _meetSlugs.Add(slug);
+        return slug;
+    }
+
+    private async Task<int> GetMeetIdAsync(string meetSlug)
+    {
+        MeetDetails? meetDetails = await _authorizedClient.GetFromJsonAsync<MeetDetails>(
+            $"{MeetsPath}/{meetSlug}", CancellationToken.None);
+        return meetDetails!.MeetId;
+    }
+
+    private async Task<int> AddParticipantAsync(int meetId)
+    {
+        AddParticipantCommand command = new AddParticipantCommandBuilder().Build();
+        HttpResponseMessage response = await _authorizedClient.PostAsJsonAsync(
+            $"{MeetsPath}/{meetId}/participants", command, CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? result = await response.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+        return result!.ParticipationId;
+    }
+
+    private async Task RecordOneAttemptAsync(int meetId)
+    {
+        int participationId = await AddParticipantAsync(meetId);
+        _participations.Add((meetId, participationId));
+
+        RecordAttemptCommand command = new RecordAttemptCommandBuilder()
+            .WithWeight(100.0m)
+            .Build();
+
+        HttpResponseMessage response = await _recordClient.PutAsJsonAsync(
+            $"{MeetsPath}/{meetId}/participants/{participationId}/attempts/{(int)Discipline.Squat}/1",
+            command,
+            CancellationToken.None);
+        response.EnsureSuccessStatusCode();
+        await _channel.WaitUntilDrainedAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Dashboard/GetDashboardTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 
+using KRAFT.Results.Contracts;
 using KRAFT.Results.Contracts.Dashboard;
 using KRAFT.Results.Contracts.Meets;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
@@ -20,6 +21,9 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
     private readonly HttpClient _authorizedClient = fixture.CreateAuthorizedHttpClient();
     private string _recentMeetSlug = string.Empty;
     private string _upcomingMeetSlug = string.Empty;
+    private string _attemptlessMeetSlug = string.Empty;
+    private int _recentMeetId;
+    private int _recentParticipationId;
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
@@ -34,6 +38,40 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
         HttpResponseMessage recentResponse = await _authorizedClient.PostAsJsonAsync(MeetsPath, recentCommand, CancellationToken.None);
         recentResponse.EnsureSuccessStatusCode();
         _recentMeetSlug = recentResponse.Headers.Location!.ToString().TrimStart('/');
+
+        MeetDetails? meetDetails = await _authorizedClient.GetFromJsonAsync<MeetDetails>(
+            $"{MeetsPath}/{_recentMeetSlug}", CancellationToken.None);
+        _recentMeetId = meetDetails!.MeetId;
+
+        AddParticipantCommand addParticipantCommand = new AddParticipantCommandBuilder().Build();
+        HttpResponseMessage participantResponse = await _authorizedClient.PostAsJsonAsync(
+            $"{MeetsPath}/{_recentMeetId}/participants", addParticipantCommand, CancellationToken.None);
+        participantResponse.EnsureSuccessStatusCode();
+
+        AddParticipantResponse? participantResult = await participantResponse.Content
+            .ReadFromJsonAsync<AddParticipantResponse>(CancellationToken.None);
+        _recentParticipationId = participantResult!.ParticipationId;
+
+        RecordAttemptCommand recordAttemptCommand = new RecordAttemptCommandBuilder()
+            .WithWeight(100.0m)
+            .Build();
+        HttpResponseMessage attemptResponse = await _authorizedClient.PutAsJsonAsync(
+            $"{MeetsPath}/{_recentMeetId}/participants/{_recentParticipationId}/attempts/{(int)Discipline.Squat}/1",
+            recordAttemptCommand,
+            CancellationToken.None);
+        attemptResponse.EnsureSuccessStatusCode();
+
+        CreateMeetCommand attemptlessCommand = new CreateMeetCommandBuilder()
+            .WithStartDate(new DateOnly(2020, 2, 1))
+            .WithMeetTypeId(1)
+            .WithIsRaw(true)
+            .WithPublishedResults(true)
+            .WithPublishedInCalendar(false)
+            .Build();
+
+        HttpResponseMessage attemptlessResponse = await _authorizedClient.PostAsJsonAsync(MeetsPath, attemptlessCommand, CancellationToken.None);
+        attemptlessResponse.EnsureSuccessStatusCode();
+        _attemptlessMeetSlug = attemptlessResponse.Headers.Location!.ToString().TrimStart('/');
 
         CreateMeetCommand upcomingCommand = new CreateMeetCommandBuilder()
             .WithStartDate(new DateOnly(2099, 6, 1))
@@ -50,9 +88,20 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
+        if (_recentParticipationId > 0)
+        {
+            await _authorizedClient.DeleteAsync(
+                $"{MeetsPath}/{_recentMeetId}/participants/{_recentParticipationId}", CancellationToken.None);
+        }
+
         if (!string.IsNullOrEmpty(_recentMeetSlug))
         {
             await _authorizedClient.DeleteAsync($"{MeetsPath}/{_recentMeetSlug}", CancellationToken.None);
+        }
+
+        if (!string.IsNullOrEmpty(_attemptlessMeetSlug))
+        {
+            await _authorizedClient.DeleteAsync($"{MeetsPath}/{_attemptlessMeetSlug}", CancellationToken.None);
         }
 
         if (!string.IsNullOrEmpty(_upcomingMeetSlug))
@@ -125,7 +174,20 @@ public sealed class GetDashboardTests(CollectionFixture fixture) : IAsyncLifetim
         meet.ShouldSatisfyAllConditions(
             () => meet.Discipline.ShouldBe(KRAFT.Results.Contracts.Constants.Powerlifting),
             () => meet.IsClassic.ShouldBeTrue(),
-            () => meet.ParticipantCount.ShouldBe(0));
+            () => meet.ParticipantCount.ShouldBe(1));
+    }
+
+    [Fact]
+    public async Task WhenRecentMeetHasNoAttempts_ExcludedFromRecentMeets()
+    {
+        // Arrange
+
+        // Act
+        DashboardSummary? result = await _client.GetFromJsonAsync<DashboardSummary>(Path, CancellationToken.None);
+
+        // Assert
+        DashboardSummary dashboard = result.ShouldNotBeNull();
+        dashboard.RecentMeets.ShouldNotContain(m => m.Slug == _attemptlessMeetSlug);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The dashboard's "Síðustu mót" (RecentMeets) list previously gated only on the manual `PublishedResults` flag plus `StartDate`, so past meets with zero recorded attempts occupied the 3 slots as non-clickable ghost cards and could crowd out older meets that have real results. This filters the recent-meets query to meets that actually have recorded attempts.

## Change

`GetDashboardHandler` — one added clause on the recent-meets query, between the `PublishedResults`/`StartDate` filters and `Take(3)`:

```csharp
.Where(m => m.Participations.Any(p => p.Attempts.Count > 0))
```

(`Count > 0` rather than the literal `.Any()` from the issue, to satisfy the CA1860 analyzer under warnings-as-errors — identical SQL.)

Applies uniformly to all users including admins; no DTO/contract change. `/meets` index (`GetMeetsHandler`) is deliberately left untouched — attempt-less meets still list there.

## Acceptance criteria

- [x] Past meet with `PublishedResults = true` but no attempts → excluded from `RecentMeets` for any user
- [x] Past meet with ≥1 participation having ≥1 attempt (incl. all-bomb-out `Total == 0`) → eligible
- [x] More than 3 qualifying meets → 3 most recent by `StartDate` returned
- [x] `/meets` index unchanged
- [x] `RecentMeet_ReturnsDisciplineIsClassicAndParticipantCount` updated to seed attempts; new test excludes an attempt-less past meet

## Tests

Integration tests updated/added in `GetDashboardTests`: existing recent-meet test now seeds an attempt (with drain); new tests cover exclusion of attempt-less meets, all-bomb-out inclusion (AC2), and the 3-most-recent ordering with descending `StartDate` assertion (AC3).

`dotnet build` passes with 0 warnings (warnings-as-errors). The suite requires Docker (Testcontainers SQL Server) to execute, which was unavailable in the implementation environment — CI runs it.

Closes #569
