### PR TITLE
fix(web-client): pin club logo and athlete photo URLs to legacy host servable variants

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
@@ -64,6 +64,7 @@
             && !Filename.Contains('?')
             && !Filename.Contains('#')
             && !Filename.Contains(',')
-            && !Filename.Contains(' ');
+            && !Filename.Contains(' ')
+            && !Filename.Contains('%');
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
+++ b/src/KRAFT.Results.Web.Client/Components/AthletePhoto.razor
@@ -6,7 +6,6 @@
     @if (_isValidFilename)
     {
         <img src="@($"{_imageBaseUrl}/{Filename}{_sizeQuery}")"
-             srcset="@($"{_imageBaseUrl}/{Filename}{_sizeQuery2x} 2x")"
              alt="@Alt"
              loading="lazy"
              onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
@@ -19,6 +18,11 @@
 </div>
 
 @code {
+    // Servable variants from the legacy image host cache — parameter order is load-bearing.
+    // See DOMAIN.md § Legacy Image Host for the full table.
+    private const string SmallQuery = "?width=64&height=64&crop=auto";
+    private const string LargeQuery = "?width=300&height=200&crop=auto";
+
     [Parameter]
     public string? Filename { get; set; }
 
@@ -31,7 +35,6 @@
     private string _imageBaseUrl = "";
     private string _sizeClass = "";
     private string _sizeQuery = "";
-    private string _sizeQuery2x = "";
     private bool _isValidFilename;
 
     protected override void OnInitialized()
@@ -48,13 +51,11 @@
             _ => "athlete-photo--sm",
         };
 
-        (int width, int height) dims = Size switch
+        _sizeQuery = Size switch
         {
-            AthletePhotoSize.Large => (300, 200),
-            _ => (64, 64),
+            AthletePhotoSize.Large => LargeQuery,
+            _ => SmallQuery,
         };
-        _sizeQuery = $"?width={dims.width}&height={dims.height}&crop=auto";
-        _sizeQuery2x = $"?width={dims.width * 2}&height={dims.height * 2}&crop=auto";
 
         _isValidFilename = !string.IsNullOrEmpty(Filename)
             && !Filename.Contains('/')

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -85,6 +85,7 @@
             && !Filename.Contains('?')
             && !Filename.Contains('#')
             && !Filename.Contains(',')
-            && !Filename.Contains(' ');
+            && !Filename.Contains(' ')
+            && !Filename.Contains('%');
     }
 }

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor
@@ -8,7 +8,6 @@
         @* Structural invariant: the placeholder div must remain the img's immediate next
            sibling — the onerror handler uses nextElementSibling to reveal it on load failure. *@
         <img src="@($"{_teamLogoBaseUrl}/{Filename}{_sizeQuery}")"
-             srcset="@($"{_teamLogoBaseUrl}/{Filename}{_sizeQuery2x} 2x")"
              alt="@Alt"
              loading="lazy"
              onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
@@ -30,6 +29,11 @@
 </div>
 
 @code {
+    // Servable variants from the legacy image host cache — parameter order is load-bearing.
+    // See DOMAIN.md § Legacy Image Host for the full table.
+    private const string SmallQuery = "?width=64&height=64&crop=auto";
+    private const string LargeQuery = "?width=128&height=128";
+
     [Parameter]
     public string? Filename { get; set; }
 
@@ -46,7 +50,6 @@
     private string _sizeClass = "";
     private string _textClass = "";
     private string _sizeQuery = "";
-    private string _sizeQuery2x = "";
     private bool _isValidFilename;
 
     protected override void OnInitialized()
@@ -69,18 +72,11 @@
             ? "team-logo--text"
             : "";
 
-        (int width, int height, bool crop) dims = Size switch
+        _sizeQuery = Size switch
         {
-            // XSmall deliberately requests its display size (24/48) rather than
-            // over-requesting like the other sizes — per issue #593 AC. Do not
-            // change this to match the Small/Medium pattern.
-            TeamLogoSize.XSmall => (24, 24, true),
-            TeamLogoSize.Large => (128, 128, false),
-            _ => (64, 64, true),
+            TeamLogoSize.Large => LargeQuery,
+            _ => SmallQuery,
         };
-        string cropSuffix = dims.crop ? "&crop=auto" : "";
-        _sizeQuery = $"?width={dims.width}&height={dims.height}{cropSuffix}";
-        _sizeQuery2x = $"?width={dims.width * 2}&height={dims.height * 2}{cropSuffix}";
 
         _isValidFilename = Filename is not null
             && !Filename.Contains('/')

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
@@ -62,6 +62,7 @@ public sealed class AthletePhotoTests : IDisposable
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
             p => p
                 .Add(c => c.Filename, "jondoe.jpg")
+                .Add(c => c.Alt, "test")
                 .Add(c => c.Size, AthletePhotoSize.Small));
 
         // Assert
@@ -78,6 +79,7 @@ public sealed class AthletePhotoTests : IDisposable
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
             p => p
                 .Add(c => c.Filename, "jondoe.jpg")
+                .Add(c => c.Alt, "test")
                 .Add(c => c.Size, AthletePhotoSize.Large));
 
         // Assert
@@ -164,6 +166,23 @@ public sealed class AthletePhotoTests : IDisposable
         IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
             p => p
                 .Add(c => c.Filename, "evil photo.jpg")
+                .Add(c => c.Alt, "test")
+                .Add(c => c.Size, AthletePhotoSize.Small));
+
+        // Assert
+        cut.Find(".athlete-photo svg").ShouldNotBeNull();
+        cut.FindAll(".athlete-photo img").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ShowsPlaceholder_WhenFilenameContainsPercent()
+    {
+        // Arrange
+
+        // Act
+        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
+            p => p
+                .Add(c => c.Filename, "logo%2Fevil.png")
                 .Add(c => c.Alt, "test")
                 .Add(c => c.Size, AthletePhotoSize.Small));
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/AthletePhotoTests.cs
@@ -54,7 +54,7 @@ public sealed class AthletePhotoTests : IDisposable
     }
 
     [Fact]
-    public void RendersImg_WithSmallQueryString_WhenSizeIsSmall()
+    public void WhenSizeIsSmall_SrcQueryStringIsPinned64x64Crop()
     {
         // Arrange
 
@@ -70,7 +70,7 @@ public sealed class AthletePhotoTests : IDisposable
     }
 
     [Fact]
-    public void RendersImg_WithLargeQueryString_WhenSizeIsLarge()
+    public void WhenSizeIsLarge_SrcQueryStringIsPinned300x200Crop()
     {
         // Arrange
 
@@ -119,8 +119,10 @@ public sealed class AthletePhotoTests : IDisposable
         cut.Find($".athlete-photo.{expectedClass}").ShouldNotBeNull();
     }
 
-    [Fact]
-    public void RendersSrcset2x_WhenSizeIsSmall()
+    [Theory]
+    [InlineData(AthletePhotoSize.Small)]
+    [InlineData(AthletePhotoSize.Large)]
+    public void DoesNotEmitSrcset_ForAnySize(AthletePhotoSize size)
     {
         // Arrange
 
@@ -129,72 +131,11 @@ public sealed class AthletePhotoTests : IDisposable
             p => p
                 .Add(c => c.Filename, "jondoe.jpg")
                 .Add(c => c.Alt, "test")
-                .Add(c => c.Size, AthletePhotoSize.Small));
+                .Add(c => c.Size, size));
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
-        string? srcset = img.GetAttribute("srcset");
-        srcset.ShouldNotBeNull();
-        srcset.ShouldEndWith(" 2x");
-        srcset.ShouldContain("width=128");
-        srcset.ShouldContain("height=128");
-        srcset.ShouldContain("crop=auto");
-    }
-
-    [Fact]
-    public void RendersSrcset2x_WhenSizeIsLarge()
-    {
-        // Arrange
-
-        // Act
-        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
-            p => p
-                .Add(c => c.Filename, "jondoe.jpg")
-                .Add(c => c.Alt, "test")
-                .Add(c => c.Size, AthletePhotoSize.Large));
-
-        // Assert
-        AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
-        string? srcset = img.GetAttribute("srcset");
-        srcset.ShouldNotBeNull();
-        srcset.ShouldEndWith(" 2x");
-        srcset.ShouldContain("width=600");
-        srcset.ShouldContain("height=400");
-        srcset.ShouldContain("crop=auto");
-    }
-
-    [Fact]
-    public void SrcRemainsUnchanged_WhenSrcsetIsAdded_ForSmall()
-    {
-        // Arrange
-
-        // Act
-        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
-            p => p
-                .Add(c => c.Filename, "jondoe.jpg")
-                .Add(c => c.Alt, "test")
-                .Add(c => c.Size, AthletePhotoSize.Small));
-
-        // Assert
-        AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
-        img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/jondoe.jpg?width=64&height=64&crop=auto");
-    }
-
-    [Fact]
-    public void SrcRemainsUnchanged_WhenSrcsetIsAdded_ForLarge()
-    {
-        // Arrange
-
-        // Act
-        IRenderedComponent<AthletePhoto> cut = _context.Render<AthletePhoto>(
-            p => p
-                .Add(c => c.Filename, "jondoe.jpg")
-                .Add(c => c.Alt, "test")
-                .Add(c => c.Size, AthletePhotoSize.Large));
-
-        // Assert
-        AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
-        img.GetAttribute("src").ShouldBe($"{ImageBaseUrl}/jondoe.jpg?width=300&height=200&crop=auto");
+        img.GetAttribute("srcset").ShouldBeNull();
     }
 
     [Fact]

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 
 using KRAFT.Results.Web.Client.Components;
 
@@ -101,8 +101,11 @@ public sealed class TeamLogoTests : IDisposable
         cut.Find($".team-logo.{expectedClass}").ShouldNotBeNull();
     }
 
-    [Fact]
-    public void WhenSizeIsXSmall_RendersSrcset2x()
+    [Theory]
+    [InlineData(TeamLogoSize.XSmall)]
+    [InlineData(TeamLogoSize.Small)]
+    [InlineData(TeamLogoSize.Medium)]
+    public void WhenSizeIsXSmallSmallOrMedium_SrcQueryStringIsPinned64x64Crop(TeamLogoSize size)
     {
         // Arrange
 
@@ -110,57 +113,15 @@ public sealed class TeamLogoTests : IDisposable
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
             p => p
                 .Add(c => c.Filename, "thor.png")
-                .Add(c => c.Size, TeamLogoSize.XSmall));
+                .Add(c => c.Size, size));
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        string? srcset = img.GetAttribute("srcset");
-        srcset.ShouldNotBeNull();
-        srcset.ShouldEndWith(" 2x");
-        srcset.ShouldContain("width=48");
-        srcset.ShouldContain("height=48");
-        srcset.ShouldContain("crop=auto");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=64&height=64&crop=auto");
     }
 
     [Fact]
-    public void WhenSizeIsXSmall_SrcRemainsUnchanged()
-    {
-        // Arrange
-
-        // Act
-        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
-            p => p
-                .Add(c => c.Filename, "thor.png")
-                .Add(c => c.Size, TeamLogoSize.XSmall));
-
-        // Assert
-        AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=24&height=24&crop=auto");
-    }
-
-    [Fact]
-    public void RendersSrcset2x_WhenSizeIsMedium()
-    {
-        // Arrange
-
-        // Act
-        IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
-            p => p
-                .Add(c => c.Filename, "thor.png")
-                .Add(c => c.Size, TeamLogoSize.Medium));
-
-        // Assert
-        AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        string? srcset = img.GetAttribute("srcset");
-        srcset.ShouldNotBeNull();
-        srcset.ShouldEndWith(" 2x");
-        srcset.ShouldContain("width=128");
-        srcset.ShouldContain("height=128");
-        srcset.ShouldContain("crop=auto");
-    }
-
-    [Fact]
-    public void RendersSrcset2x_WhenSizeIsLarge()
+    public void WhenSizeIsLarge_SrcQueryStringIsPinned128x128()
     {
         // Arrange
 
@@ -172,16 +133,15 @@ public sealed class TeamLogoTests : IDisposable
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        string? srcset = img.GetAttribute("srcset");
-        srcset.ShouldNotBeNull();
-        srcset.ShouldEndWith(" 2x");
-        srcset.ShouldContain("width=256");
-        srcset.ShouldContain("height=256");
-        srcset.ShouldNotContain("crop=auto");
+        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=128&height=128");
     }
 
-    [Fact]
-    public void SrcRemainsUnchanged_WhenSrcsetIsAdded_ForMedium()
+    [Theory]
+    [InlineData(TeamLogoSize.XSmall)]
+    [InlineData(TeamLogoSize.Small)]
+    [InlineData(TeamLogoSize.Medium)]
+    [InlineData(TeamLogoSize.Large)]
+    public void DoesNotEmitSrcset_ForAnySize(TeamLogoSize size)
     {
         // Arrange
 
@@ -189,11 +149,11 @@ public sealed class TeamLogoTests : IDisposable
         IRenderedComponent<TeamLogo> cut = _context.Render<TeamLogo>(
             p => p
                 .Add(c => c.Filename, "thor.png")
-                .Add(c => c.Size, TeamLogoSize.Medium));
+                .Add(c => c.Size, size));
 
         // Assert
         AngleSharp.Dom.IElement img = cut.Find(".team-logo img");
-        img.GetAttribute("src").ShouldBe($"{TeamLogoBaseUrl}/thor.png?width=64&height=64&crop=auto");
+        img.GetAttribute("srcset").ShouldBeNull();
     }
 
     [Fact]

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/TeamLogoTests.cs
@@ -295,6 +295,7 @@ public sealed class TeamLogoTests : IDisposable
     [InlineData("javascript:alert(1)")]
     [InlineData("logo.png?width=999")]
     [InlineData("logo.png#section")]
+    [InlineData("logo%2Fevil.png")]
     public void WhenFallbackTextSetAndFilenameIsUnsafe_RendersFallbackText(string unsafeFilename)
     {
         // Arrange
@@ -353,6 +354,7 @@ public sealed class TeamLogoTests : IDisposable
     [InlineData("javascript:alert(1)")]
     [InlineData("logo.png?width=999")]
     [InlineData("logo.png#section")]
+    [InlineData("logo%2Fevil.png")]
     public void ShowsPlaceholder_WhenFilenameIsInvalid(string invalidFilename)
     {
         // Arrange


### PR DESCRIPTION
Closes #603

## Summary
Club logos never rendered on meet participation cards (and all images degraded on high-DPI displays) because `TeamLogo` / `AthletePhoto` computed resize query strings the legacy image host cannot serve — the host serves only per-file cached variants matched by the exact literal query string, returning a slow ~30s HTTP 500 on anything else and tripping the `onerror` fallback.

## Changes
- **`TeamLogo.razor`** — query strings pinned as verbatim `private const` constants (mirroring the `MeetPhotoSizes` pattern): XSmall/Small/Medium → `?width=64&height=64&crop=auto`, Large → `?width=128&height=128`. Removed the computed dims tuple, the `_sizeQuery2x` field, and the `srcset` attribute (no 2x variants exist on the host). Removed the misleading "per issue #593 AC — do not change" comment.
- **`AthletePhoto.razor`** — same treatment: Small → `?width=64&height=64&crop=auto`, Large → `?width=300&height=200&crop=auto`; `srcset` removed.
- Display box sizes (24/48/48/80 px) unchanged — achieved purely via CSS `object-fit` as before. Filename guard and `onerror` fallback preserved.
- **bUnit tests** — updated to assert the pinned variants and the absence of `srcset` across all render sizes.

## Review-gate hardening (included)
- Blocked `%` in the filename safety guard of both components (percent-encoded path-separator bypass) + tests.
- Added the `[EditorRequired]` `Alt` param to two `AthletePhoto` tests.

## Verification
- 467 bUnit tests pass; solution builds with 0 warnings.
- Manual: participation cards now render club logos (e.g. BRE → `Breidablik.png`) on standard and high-DPI displays.

Parameter order and casing are load-bearing (copied verbatim from `DOMAIN.md § Legacy Image Host`), never computed. No contract/API/DB changes — Web.Client components and bUnit tests only. Unblocks #594.