### PR TITLE
fix(web.client): always render EntityStatCard value red in span variant

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/Cards/EntityStatCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/Cards/EntityStatCard.razor.css
@@ -162,11 +162,11 @@ a.esc-leading--badge::before {
 ::deep a.esc-value {
     font-size: 1.125rem;
     white-space: nowrap;
+    color: var(--color-primary);
 }
 
 ::deep a.esc-value {
     position: relative;
-    color: var(--color-primary);
     text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
`EntityStatCard`'s numeric value rendered red only in the anchor (link) variant. The span variant (no `ValueHref`) had no color rule and fell through to the global `.stat-value` → near-black `var(--color-text)`. The value should always be red regardless of variant.

## Change
- Moved `color: var(--color-primary)` from the anchor-only `::deep a.esc-value` rule into the shared `::deep span.esc-value, ::deep a.esc-value` rule in `EntityStatCard.razor.css`, so both variants render red.
- Hover darkening (`var(--color-primary-dark)`) stays anchor-only — unchanged.
- No markup, component-parameter, or `app.css` changes; the dashboard season stat tiles remain text-colored.

## Acceptance criteria
- [x] `StandingsCard` / `RecordHistoryCard` span-variant values render `var(--color-primary)` red
- [x] Linked values (`DashboardRecordCard`, `RecordCard`, `RankingCard`) remain red at rest and darken on hover
- [x] Dashboard season stat tiles (`stat-number stat-value`) stay `var(--color-text)`
- [x] Units (`.stat-unit`) stay muted gray in either variant

## Testing
CSS-only change; build passes with 0 warnings/0 errors. No test updates required — existing bUnit tests assert tag names and classes (unchanged); bUnit cannot assert computed styles.

Closes #578