### PR TITLE
ci: retry failed tower builds instead of latching up-to-date

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+if [ -z "$KRAFT_DEPLOY_LOCKED" ]; then
+    exec 9> /tmp/kraft-deploy.lock
+    flock -n 9 || exit 0
+    export KRAFT_DEPLOY_LOCKED=1
+fi
+
 if docker-compose version &>/dev/null 2>&1; then
     COMPOSE="docker-compose"
 elif docker compose version &>/dev/null 2>&1; then
@@ -12,20 +18,24 @@ fi
 
 cd "$(dirname "$0")"
 
+DEPLOYED_COMMIT_FILE=".last-deployed-commit"
+
 if [ "$1" = "--build" ]; then
     echo "$(date): Building and starting containers..."
     $COMPOSE build api
     $COMPOSE build web
     $COMPOSE up -d api web
+    git rev-parse HEAD > "$DEPLOYED_COMMIT_FILE"
+    docker image prune -f > /dev/null
     echo "$(date): Deploy complete"
     exit 0
 fi
 git fetch origin main
-LOCAL=$(git rev-parse main)
 REMOTE=$(git rev-parse origin/main)
-if [ "$LOCAL" != "$REMOTE" ]; then
+DEPLOYED=$(cat "$DEPLOYED_COMMIT_FILE" 2>/dev/null || true)
+if [ "$DEPLOYED" != "$REMOTE" ]; then
     echo "$(date): Changes detected, deploying..."
     git reset --hard origin/main
-    git clean -fd
+    git clean -fd -e "$DEPLOYED_COMMIT_FILE"
     exec "$0" --build
 fi


### PR DESCRIPTION
## Problem

\`deploy.sh\` resets the repo to \`origin/main\` before building and detects changes by comparing the local branch to \`origin/main\`. A failed build therefore leaves the repo "up to date" and the script never retries — tower stayed on the Jul 31 build after the Aug 4 disk-full build failures, silently.

## Changes

- Track the last **successfully deployed** commit in \`.last-deployed-commit\` (written only after \`compose up\` succeeds) and compare \`origin/main\` against it, so failed builds retry on the next cron run.
- Exclude the tracking file from \`git clean\`.
- \`flock\` guard against overlapping cron runs (builds take longer than the 5-minute cron interval; the lock fd survives the self-updating \`exec "$0" --build\`).
- \`docker image prune -f\` after each successful build so superseded layers stop filling docker.img.

Closes #597