### PR TITLE
feat(web.client): unify UI date and number formatting to Icelandic conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,18 @@ Use tracked lists (`_participations`, `_meetSlugs`, `_athleteSlugs`) populated d
 
 `GetRecordsTests.cs` is the canonical example of a fully migrated test — use it as the pattern for all remaining migrations.
 
+## Formatting
+
+All UI date/number formatting routes through the `DisplayFormat` static helper in `Web.Client` root — never use inline `InvariantCulture` or ad-hoc format strings at render sites.
+
+- **Lifted weights** (attempts, records, totals) — one decimal, comma separator, no thousands grouping (`220,5`).
+- **Bodyweight and IPF points** — two decimals, comma separator (`82,50`).
+- **Full dates** — `dd.MM.yyyy` (`15.03.2024`); contextual month variants (`MMM yyyy`, `MMMM`) use explicit is-IS culture for Icelandic month names.
+- **Numeric inputs** — accept both `,` and `.` via `DisplayFormat.TryParseWeight`; display always renders the comma form.
+- **Machine-readable attributes** (`datetime="yyyy-MM-dd"`, date-input `max`) stay ISO 8601 — do not route these through `DisplayFormat`.
+- **Culture pinning** — both hosts pin is-IS: `Web/Program.cs` and `Web.Client/Program.cs` set `CultureInfo.DefaultThreadCurrentCulture` and `CultureInfo.DefaultThreadCurrentUICulture` to `new CultureInfo("is-IS")`. bUnit tests pin is-IS via `TestCulture.cs`.
+- **Deliberate deviation from results.kraft.is** — the live site (source of truth for *values*) renders two decimals for all weights (`125,00`) and hyphenated dates (`01-02-2025`). We intentionally deviate in *presentation only*: one decimal for lifted weights and `dd.MM.yyyy` dates. Values still match the live site. Do not revert this.
+
 ## Code Style
 
 Key `.editorconfig` rules (warnings are errors in build):

--- a/src/KRAFT.Results.Web.Client/Components/AttemptPill.razor
+++ b/src/KRAFT.Results.Web.Client/Components/AttemptPill.razor
@@ -1,4 +1,5 @@
 @using KRAFT.Results.Contracts.Meets
+@using KRAFT.Results.Web.Client
 
 @if (OnClick.HasDelegate)
 {
@@ -50,7 +51,7 @@ else
             return;
         }
 
-        _value = $"{Attempt.Weight:F1}";
+        _value = DisplayFormat.Weight(Attempt.Weight);
 
         if (Attempt.IsGood && Attempt.IsRecord)
         {

--- a/src/KRAFT.Results.Web.Client/Components/BodyWeight.razor
+++ b/src/KRAFT.Results.Web.Client/Components/BodyWeight.razor
@@ -4,7 +4,7 @@
     </div>
 
     <div class="side right">
-        @($"{Value:F2}")
+        @DisplayFormat.BodyWeight(Value)
     </div>
 </div>
 

--- a/src/KRAFT.Results.Web.Client/Components/Cards/MeetCard.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Cards/MeetCard.razor
@@ -7,7 +7,7 @@
 <Card Clickable="@_isLinked" CssClass="@_cardClasses">
     <div class="meet-card-header">
         <time class="meet-card-date" datetime="@Meet.StartDate.ToString("yyyy-MM-dd")">
-            @Meet.StartDate.ToString("dd. MMM yyyy", new System.Globalization.CultureInfo("is-IS"))
+            @DisplayFormat.MeetCardDate(Meet.StartDate)
         </time>
         <div class="meet-card-pills">
             <span class="pill pill-discipline">@Meet.Discipline</span>

--- a/src/KRAFT.Results.Web.Client/Components/Cards/MeetCard.razor
+++ b/src/KRAFT.Results.Web.Client/Components/Cards/MeetCard.razor
@@ -7,7 +7,7 @@
 <Card Clickable="@_isLinked" CssClass="@_cardClasses">
     <div class="meet-card-header">
         <time class="meet-card-date" datetime="@Meet.StartDate.ToString("yyyy-MM-dd")">
-            @Meet.StartDate.ToString("dd. MMM yyyy")
+            @Meet.StartDate.ToString("dd. MMM yyyy", new System.Globalization.CultureInfo("is-IS"))
         </time>
         <div class="meet-card-pills">
             <span class="pill pill-discipline">@Meet.Discipline</span>

--- a/src/KRAFT.Results.Web.Client/Components/WeightCell.razor
+++ b/src/KRAFT.Results.Web.Client/Components/WeightCell.razor
@@ -1,6 +1,4 @@
-﻿@using System.Text
-
-<td class="@Border">
+﻿<td class="@Border">
     <div class="@Classes">
         @Value
     </div>
@@ -10,9 +8,6 @@
     [Parameter]
     [EditorRequired]
     public decimal? Weight { get; set; }
-
-    [Parameter]
-    public int SignificantDigits { get; init; } = 1;
 
     public string Border { get; set; } = string.Empty;
 
@@ -28,10 +23,7 @@
             return;
         }
 
-        Value = Weight?.ToString($"F{SignificantDigits}") ?? "-";
-
-        StringBuilder stringBuilder = new("rounded-box ");
-
-        Classes = stringBuilder.ToString();
+        Value = DisplayFormat.Weight(Weight.Value);
+        Classes = "rounded-box ";
     }
 }

--- a/src/KRAFT.Results.Web.Client/DisplayFormat.cs
+++ b/src/KRAFT.Results.Web.Client/DisplayFormat.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+
+namespace KRAFT.Results.Web.Client;
+
+public static class DisplayFormat
+{
+    private static readonly CultureInfo IcelandicCulture = new("is-IS");
+
+    public static string Weight(decimal value) =>
+        value.ToString("0.0", IcelandicCulture);
+
+    public static string BodyWeight(decimal value) =>
+        value.ToString("0.00", IcelandicCulture);
+
+    public static string Points(decimal value) =>
+        value.ToString("0.00", IcelandicCulture);
+
+    public static string Date(DateOnly value) =>
+        value.ToString("dd.MM.yyyy", IcelandicCulture);
+
+    public static string Date(DateTime value) =>
+        value.ToString("dd.MM.yyyy", IcelandicCulture);
+
+    public static bool TryParseWeight(string? input, out decimal value)
+    {
+        value = 0m;
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        string trimmed = input.Trim();
+
+        int commaCount = 0;
+        int dotCount = 0;
+
+        foreach (char c in trimmed)
+        {
+            if (c == ',')
+            {
+                commaCount++;
+            }
+            else if (c == '.')
+            {
+                dotCount++;
+            }
+        }
+
+        // Reject ambiguous strings with multiple separators (e.g. "1.500,5" — thousands + decimal)
+        if (commaCount + dotCount > 1)
+        {
+            return false;
+        }
+
+        // Normalize a lone dot to comma so is-IS parses it as decimal
+        string normalized = dotCount == 1 && commaCount == 0
+            ? trimmed.Replace('.', ',')
+            : trimmed;
+
+        return decimal.TryParse(
+            normalized,
+            NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign,
+            IcelandicCulture,
+            out value);
+    }
+}

--- a/src/KRAFT.Results.Web.Client/DisplayFormat.cs
+++ b/src/KRAFT.Results.Web.Client/DisplayFormat.cs
@@ -24,6 +24,19 @@ public static class DisplayFormat
     public static string MonthYear(DateOnly value) =>
         value.ToString("MMM yyyy", IcelandicCulture);
 
+    public static string MeetCardDate(DateOnly value) =>
+        value.ToString("dd. MMM yyyy", IcelandicCulture);
+
+    public static string MonthName(DateOnly value) =>
+        value.ToString("MMMM", IcelandicCulture);
+
+    /// <summary>
+    /// Attempts to parse a weight value from user input.
+    /// Accepts both comma (<c>,</c>) and dot (<c>.</c>) as the decimal separator.
+    /// Accepts a leading sign (negative values represent failed lift attempts).
+    /// Rejects input containing more than one separator, null, whitespace, or non-numeric text.
+    /// Returns <see langword="false"/> and sets <paramref name="value"/> to zero on failure.
+    /// </summary>
     public static bool TryParseWeight(string? input, out decimal value)
     {
         value = 0m;

--- a/src/KRAFT.Results.Web.Client/DisplayFormat.cs
+++ b/src/KRAFT.Results.Web.Client/DisplayFormat.cs
@@ -21,6 +21,9 @@ public static class DisplayFormat
     public static string Date(DateTime value) =>
         value.ToString("dd.MM.yyyy", IcelandicCulture);
 
+    public static string MonthYear(DateOnly value) =>
+        value.ToString("MMM yyyy", IcelandicCulture);
+
     public static bool TryParseWeight(string? input, out decimal value)
     {
         value = 0m;

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/Components/AthleteParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/Components/AthleteParticipationCard.razor
@@ -22,28 +22,28 @@
             {
                 <div class="ap-lift-pill">
                     <span class="ap-lift-label">@Constants.Squat</span>
-                    <span class="ap-lift-val">@(Participation.Squat > 0 ? Participation.Squat.ToString("F1") : "\u2013")</span>
+                    <span class="ap-lift-val">@(Participation.Squat > 0 ? DisplayFormat.Weight(Participation.Squat) : "\u2013")</span>
                 </div>
             }
             @if (MeetType == Constants.Powerlifting || MeetType.StartsWith(Constants.Bench, StringComparison.Ordinal))
             {
                 <div class="ap-lift-pill">
                     <span class="ap-lift-label">@Constants.Bench</span>
-                    <span class="ap-lift-val">@(Participation.Benchpress > 0 ? Participation.Benchpress.ToString("F1") : "\u2013")</span>
+                    <span class="ap-lift-val">@(Participation.Benchpress > 0 ? DisplayFormat.Weight(Participation.Benchpress) : "\u2013")</span>
                 </div>
             }
             @if (MeetType == Constants.Powerlifting || MeetType.StartsWith(Constants.Deadlift, StringComparison.Ordinal))
             {
                 <div class="ap-lift-pill">
                     <span class="ap-lift-label">@Constants.Deadlift</span>
-                    <span class="ap-lift-val">@(Participation.Deadlift > 0 ? Participation.Deadlift.ToString("F1") : "\u2013")</span>
+                    <span class="ap-lift-val">@(Participation.Deadlift > 0 ? DisplayFormat.Weight(Participation.Deadlift) : "\u2013")</span>
                 </div>
             }
             @if (MeetType == Constants.Powerlifting)
             {
                 <div class="ap-lift-pill ap-lift-total">
                     <span class="ap-lift-label">@Constants.Total</span>
-                    <span class="ap-lift-val">@(Participation.Total > 0 ? Participation.Total.ToString("F1") : "\u2013")</span>
+                    <span class="ap-lift-val">@(Participation.Total > 0 ? DisplayFormat.Weight(Participation.Total) : "\u2013")</span>
                 </div>
             }
         </div>
@@ -88,14 +88,14 @@
 
         List<string> metaParts =
         [
-            Participation.Date.ToString("dd.MM.yyyy"),
+            DisplayFormat.Date(Participation.Date),
             Participation.WeightCategory,
-            $"{Participation.BodyWeight:F1} kg",
+            $"{DisplayFormat.BodyWeight(Participation.BodyWeight)} kg",
         ];
 
         if (ShowIpfPoints && Participation.IpfPoints.HasValue && Participation.IpfPoints.Value > 0)
         {
-            metaParts.Add($"IPF {Participation.IpfPoints.Value:F2}");
+            metaParts.Add($"IPF {DisplayFormat.Points(Participation.IpfPoints.Value)}");
         }
 
         _metaLine = string.Join(" \u00b7 ", metaParts);

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/Components/AthletePersonalBestCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/Components/AthletePersonalBestCard.razor
@@ -1,4 +1,3 @@
-@using System.Globalization
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Athletes
 @using KRAFT.Results.Web.Client.Components.Cards
@@ -6,7 +5,7 @@
 <EntityStatCard Name="@_name"
                 Pills="@_pills"
                 MetaText="@_metaText"
-                Value="@Best.Weight.ToString("F1", CultureInfo.InvariantCulture)"
+                Value="@DisplayFormat.Weight(Best.Weight)"
                 Unit="kg"
                 ValueHref="@SlugSanitizer.SlugHref("/meets/", Best.MeetSlug)"
                 ValueAriaLabel="@_valueAriaLabel"
@@ -28,7 +27,7 @@
             ? "Samanlagt"
             : Best.Discipline.ToDisplayName();
 
-        _metaText = $"{Best.Date.ToString("dd.MM.yyyy")} · {Best.BodyWeight.ToString("F1", CultureInfo.InvariantCulture)} kg";
+        _metaText = $"{DisplayFormat.Date(Best.Date)} · {DisplayFormat.BodyWeight(Best.BodyWeight)} kg";
 
         _pills = [];
 
@@ -51,7 +50,7 @@
             ? " — " + string.Join(", ", Best.Matches.Select(BuildMatchLine))
             : string.Empty;
 
-        _valueAriaLabel = $"{_name} — {Best.Weight.ToString("F1", CultureInfo.InvariantCulture)} kg{recordSuffix}";
+        _valueAriaLabel = $"{_name} — {DisplayFormat.Weight(Best.Weight)} kg{recordSuffix}";
 
         _cssClass = Best.Discipline == Discipline.None
             ? "card-spaced esc-total"

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/Components/AthleteRecordCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/Components/AthleteRecordCard.razor
@@ -1,4 +1,3 @@
-@using System.Globalization
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Athletes
 @using KRAFT.Results.Web.Client.Components.Cards
@@ -6,11 +5,11 @@
 <EntityStatCard Leading="@CardLeading.Badge(Record.WeightCategory)"
                 Name="@Record.Type"
                 Pills="@_pills"
-                MetaText="@Record.Date.ToString("dd.MM.yyyy")"
-                Value="@Record.Weight.ToString("F1", CultureInfo.InvariantCulture)"
+                MetaText="@DisplayFormat.Date(Record.Date)"
+                Value="@DisplayFormat.Weight(Record.Weight)"
                 Unit="kg"
                 ValueHref="@SlugSanitizer.SlugHref("/meets/", Record.MeetSlug)"
-                ValueAriaLabel="@($"{Record.Type} — {Record.Weight.ToString("F1", CultureInfo.InvariantCulture)} kg — {Record.Meet}")"
+                ValueAriaLabel="@($"{Record.Type} — {DisplayFormat.Weight(Record.Weight)} kg — {Record.Meet}")"
                 CssClass="card-spaced" />
 
 @code {

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardRecordCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardRecordCard.razor
@@ -6,10 +6,10 @@
                 NameHref="@SlugSanitizer.SlugHref("/athletes/", Record.AthleteSlug)"
                 Pills="@_pills"
                 Label="@Record.Lift"
-                Value="@Record.Weight.ToString()"
+                Value="@DisplayFormat.Weight(Record.Weight)"
                 Unit="kg"
                 ValueHref="@SlugSanitizer.SlugHref("/meets/", Record.MeetSlug)"
-                ValueAriaLabel="@($"{Record.AthleteName} — {Record.Lift} — {Record.Weight} kg")"
+                ValueAriaLabel="@($"{Record.AthleteName} — {Record.Lift} — {DisplayFormat.Weight(Record.Weight)} kg")"
                 MetaText="@DisplayFormat.MonthYear(Record.MeetDate)"
                 CssClass="card-spaced" />
 

--- a/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardRecordCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Dashboard/DashboardRecordCard.razor
@@ -1,4 +1,3 @@
-@using System.Globalization
 @using KRAFT.Results.Contracts
 @using KRAFT.Results.Contracts.Dashboard
 @using KRAFT.Results.Web.Client.Components.Cards
@@ -11,7 +10,7 @@
                 Unit="kg"
                 ValueHref="@SlugSanitizer.SlugHref("/meets/", Record.MeetSlug)"
                 ValueAriaLabel="@($"{Record.AthleteName} — {Record.Lift} — {Record.Weight} kg")"
-                MetaText="@Record.MeetDate.ToString("MMM yyyy", CultureInfo.CurrentCulture)"
+                MetaText="@DisplayFormat.MonthYear(Record.MeetDate)"
                 CssClass="card-spaced" />
 
 @code {

--- a/src/KRAFT.Results.Web.Client/Features/Meets/AddParticipantForm.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/AddParticipantForm.razor
@@ -2,7 +2,6 @@
 @using KRAFT.Results.Contracts.Athletes
 @using KRAFT.Results.Contracts.Meets
 @using KRAFT.Results.Contracts.Teams
-@using System.Globalization
 
 @inject HttpClient HttpClient
 
@@ -222,7 +221,7 @@
 
     private bool IsFormValid =>
         !string.IsNullOrEmpty(_selectedAthleteSlug)
-        && decimal.TryParse(_bodyWeightText, System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out decimal _bw)
+        && DisplayFormat.TryParseWeight(_bodyWeightText, out decimal _bw)
         && _bw > 0;
 
     private string SubmitHint
@@ -236,7 +235,7 @@
                 missing.Add("veldu keppanda");
             }
 
-            if (!decimal.TryParse(_bodyWeightText, System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out decimal _bwHint) || _bwHint <= 0)
+            if (!DisplayFormat.TryParseWeight(_bodyWeightText, out decimal _bwHint) || _bwHint <= 0)
             {
                 missing.Add("sláðu inn þyngd");
             }
@@ -496,7 +495,7 @@
 
         try
         {
-            decimal.TryParse(_bodyWeightText, System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out decimal parsedBodyWeight);
+            DisplayFormat.TryParseWeight(_bodyWeightText, out decimal parsedBodyWeight);
             AddParticipantCommand command = new(_selectedAthleteSlug, parsedBodyWeight, _selectedTeamId, _selectedAgeCategorySlug.Length > 0 ? _selectedAgeCategorySlug : null);
             HttpResponseMessage response = await HttpClient.PostAsJsonAsync(
                 $"/meets/{MeetId}/participants", command);
@@ -543,7 +542,7 @@
                 continue;
             }
 
-            if (!decimal.TryParse(entry.Value, CultureInfo.CurrentCulture, out decimal weight) || weight == 0)
+            if (!DisplayFormat.TryParseWeight(entry.Value, out decimal weight) || weight == 0)
             {
                 continue;
             }

--- a/src/KRAFT.Results.Web.Client/Features/Meets/AddParticipantForm.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/AddParticipantForm.razor
@@ -495,7 +495,11 @@
 
         try
         {
-            DisplayFormat.TryParseWeight(_bodyWeightText, out decimal parsedBodyWeight);
+            if (!DisplayFormat.TryParseWeight(_bodyWeightText, out decimal parsedBodyWeight) || parsedBodyWeight <= 0)
+            {
+                return;
+            }
+
             AddParticipantCommand command = new(_selectedAthleteSlug, parsedBodyWeight, _selectedTeamId, _selectedAgeCategorySlug.Length > 0 ? _selectedAgeCategorySlug : null);
             HttpResponseMessage response = await HttpClient.PostAsJsonAsync(
                 $"/meets/{MeetId}/participants", command);

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -58,10 +58,10 @@
             </AuthorizeView>
         </div>
         <p>
-            @($"{Meet?.StartDate:dd-MM-yyyy}")
+            @(Meet is not null ? DisplayFormat.Date(Meet.StartDate) : string.Empty)
             @if (Meet?.EndDate is DateOnly endDate && endDate != Meet?.StartDate)
             {
-                <span> - @($"{endDate:dd-MM-yyyy}")</span>
+                <span> - @DisplayFormat.Date(endDate)</span>
             }
             <br />
             @Meet?.Location<br />
@@ -110,10 +110,10 @@
                                             <div class="leader-info">
                                                 <NavLink class="leader-name" href="@($"/athletes/{leader.Participation.AthleteSlug}")">@leader.Participation.Athlete</NavLink>
                                                 <span class="leader-meta">
-                                                    @leader.Participation.YearOfBirth@(!string.IsNullOrWhiteSpace(leader.Participation.Club) ? $" · {leader.Participation.Club}" : string.Empty) · @($"{leader.Participation.BodyWeight:F2}") kg
+                                                    @leader.Participation.YearOfBirth@(!string.IsNullOrWhiteSpace(leader.Participation.Club) ? $" · {leader.Participation.Club}" : string.Empty) · @DisplayFormat.BodyWeight(leader.Participation.BodyWeight) kg
                                                 </span>
                                             </div>
-                                            <span class="leader-pts">@($"{leader.Participation.IpfPoints:F2}")</span>
+                                            <span class="leader-pts">@DisplayFormat.Points(leader.Participation.IpfPoints)</span>
                                         </div>
                                     }
                                 </div>

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
@@ -14,7 +14,7 @@
 <DataLoader @key="Year" T="IReadOnlyCollection<MeetSummary>" Loader="LoadAsync" Noun="mót">
     <ChildContent Context="meets">
         <div class="content-column">
-            @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => x.StartDate.ToString("MMMM", new System.Globalization.CultureInfo("is-IS"))))
+            @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => DisplayFormat.MonthName(x.StartDate)))
             {
                 <h4>@($"{char.ToUpper(group.Key[0])}{group.Key[1..]}")</h4>
                 @foreach (MeetSummary meet in group)

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetIndex.razor
@@ -1,6 +1,5 @@
 @page "/meets/{year:int?}"
 
-@using System.Globalization
 @using KRAFT.Results.Contracts.Meets
 @using KRAFT.Results.Web.Client.Components
 
@@ -15,7 +14,7 @@
 <DataLoader @key="Year" T="IReadOnlyCollection<MeetSummary>" Loader="LoadAsync" Noun="mót">
     <ChildContent Context="meets">
         <div class="content-column">
-            @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => x.StartDate.ToString("MMMM", CultureInfo.CurrentCulture)))
+            @foreach (IGrouping<string, MeetSummary> group in meets.GroupBy(x => x.StartDate.ToString("MMMM", new System.Globalization.CultureInfo("is-IS"))))
             {
                 <h4>@($"{char.ToUpper(group.Key[0])}{group.Key[1..]}")</h4>
                 @foreach (MeetSummary meet in group)

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetRecordsSection.razor
@@ -1,4 +1,3 @@
-@using System.Globalization
 @using KRAFT.Results.Contracts.Meets
 
 <section class="mr-section content-column">
@@ -11,14 +10,14 @@
                 {
                     <a class="mr-row"
                        href="@($"/athletes/{record.AthleteSlug}")"
-                       aria-label="@($"{record.WeightCategory} — {record.Discipline} — {record.AthleteName} — {record.Weight.ToString("F1", CultureInfo.InvariantCulture)} kg")">
+                       aria-label="@($"{record.WeightCategory} — {record.Discipline} — {record.AthleteName} — {DisplayFormat.Weight(record.Weight)} kg")">
                         <span class="mr-cat">@record.WeightCategory</span>
                         <div class="mr-info">
                             <span class="mr-type">@record.Discipline</span>
                             <span class="mr-meta">@record.AgeCategory</span>
                         </div>
                         <span class="mr-name">@record.AthleteName</span>
-                        <span class="mr-weight">@record.Weight.ToString("F1", CultureInfo.InvariantCulture) <span class="mr-unit">kg</span></span>
+                        <span class="mr-weight">@DisplayFormat.Weight(record.Weight) <span class="mr-unit">kg</span></span>
                     </a>
                 }
             </div>

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
@@ -150,7 +150,7 @@
             <span class="p-footer-label">Samtala</span>
             @if (!Participation.Disqualified && DisplayTotal > 0)
             {
-                @($"{DisplayTotal:F1}")
+                @DisplayFormat.Weight(DisplayTotal)
             }
             else if (!Participation.Disqualified)
             {
@@ -163,7 +163,7 @@
                 <span class="p-footer-label">IPF stig</span>
                 @if (!Participation.Disqualified && DisplayIpfPoints > 0)
                 {
-                    @($"{DisplayIpfPoints:F2}")
+                    @DisplayFormat.Points(DisplayIpfPoints)
                 }
             </div>
         }
@@ -284,7 +284,7 @@
     {
         decimal bodyWeight = _freshParticipation?.BodyWeight ?? Participation.BodyWeight;
         List<string> metaParts = [Participation.YearOfBirth.ToString()];
-        metaParts.Add($"{bodyWeight:F2} kg");
+        metaParts.Add($"{DisplayFormat.BodyWeight(bodyWeight)} kg");
         _metaLine = string.Join(" · ", metaParts);
     }
 

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
@@ -2,7 +2,6 @@
 @using KRAFT.Results.Contracts.Meets
 @using KRAFT.Results.Web.Client.Components
 @using Microsoft.AspNetCore.Components.Authorization
-@using System.Globalization
 
 @inject HttpClient HttpClient
 @inject IJSRuntime JS
@@ -408,8 +407,8 @@
 
         if (attempt is not null && attempt.Weight > 0)
         {
-            decimal signedWeight = attempt.IsGood ? attempt.Weight : -attempt.Weight;
-            _editValues[(discipline, round)] = signedWeight.ToString("F1", CultureInfo.CurrentCulture);
+            string sign = attempt.IsGood ? string.Empty : "-";
+            _editValues[(discipline, round)] = sign + DisplayFormat.Weight(attempt.Weight);
         }
         else
         {
@@ -433,7 +432,7 @@
             return;
         }
 
-        if (!decimal.TryParse(value, CultureInfo.CurrentCulture, out decimal weight) || weight == 0)
+        if (!DisplayFormat.TryParseWeight(value, out decimal weight) || weight == 0)
         {
             _attemptErrors[(discipline, round)] = "Ógilt gildi";
             return;

--- a/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Rankings/RankingCard.razor
@@ -22,11 +22,11 @@
 
     protected override void OnParametersSet()
     {
-        _pills = [new MetaPill(PillKind.Neutral, $"{Entry.BodyWeight:F2} kg")];
+        _pills = [new MetaPill(PillKind.Neutral, $"{DisplayFormat.BodyWeight(Entry.BodyWeight)} kg")];
 
         if (Entry.IpfPoints.HasValue)
         {
-            string formatted = Entry.IpfPoints.Value.ToString("F2");
+            string formatted = DisplayFormat.Points(Entry.IpfPoints.Value);
             _value = formatted;
             _valueHref = SlugSanitizer.SlugHref("/meets/", Entry.MeetSlug);
             _valueAriaLabel = $"{formatted} IPF stig, opna mót";

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordCard.razor
@@ -54,17 +54,17 @@
 
             if (Record.BodyWeight.HasValue)
             {
-                pills.Add(new MetaPill(PillKind.Neutral, $"{Record.BodyWeight.Value:F1} kg"));
+                pills.Add(new MetaPill(PillKind.Neutral, $"{DisplayFormat.BodyWeight(Record.BodyWeight.Value)} kg"));
             }
 
             _pills = pills;
-            _metaText = Record.Date.ToString("dd.MM.yyyy");
+            _metaText = DisplayFormat.Date(Record.Date);
             _valueHref = Record.MeetSlug is not null
                 ? SlugSanitizer.SlugHref("/meets/", Record.MeetSlug)
                 : null;
         }
 
-        _value = Record.Weight.ToString("F1");
+        _value = DisplayFormat.Weight(Record.Weight);
 
         _valueAriaLabel = _valueHref is not null
             ? $"{_value} kg, opna mót"

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
@@ -22,7 +22,7 @@
 
     protected override void OnParametersSet()
     {
-        _value = Entry.Weight.ToString("F1");
+        _value = DisplayFormat.Weight(Entry.Weight);
         _cssClass = Entry.IsCurrent ? "card-spaced rhc-current" : "card-spaced";
 
         if (Entry.IsStandard)
@@ -42,7 +42,7 @@
             List<MetaPill> pills = [];
             if (Entry.BodyWeight.HasValue)
             {
-                pills.Add(new MetaPill(PillKind.Neutral, $"{Entry.BodyWeight.Value:F1} kg"));
+                pills.Add(new MetaPill(PillKind.Neutral, $"{DisplayFormat.BodyWeight(Entry.BodyWeight.Value)} kg"));
             }
 
             _pills = pills;
@@ -70,7 +70,7 @@
 
         @if (Entry.Delta.HasValue)
         {
-            <span class="rhc-delta">▲ +@Entry.Delta.Value.ToString("F1")</span>
+            <span class="rhc-delta">▲ +@DisplayFormat.Weight(Entry.Delta.Value)</span>
         }
     };
 
@@ -85,7 +85,7 @@
 
         @if (Entry.Delta.HasValue)
         {
-            <span class="rhc-delta">▲ +@Entry.Delta.Value.ToString("F1")</span>
+            <span class="rhc-delta">▲ +@DisplayFormat.Weight(Entry.Delta.Value)</span>
         }
     };
 }

--- a/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Records/RecordHistoryCard.razor
@@ -57,7 +57,7 @@
             <span class="card-status card-status--active">Núverandi met</span>
         }
 
-        <span>@Entry.Date.ToString("dd.MM.yyyy")</span>
+        <span>@DisplayFormat.Date(Entry.Date)</span>
 
         @if (Entry.MeetSlug is not null && Entry.Meet is not null)
         {
@@ -81,7 +81,7 @@
             <span class="card-status card-status--active">Núverandi met</span>
         }
 
-        <span>@Entry.Date.ToString("dd.MM.yyyy")</span>
+        <span>@DisplayFormat.Date(Entry.Date)</span>
 
         @if (Entry.Delta.HasValue)
         {

--- a/src/KRAFT.Results.Web/Components/App.razor
+++ b/src/KRAFT.Results.Web/Components/App.razor
@@ -1,7 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="is">
 
 <head>
     <meta charset="utf-8" />

--- a/src/KRAFT.Results.Web/Program.cs
+++ b/src/KRAFT.Results.Web/Program.cs
@@ -1,8 +1,13 @@
+using System.Globalization;
+
 using KRAFT.Results.Web;
 using KRAFT.Results.Web.Client.Features.Auth;
 using KRAFT.Results.Web.Components;
 
 using Microsoft.AspNetCore.Authorization;
+
+CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("is-IS");
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("is-IS");
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/MeetCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/MeetCardTests.cs
@@ -19,6 +19,27 @@ public sealed class MeetCardTests : IDisposable
     }
 
     [Fact]
+    public void WhenRendered_DateTextUsesIcelandicMonthAbbreviation()
+    {
+        // Arrange
+        MeetSummary meet = new(
+            Slug: "test-meet",
+            Title: "Test Meet",
+            Location: "Reykjavík",
+            StartDate: new DateOnly(2024, 3, 15),
+            Discipline: "Kraftlyftingar",
+            IsClassic: true,
+            ParticipantCount: 0);
+
+        // Act
+        IRenderedComponent<MeetCard> cut = _context.Render<MeetCard>(
+            p => p.Add(c => c.Meet, meet));
+
+        // Assert
+        cut.Find(".meet-card-date").TextContent.Trim().ShouldBe("15. mar. 2024");
+    }
+
+    [Fact]
     public void RendersArticleWithMeetCardClass_WhenPastMeet()
     {
         // Arrange

--- a/tests/KRAFT.Results.Web.Client.Tests/DisplayFormatTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/DisplayFormatTests.cs
@@ -1,0 +1,122 @@
+using KRAFT.Results.Web.Client;
+
+using Shouldly;
+
+namespace KRAFT.Results.Web.Client.Tests;
+
+public sealed class DisplayFormatTests
+{
+    [Theory]
+    [InlineData(220.5, "220,5")]
+    [InlineData(200.0, "200,0")]
+    [InlineData(1057.5, "1057,5")]
+    public void Weight_WhenCalled_FormatsWithOneDecimalAndCommaNoThousandsSeparator(
+        double input,
+        string expected)
+    {
+        // Arrange
+        decimal value = (decimal)input;
+
+        // Act
+        string result = DisplayFormat.Weight(value);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(82.5, "82,50")]
+    [InlineData(82.0, "82,00")]
+    public void BodyWeight_WhenCalled_FormatsWithTwoDecimalsAndComma(double input, string expected)
+    {
+        // Arrange
+        decimal value = (decimal)input;
+
+        // Act
+        string result = DisplayFormat.BodyWeight(value);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(512.3, "512,30")]
+    [InlineData(100.0, "100,00")]
+    public void Points_WhenCalled_FormatsWithTwoDecimalsAndComma(double input, string expected)
+    {
+        // Arrange
+        decimal value = (decimal)input;
+
+        // Act
+        string result = DisplayFormat.Points(value);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Date_WithDateOnly_FormatsAsDdMmYyyy()
+    {
+        // Arrange
+        DateOnly date = new(2024, 3, 15);
+
+        // Act
+        string result = DisplayFormat.Date(date);
+
+        // Assert
+        result.ShouldBe("15.03.2024");
+    }
+
+    [Fact]
+    public void Date_WithDateTime_FormatsAsDdMmYyyy()
+    {
+        // Arrange
+        DateTime date = new(2024, 3, 15, 10, 30, 0, DateTimeKind.Utc);
+
+        // Act
+        string result = DisplayFormat.Date(date);
+
+        // Assert
+        result.ShouldBe("15.03.2024");
+    }
+
+    [Theory]
+    [InlineData("147,5", true, 147.5)]
+    [InlineData("147.5", true, 147.5)]
+    [InlineData("1057,5", true, 1057.5)]
+    [InlineData("200", true, 200.0)]
+    public void TryParseWeight_WhenValidInput_ReturnsTrueAndParsedValue(
+        string input,
+        bool expectedSuccess,
+        double expectedValue)
+    {
+        // Arrange
+        // (input supplied by theory)
+
+        // Act
+        bool success = DisplayFormat.TryParseWeight(input, out decimal parsed);
+
+        // Assert
+        success.ShouldBe(expectedSuccess);
+        parsed.ShouldBe((decimal)expectedValue);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("1.500,5")]
+    public void TryParseWeight_WhenInvalidInput_ReturnsFalse(string? input)
+    {
+        // Arrange
+        // (input supplied by theory)
+
+        // Act
+        bool success = DisplayFormat.TryParseWeight(input, out decimal parsed);
+
+        // Assert
+        success.ShouldBeFalse();
+        parsed.ShouldBe(0m);
+    }
+}

--- a/tests/KRAFT.Results.Web.Client.Tests/DisplayFormatTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/DisplayFormatTests.cs
@@ -10,7 +10,7 @@ public sealed class DisplayFormatTests
     [InlineData(220.5, "220,5")]
     [InlineData(200.0, "200,0")]
     [InlineData(1057.5, "1057,5")]
-    public void Weight_WhenCalled_FormatsWithOneDecimalAndCommaNoThousandsSeparator(
+    public void WhenWeightFormatted_UsesOneDecimalWithCommaAndNoThousandsSeparator(
         double input,
         string expected)
     {
@@ -27,7 +27,7 @@ public sealed class DisplayFormatTests
     [Theory]
     [InlineData(82.5, "82,50")]
     [InlineData(82.0, "82,00")]
-    public void BodyWeight_WhenCalled_FormatsWithTwoDecimalsAndComma(double input, string expected)
+    public void WhenBodyWeightFormatted_UsesTwoDecimalsWithComma(double input, string expected)
     {
         // Arrange
         decimal value = (decimal)input;
@@ -42,7 +42,7 @@ public sealed class DisplayFormatTests
     [Theory]
     [InlineData(512.3, "512,30")]
     [InlineData(100.0, "100,00")]
-    public void Points_WhenCalled_FormatsWithTwoDecimalsAndComma(double input, string expected)
+    public void WhenPointsFormatted_UsesTwoDecimalsWithComma(double input, string expected)
     {
         // Arrange
         decimal value = (decimal)input;
@@ -55,7 +55,7 @@ public sealed class DisplayFormatTests
     }
 
     [Fact]
-    public void Date_WithDateOnly_FormatsAsDdMmYyyy()
+    public void WhenDateOnlyFormatted_UsesIcelandicDotSeparatedDate()
     {
         // Arrange
         DateOnly date = new(2024, 3, 15);
@@ -68,7 +68,7 @@ public sealed class DisplayFormatTests
     }
 
     [Fact]
-    public void Date_WithDateTime_FormatsAsDdMmYyyy()
+    public void WhenDateTimeFormatted_UsesIcelandicDotSeparatedDate()
     {
         // Arrange
         DateTime date = new(2024, 3, 15, 10, 30, 0, DateTimeKind.Utc);
@@ -81,7 +81,7 @@ public sealed class DisplayFormatTests
     }
 
     [Fact]
-    public void MonthYear_FormatsAsMmmYyyyWithIcelandicAbbreviation()
+    public void WhenMonthYearFormatted_UsesIcelandicAbbreviatedMonthName()
     {
         // Arrange
         DateOnly date = new(2024, 3, 15);
@@ -93,12 +93,41 @@ public sealed class DisplayFormatTests
         result.ShouldBe("mar. 2024");
     }
 
+    [Fact]
+    public void WhenMeetCardDateFormatted_UsesIcelandicAbbreviatedMonthWithSpaces()
+    {
+        // Arrange
+        DateOnly date = new(2024, 1, 15);
+
+        // Act
+        string result = DisplayFormat.MeetCardDate(date);
+
+        // Assert
+        result.ShouldBe("15. jan. 2024");
+    }
+
+    [Fact]
+    public void WhenMonthNameFormatted_UsesIcelandicFullMonthName()
+    {
+        // Arrange
+        DateOnly date = new(2024, 1, 15);
+
+        // Act
+        string result = DisplayFormat.MonthName(date);
+
+        // Assert
+        result.ShouldBe("janúar");
+    }
+
     [Theory]
     [InlineData("147,5", true, 147.5)]
     [InlineData("147.5", true, 147.5)]
     [InlineData("1057,5", true, 1057.5)]
     [InlineData("200", true, 200.0)]
-    public void TryParseWeight_WhenValidInput_ReturnsTrueAndParsedValue(
+    [InlineData("-147,5", true, -147.5)]
+    [InlineData("-147.5", true, -147.5)]
+    [InlineData(".5", true, 0.5)]
+    public void WhenInputIsValid_TryParseWeightReturnsTrueAndParsedValue(
         string input,
         bool expectedSuccess,
         double expectedValue)
@@ -120,7 +149,7 @@ public sealed class DisplayFormatTests
     [InlineData("   ")]
     [InlineData("abc")]
     [InlineData("1.500,5")]
-    public void TryParseWeight_WhenInvalidInput_ReturnsFalse(string? input)
+    public void WhenInputIsInvalid_TryParseWeightReturnsFalse(string? input)
     {
         // Arrange
         // (input supplied by theory)

--- a/tests/KRAFT.Results.Web.Client.Tests/DisplayFormatTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/DisplayFormatTests.cs
@@ -80,6 +80,19 @@ public sealed class DisplayFormatTests
         result.ShouldBe("15.03.2024");
     }
 
+    [Fact]
+    public void MonthYear_FormatsAsMmmYyyyWithIcelandicAbbreviation()
+    {
+        // Arrange
+        DateOnly date = new(2024, 3, 15);
+
+        // Act
+        string result = DisplayFormat.MonthYear(date);
+
+        // Assert
+        result.ShouldBe("mar. 2024");
+    }
+
     [Theory]
     [InlineData("147,5", true, 147.5)]
     [InlineData("147.5", true, 147.5)]

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteParticipationCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteParticipationCardTests.cs
@@ -71,6 +71,59 @@ public sealed class AthleteParticipationCardTests : IDisposable
     }
 
     [Fact]
+    public void WhenRendered_MetaLineFormatsBodyWeightAsTwoDecimals()
+    {
+        // Arrange & Act
+        IRenderedComponent<AthleteParticipationCard> cut = _context.Render<AthleteParticipationCard>(
+            p => p.Add(c => c.Participation, MakeParticipation())
+                  .Add(c => c.MeetType, Constants.Powerlifting)
+                  .Add(c => c.ShowIpfPoints, false));
+
+        // Assert
+        cut.Find(".ap-meta").TextContent.ShouldContain("82,50 kg");
+    }
+
+    [Fact]
+    public void WhenRendered_MetaLineFormatsDateAsIcelandic()
+    {
+        // Arrange & Act
+        IRenderedComponent<AthleteParticipationCard> cut = _context.Render<AthleteParticipationCard>(
+            p => p.Add(c => c.Participation, MakeParticipation())
+                  .Add(c => c.MeetType, Constants.Powerlifting)
+                  .Add(c => c.ShowIpfPoints, false));
+
+        // Assert
+        cut.Find(".ap-meta").TextContent.ShouldContain("15.03.2024");
+    }
+
+    [Fact]
+    public void WhenShowIpfPoints_MetaLineFormatsPointsAsTwoDecimals()
+    {
+        // Arrange & Act
+        IRenderedComponent<AthleteParticipationCard> cut = _context.Render<AthleteParticipationCard>(
+            p => p.Add(c => c.Participation, MakeParticipation(ipfPoints: 412.34m))
+                  .Add(c => c.MeetType, Constants.Powerlifting)
+                  .Add(c => c.ShowIpfPoints, true));
+
+        // Assert
+        cut.Find(".ap-meta").TextContent.ShouldContain("412,34");
+    }
+
+    [Fact]
+    public void WhenShowWeights_FormatsWeightWithOneDecimalAndComma()
+    {
+        // Arrange & Act
+        IRenderedComponent<AthleteParticipationCard> cut = _context.Render<AthleteParticipationCard>(
+            p => p.Add(c => c.Participation, MakeParticipation(squat: 245.0m))
+                  .Add(c => c.MeetType, Constants.Powerlifting)
+                  .Add(c => c.ShowIpfPoints, false));
+
+        // Assert
+        IReadOnlyList<AngleSharp.Dom.IElement> values = cut.FindAll(".ap-lift-val");
+        values[0].TextContent.ShouldBe("245,0");
+    }
+
+    [Fact]
     public void ShowsOneBenchPill_ForBenchMeet()
     {
         // Arrange

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletePersonalBestCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthletePersonalBestCardTests.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-
 using Bunit;
 
 using KRAFT.Results.Contracts;
@@ -58,7 +56,7 @@ public sealed class AthletePersonalBestCardTests : IDisposable
             parameters => parameters.Add(p => p.Best, best));
 
         // Assert
-        cut.Find(".esc-meta").TextContent.Trim().ShouldBe("15.03.2024 · 82.5 kg");
+        cut.Find(".esc-meta").TextContent.Trim().ShouldBe("15.03.2024 · 82,50 kg");
     }
 
     [Fact]
@@ -75,7 +73,7 @@ public sealed class AthletePersonalBestCardTests : IDisposable
         // Assert
         AngleSharp.Dom.IElement valueLink = cut.Find("a.esc-value");
         valueLink.GetAttribute("href").ShouldBe("/meets/islandsmot-2024");
-        valueLink.TextContent.Trim().ShouldContain("250.5");
+        valueLink.TextContent.Trim().ShouldContain("250,5");
         cut.Find(".esc-unit").TextContent.Trim().ShouldBe("kg");
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteRecordCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteRecordCardTests.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-
 using Bunit;
 
 using KRAFT.Results.Contracts;
@@ -97,13 +95,13 @@ public sealed class AthleteRecordCardTests : IDisposable
         // Assert
         AngleSharp.Dom.IElement valueLink = cut.Find("a.esc-value");
         valueLink.GetAttribute("href").ShouldBe("/meets/islandsmot-2024");
-        valueLink.GetAttribute("aria-label").ShouldBe($"{Constants.Squat} — 250.5 kg — Íslandsmót 2024");
-        valueLink.TextContent.Trim().ShouldContain("250.5");
+        valueLink.GetAttribute("aria-label").ShouldBe($"{Constants.Squat} — 250,5 kg — Íslandsmót 2024");
+        valueLink.TextContent.Trim().ShouldContain("250,5");
         cut.Find(".esc-unit").TextContent.Trim().ShouldBe("kg");
     }
 
     [Fact]
-    public void WhenRendered_WeightFormatsWithF1InvariantCulture()
+    public void WhenRendered_WeightFormatsWithF1IcelandicCulture()
     {
         // Arrange
         AthleteRecord record = BuildRecord(weight: 200m);
@@ -115,7 +113,7 @@ public sealed class AthleteRecordCardTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement valueLink = cut.Find("a.esc-value");
-        valueLink.TextContent.Trim().ShouldContain(200m.ToString("F1", CultureInfo.InvariantCulture));
+        valueLink.TextContent.Trim().ShouldContain("200,0");
     }
 
     [Fact]

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Dashboard/DashboardRecordCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Dashboard/DashboardRecordCardTests.cs
@@ -44,8 +44,8 @@ public sealed class DashboardRecordCardTests : IDisposable
         // Assert
         AngleSharp.Dom.IElement valueLink = cut.Find("a.esc-value");
         valueLink.GetAttribute("href").ShouldBe("/meets/kraftlyftingar-2024");
-        valueLink.GetAttribute("aria-label").ShouldBe("Jón Jónsson — Hnéböð — 250 kg");
-        valueLink.TextContent.Trim().ShouldContain("250");
+        valueLink.GetAttribute("aria-label").ShouldBe("Jón Jónsson — Hnéböð — 250,0 kg");
+        valueLink.TextContent.Trim().ShouldContain("250,0");
         cut.Find(".esc-unit").TextContent.Trim().ShouldBe("kg");
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Dashboard/DashboardRecordCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Dashboard/DashboardRecordCardTests.cs
@@ -23,8 +23,7 @@ public sealed class DashboardRecordCardTests : IDisposable
             parameters => parameters.Add(p => p.Record, record));
 
         // Assert
-        string expectedDate = new DateOnly(2024, 3, 15).ToString("MMM yyyy", System.Globalization.CultureInfo.CurrentCulture);
-        cut.Find(".esc-meta").TextContent.Trim().ShouldBe(expectedDate);
+        cut.Find(".esc-meta").TextContent.Trim().ShouldBe("mar. 2024");
     }
 
     [Fact]

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/MeetIndexTests.cs
@@ -50,6 +50,27 @@ public sealed class MeetIndexTests : IDisposable
     }
 
     [Fact]
+    public void WhenMeetsInMarch_GroupHeaderUsesIcelandicMonthName()
+    {
+        // Arrange
+        List<MeetSummary> meets =
+        [
+            new("nationals-2024", "Nationals 2024", "Reykjavik", new DateOnly(2024, 3, 15), "Kraftlyftingar", false, 0),
+        ];
+        RegisterHttpClient(meets);
+
+        // Act
+        IRenderedComponent<MeetIndex> cut = _context.Render<MeetIndex>(
+            parameters => parameters.Add(p => p.Year, 2024));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("h4").TextContent.Trim().ShouldBe("Mars");
+        });
+    }
+
+    [Fact]
     public void ShowsMeetCards_WhenMeetsAreLoaded()
     {
         // Arrange

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
@@ -86,6 +86,84 @@ public sealed class ParticipationCardTests : IDisposable
         inputAgain.GetAttribute("value").ShouldBe("210,0");
     }
 
+    [Fact]
+    public async Task ExistingAttempt_WhenFirstEdited_InputPreFillsWithCommaDecimal()
+    {
+        // Arrange — participation with one existing squat attempt at 147,5 kg
+        MeetParticipation participation = MakeParticipation(
+            [new MeetAttempt(Discipline.Squat, 1, 147.5m, true, false)]);
+
+        IRenderedComponent<ParticipationCard> cut = _context.Render<ParticipationCard>(
+            p => p.Add(c => c.Participation, participation)
+                  .Add(c => c.ShowIpfPoints, false)
+                  .Add(c => c.ShowClub, false)
+                  .Add(c => c.IncludedDisciplines, new Dictionary<Discipline, bool> { [Discipline.Squat] = true })
+                  .Add(c => c.DesktopGridTemplate, "auto")
+                  .Add(c => c.IsAdmin, true));
+
+        // Act — click the pill to enter edit mode for the first time
+        AngleSharp.Dom.IElement pillButton = cut.Find("button.pill-clickable");
+        await cut.InvokeAsync(() => pillButton.Click());
+
+        // Assert — input pre-fills with Icelandic comma decimal, not a dot
+        AngleSharp.Dom.IElement input = cut.Find("input.inline-attempt-input");
+        input.GetAttribute("value").ShouldBe("147,5");
+    }
+
+    [Fact]
+    public async Task AttemptInput_WhenUserTypesDot_ParsesAndSavesCorrectly()
+    {
+        // Arrange — participation with no existing attempts
+        MeetParticipation participation = MakeParticipation([]);
+
+        IRenderedComponent<ParticipationCard> cut = _context.Render<ParticipationCard>(
+            p => p.Add(c => c.Participation, participation)
+                  .Add(c => c.ShowIpfPoints, false)
+                  .Add(c => c.ShowClub, false)
+                  .Add(c => c.IncludedDisciplines, new Dictionary<Discipline, bool> { [Discipline.Squat] = true })
+                  .Add(c => c.DesktopGridTemplate, "auto")
+                  .Add(c => c.IsAdmin, true));
+
+        // Act — click an empty pill, type using dot decimal separator, then blur to save
+        AngleSharp.Dom.IElement pillButton = cut.Find("button.pill-clickable");
+        await cut.InvokeAsync(() => pillButton.Click());
+
+        AngleSharp.Dom.IElement input = cut.Find("input.inline-attempt-input");
+        await cut.InvokeAsync(() => input.Input("147.5"));
+        await cut.InvokeAsync(() => input.Blur());
+
+        // Assert — pill shows the comma form (no attempt-error visible)
+        cut.FindAll(".attempt-error").Count.ShouldBe(0);
+        cut.Find(".pill").TextContent.Trim().ShouldBe("147,5");
+    }
+
+    [Fact]
+    public async Task AttemptInput_WhenUserTypesComma_ParsesAndSavesCorrectly()
+    {
+        // Arrange — participation with no existing attempts
+        MeetParticipation participation = MakeParticipation([]);
+
+        IRenderedComponent<ParticipationCard> cut = _context.Render<ParticipationCard>(
+            p => p.Add(c => c.Participation, participation)
+                  .Add(c => c.ShowIpfPoints, false)
+                  .Add(c => c.ShowClub, false)
+                  .Add(c => c.IncludedDisciplines, new Dictionary<Discipline, bool> { [Discipline.Squat] = true })
+                  .Add(c => c.DesktopGridTemplate, "auto")
+                  .Add(c => c.IsAdmin, true));
+
+        // Act — click an empty pill, type using comma decimal separator, then blur to save
+        AngleSharp.Dom.IElement pillButton = cut.Find("button.pill-clickable");
+        await cut.InvokeAsync(() => pillButton.Click());
+
+        AngleSharp.Dom.IElement input = cut.Find("input.inline-attempt-input");
+        await cut.InvokeAsync(() => input.Input("147,5"));
+        await cut.InvokeAsync(() => input.Blur());
+
+        // Assert — pill shows the comma form (no attempt-error visible)
+        cut.FindAll(".attempt-error").Count.ShouldBe(0);
+        cut.Find(".pill").TextContent.Trim().ShouldBe("147,5");
+    }
+
     public void Dispose()
     {
         _context.Dispose();

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
@@ -111,6 +111,30 @@ public sealed class ParticipationCardTests : IDisposable
     }
 
     [Fact]
+    public async Task WhenFailedAttemptIsEdited_InputPreFillsWithNegativeCommaForm()
+    {
+        // Arrange — participation with a failed squat attempt at 147.5 kg (IsGood = false)
+        MeetParticipation participation = MakeParticipation(
+            [new MeetAttempt(Discipline.Squat, 1, 147.5m, false, false)]);
+
+        IRenderedComponent<ParticipationCard> cut = _context.Render<ParticipationCard>(
+            p => p.Add(c => c.Participation, participation)
+                  .Add(c => c.ShowIpfPoints, false)
+                  .Add(c => c.ShowClub, false)
+                  .Add(c => c.IncludedDisciplines, new Dictionary<Discipline, bool> { [Discipline.Squat] = true })
+                  .Add(c => c.DesktopGridTemplate, "auto")
+                  .Add(c => c.IsAdmin, true));
+
+        // Act — click the pill to enter edit mode for the first time
+        AngleSharp.Dom.IElement pillButton = cut.Find("button.pill-clickable");
+        await cut.InvokeAsync(() => pillButton.Click());
+
+        // Assert — input pre-fills with Icelandic negative comma decimal
+        AngleSharp.Dom.IElement input = cut.Find("input.inline-attempt-input");
+        input.GetAttribute("value").ShouldBe("-147,5");
+    }
+
+    [Fact]
     public async Task AttemptInput_WhenUserTypesDot_ParsesAndSavesCorrectly()
     {
         // Arrange — participation with no existing attempts

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
@@ -50,9 +50,8 @@ public sealed class ParticipationCardTests : IDisposable
         await cut.InvokeAsync(() => input.Input("210"));
         await cut.InvokeAsync(() => input.Blur());
 
-        // Assert — pill shows the new value, not the original 200.0
-        string expected = 210m.ToString("F1", System.Globalization.CultureInfo.CurrentCulture);
-        cut.Find(".pill").TextContent.Trim().ShouldBe(expected);
+        // Assert — pill shows the new value, not the original 200,0
+        cut.Find(".pill").TextContent.Trim().ShouldBe("210,0");
     }
 
     [Fact]
@@ -83,9 +82,8 @@ public sealed class ParticipationCardTests : IDisposable
         await cut.InvokeAsync(() => pillButtonAgain.Click());
 
         // Assert — input pre-fills with 210, not the original 200
-        string expected = 210m.ToString("F1", System.Globalization.CultureInfo.CurrentCulture);
         AngleSharp.Dom.IElement inputAgain = cut.Find("input.inline-attempt-input");
-        inputAgain.GetAttribute("value").ShouldBe(expected);
+        inputAgain.GetAttribute("value").ShouldBe("210,0");
     }
 
     public void Dispose()

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Rankings/RankingsIndexTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Rankings/RankingsIndexTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
 
@@ -90,11 +89,9 @@ public sealed class RankingsIndexTests : IDisposable
     public void WhenRendered_AthleteLinkAndPillsAppear()
     {
         // Arrange
-        decimal bodyWeight = 91.5m;
-        string formattedBodyWeight = bodyWeight.ToString("F2", CultureInfo.CurrentCulture);
         PagedResponse<RankingEntry> response = MakeResponse(items:
         [
-            new(3, "Gunnar Gunnarsson", "gunnar-gunnarsson", bodyWeight, 450.25m, "spring-2024"),
+            new(3, "Gunnar Gunnarsson", "gunnar-gunnarsson", 91.5m, 450.25m, "spring-2024"),
         ]);
         RegisterHttpClient(response);
 
@@ -110,7 +107,7 @@ public sealed class RankingsIndexTests : IDisposable
 
             IReadOnlyList<IElement> pills = cut.FindAll(".esc-pill");
             pills.Count.ShouldBe(1);
-            pills[0].TextContent.ShouldContain($"{formattedBodyWeight} kg");
+            pills[0].TextContent.ShouldContain("91,50 kg");
         });
     }
 
@@ -118,11 +115,9 @@ public sealed class RankingsIndexTests : IDisposable
     public void WhenIpfPointsHasValue_ValueRendersAsLinkToMeetWithAriaLabel()
     {
         // Arrange
-        decimal ipfPoints = 450.25m;
-        string formatted = ipfPoints.ToString("F2", CultureInfo.CurrentCulture);
         PagedResponse<RankingEntry> response = MakeResponse(items:
         [
-            new(1, "Gunnar Gunnarsson", "gunnar-gunnarsson", 91.5m, ipfPoints, "spring-2024"),
+            new(1, "Gunnar Gunnarsson", "gunnar-gunnarsson", 91.5m, 450.25m, "spring-2024"),
         ]);
         RegisterHttpClient(response);
 
@@ -134,8 +129,8 @@ public sealed class RankingsIndexTests : IDisposable
         {
             IElement valueLink = cut.Find("a.esc-value");
             valueLink.GetAttribute("href").ShouldBe("/meets/spring-2024");
-            valueLink.GetAttribute("aria-label").ShouldBe($"{formatted} IPF stig, opna mót");
-            valueLink.TextContent.Trim().ShouldBe(formatted);
+            valueLink.GetAttribute("aria-label").ShouldBe("450,25 IPF stig, opna mót");
+            valueLink.TextContent.Trim().ShouldBe("450,25");
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordCardTests.cs
@@ -134,7 +134,7 @@ public sealed class RecordCardTests : IDisposable
             parameters => parameters.Add(p => p.Record, entry));
 
         // Assert
-        cut.Find("a.esc-value").GetAttribute("aria-label").ShouldBe("120.0 kg, opna mót");
+        cut.Find("a.esc-value").GetAttribute("aria-label").ShouldBe("120,0 kg, opna mót");
     }
 
     [Fact]
@@ -187,7 +187,7 @@ public sealed class RecordCardTests : IDisposable
         System.Collections.Generic.IReadOnlyList<AngleSharp.Dom.IElement> pills = cut.FindAll(".esc-pill");
         pills.Count.ShouldBe(2);
         pills[0].TextContent.ShouldBe("1990");
-        pills[1].TextContent.ShouldBe("82.5 kg");
+        pills[1].TextContent.ShouldBe("82,50 kg");
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public sealed class RecordCardTests : IDisposable
         // Assert
         AngleSharp.Dom.IElement valueLink = cut.Find("a.esc-value");
         valueLink.GetAttribute("href").ShouldBe("/meets/nationals-2024");
-        valueLink.TextContent.Trim().ShouldBe("220.5kg");
+        valueLink.TextContent.Trim().ShouldBe("220,5kg");
     }
 
     [Fact]
@@ -311,7 +311,7 @@ public sealed class RecordCardTests : IDisposable
 
         // Assert
         cut.FindAll("a.esc-value").Count.ShouldBe(0);
-        cut.Find("span.esc-value").TextContent.Trim().ShouldBe("200.0kg");
+        cut.Find("span.esc-value").TextContent.Trim().ShouldBe("200,0kg");
     }
 
     [Fact]
@@ -337,7 +337,7 @@ public sealed class RecordCardTests : IDisposable
         // Assert
         System.Collections.Generic.IReadOnlyList<AngleSharp.Dom.IElement> pills = cut.FindAll(".esc-pill");
         pills.Count.ShouldBe(1);
-        pills[0].TextContent.ShouldBe("82.5 kg");
+        pills[0].TextContent.ShouldBe("82,50 kg");
     }
 
     [Fact]
@@ -486,7 +486,7 @@ public sealed class RecordCardTests : IDisposable
 
         // Assert
         cut.FindAll("a.esc-value").Count.ShouldBe(0);
-        cut.Find("span.esc-value").TextContent.Trim().ShouldBe("220.5kg");
+        cut.Find("span.esc-value").TextContent.Trim().ShouldBe("220,5kg");
     }
 
     public void Dispose()

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordHistoryCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Records/RecordHistoryCardTests.cs
@@ -51,7 +51,7 @@ public sealed class RecordHistoryCardTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement pill = cut.Find(".esc-pill");
-        pill.TextContent.ShouldBe("82.5 kg");
+        pill.TextContent.ShouldBe("82,50 kg");
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public sealed class RecordHistoryCardTests : IDisposable
             parameters => parameters.Add(p => p.Entry, entry));
 
         // Assert
-        cut.Find(".rhc-delta").TextContent.ShouldBe("▲ +5.0");
+        cut.Find(".rhc-delta").TextContent.ShouldBe("▲ +5,0");
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public sealed class RecordHistoryCardTests : IDisposable
             parameters => parameters.Add(p => p.Entry, entry));
 
         // Assert
-        cut.Find(".esc-value").TextContent.Trim().ShouldBe("200.5kg");
+        cut.Find(".esc-value").TextContent.Trim().ShouldBe("200,5kg");
     }
 
     [Fact]
@@ -181,7 +181,7 @@ public sealed class RecordHistoryCardTests : IDisposable
             parameters => parameters.Add(p => p.Entry, entry));
 
         // Assert
-        cut.Find(".rhc-delta").TextContent.ShouldBe("▲ +5.0");
+        cut.Find(".rhc-delta").TextContent.ShouldBe("▲ +5,0");
     }
 
     [Fact]

--- a/tests/KRAFT.Results.Web.Client.Tests/TestCulture.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/TestCulture.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace KRAFT.Results.Web.Client.Tests;
+
+internal static class TestCulture
+{
+    [ModuleInitializer]
+    internal static void SetIcelandicCulture()
+    {
+        CultureInfo icelandic = new("is-IS");
+        CultureInfo.DefaultThreadCurrentCulture = icelandic;
+        CultureInfo.DefaultThreadCurrentUICulture = icelandic;
+        CultureInfo.CurrentCulture = icelandic;
+        CultureInfo.CurrentUICulture = icelandic;
+    }
+}


### PR DESCRIPTION
## Summary

Unifies all UI date and number formatting to Icelandic (is-IS) conventions via a shared `DisplayFormat` helper, replacing ~25 scattered render sites that mixed `InvariantCulture` dot-decimals, three date styles, and an unformatted dashboard weight. Presentation is deliberately deviated from the live site (documented in CLAUDE.md).

## What changed

- **`DisplayFormat` helper** (`Web.Client` root, alongside `SlugSanitizer.cs`): `Weight` (one decimal, comma, no thousands grouping → `220,5`), `BodyWeight`/`Points` (two decimals → `82,50`), `Date` (`dd.MM.yyyy`), `MonthYear`/`MonthName`/`MeetCardDate` (Icelandic month names), and `TryParseWeight` (lenient parse accepting both `147,5` and `147.5`).
- **Render-site sweep**: every weight/bodyweight/points/date in Web.Client now routes through `DisplayFormat` — no inline `InvariantCulture` or ad-hoc `F1`/`F2` format strings remain at render sites. Bodyweight/points sites upgraded from one to two decimals.
- **`WeightCell.SignificantDigits`** parameter removed (no two-decimal caller) — delegates to `DisplayFormat.Weight`.
- **Lenient input parsing** in `AddParticipantForm` and `ParticipationCard` edit via `TryParseWeight`; edit prefill renders the comma with failed-lift `-` sign preserved.
- **Blazor Server host** (`Web/Program.cs`) pins `is-IS` as `DefaultThreadCurrentCulture`/`DefaultThreadCurrentUICulture` so prerender matches the WASM client; `App.razor` → `<html lang="is">`.
- **Tests**: `DisplayFormat` unit tests assert literal Icelandic strings (culture-independent); bUnit fixture pins is-IS via `TestCulture.cs` `[ModuleInitializer]`; hard-coded dot assertions updated to comma.
- **CLAUDE.md** gains a **Formatting** section documenting the rules and the deliberate deviation from results.kraft.is.

## Deliberate deviation
results.kraft.is renders two decimals for all weights (`125,00`) and hyphenated dates (`01-02-2025`). Values match; presentation intentionally differs — one decimal for lifted weights, `dd.MM.yyyy` dates. Documented in CLAUDE.md so a future session does not revert it.

## Testing
- `dotnet build` — 0 warnings (warnings-as-errors).
- Web.Client suite — 421/421 pass.
- Review gate (security, code-quality, UX): all blocking findings resolved.

## Follow-up (out of scope)
`EditBodyWeightDialog` still uses `@bind:culture` and rejects dot-decimal input — untouched file outside this issue's scoped two forms; recommend a follow-up to route it through `TryParseWeight` for full input consistency.

Closes #588
