### PR TITLE
feat(web-client): show club logo in athlete details header

### DIFF
--- a/src/KRAFT.Results.Contracts/Athletes/AthleteDetails.cs
+++ b/src/KRAFT.Results.Contracts/Athletes/AthleteDetails.cs
@@ -6,5 +6,7 @@ public sealed record class AthleteDetails(
     int? YearOfBirth,
     string? Club,
     string? ClubSlug,
+    string? ClubShortTitle,
+    string? ClubLogoImageFilename,
     int RecordCount,
     string? ProfileImageFilename);

--- a/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/TeamLogo.razor.css
@@ -65,3 +65,19 @@
     width: auto;
     justify-content: flex-start;
 }
+
+.team-logo--lg.team-logo--text {
+    width: 80px;
+    height: 80px;
+    overflow: hidden;
+}
+
+.team-logo--lg.team-logo--text .team-logo-placeholder {
+    background: color-mix(in oklch, var(--color-border), transparent 40%);
+    opacity: 1;
+    justify-content: center;
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1.5rem;
+    color: var(--color-text-muted);
+}

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
@@ -17,6 +17,17 @@
                               Alt="@pageData.Athlete.Name"
                               Size="AthletePhotoSize.Large" />
                 <h1>@pageData.Athlete.Name</h1>
+                @if (pageData.ShowClubs)
+                {
+                    <NavLink class="club-anchor"
+                             href="@SlugSanitizer.SlugHref("/teams/", pageData.Athlete.ClubSlug ?? string.Empty)"
+                             title="@pageData.Athlete.Club">
+                        <TeamLogo Filename="@pageData.Athlete.ClubLogoImageFilename"
+                                  Alt="@pageData.Athlete.Club"
+                                  FallbackText="@pageData.Athlete.ClubShortTitle"
+                                  Size="TeamLogoSize.Large" />
+                    </NavLink>
+                }
             </div>
             <AuthorizeView Roles="Admin">
                 <div class="admin-actions">

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor
@@ -17,11 +17,12 @@
                               Alt="@pageData.Athlete.Name"
                               Size="AthletePhotoSize.Large" />
                 <h1>@pageData.Athlete.Name</h1>
-                @if (pageData.ShowClubs)
+                @if (pageData.ShowClubLogo)
                 {
                     <NavLink class="club-anchor"
                              href="@SlugSanitizer.SlugHref("/teams/", pageData.Athlete.ClubSlug ?? string.Empty)"
-                             title="@pageData.Athlete.Club">
+                             title="@pageData.Athlete.Club"
+                             aria-label="@pageData.Athlete.Club">
                         <TeamLogo Filename="@pageData.Athlete.ClubLogoImageFilename"
                                   Alt="@pageData.Athlete.Club"
                                   FallbackText="@pageData.Athlete.ClubShortTitle"
@@ -160,7 +161,8 @@
         IReadOnlyList<AthleteRecord> Records,
         IReadOnlyList<AthleteParticipation> Participations,
         List<SectionNav.SectionNavLink> NavLinks,
-        bool ShowClubs);
+        bool ShowClubs,
+        bool ShowClubLogo);
 
     private ConfirmDialog? _deleteDialog;
     private bool _isDeleting;
@@ -186,13 +188,14 @@
             await HttpClient.GetFromJsonAsync<IReadOnlyList<AthleteParticipation>>($"/athletes/{Slug}/participations") ?? [];
 
         bool showClubs = !string.IsNullOrWhiteSpace(athlete.Club);
+        bool showClubLogo = showClubs && !string.IsNullOrWhiteSpace(athlete.ClubSlug);
 
         List<SectionNav.SectionNavLink> navLinks = [];
         if (personalBests.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Besti árangur", $"/athletes/{Slug}#bestaragangur")); }
         if (records.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Íslandsmet", $"/athletes/{Slug}#islandsmet")); }
         if (participations.Count > 0) { navLinks.Add(new SectionNav.SectionNavLink("Ferill", $"/athletes/{Slug}#ferill")); }
 
-        return new AthletePageData(athlete, personalBests, records, participations, navLinks, showClubs);
+        return new AthletePageData(athlete, personalBests, records, participations, navLinks, showClubs, showClubLogo);
     }
 
     private async Task ShowDeleteDialog()

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
@@ -11,6 +11,40 @@
     min-width: 0;
 }
 
+.athlete-detail-header > h1 {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.club-anchor {
+    flex-shrink: 0;
+    margin-inline-start: auto;
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    border-radius: var(--radius-sm);
+    transition: opacity var(--transition-fast) ease;
+}
+
+.club-anchor:hover {
+    opacity: 0.85;
+}
+
+.club-anchor:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+@media (max-width: 56rem) {
+    .club-anchor .team-logo--lg {
+        width: 56px;
+        height: 56px;
+    }
+}
+
 .athlete-meta {
     display: flex;
     align-items: center;

--- a/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Athletes/AthleteDetailsPage.razor.css
@@ -39,7 +39,12 @@
 }
 
 @media (max-width: 56rem) {
-    .club-anchor .team-logo--lg {
+    .club-anchor ::deep .team-logo--lg {
+        width: 56px;
+        height: 56px;
+    }
+
+    .club-anchor ::deep .team-logo--lg.team-logo--text {
         width: 56px;
         height: 56px;
     }

--- a/src/KRAFT.Results.WebApi/Features/Athletes/GetDetails/GetAthleteDetailsHandler.cs
+++ b/src/KRAFT.Results.WebApi/Features/Athletes/GetDetails/GetAthleteDetailsHandler.cs
@@ -15,6 +15,8 @@ internal sealed class GetAthleteDetailsHandler(ResultsDbContext dbContext)
                 x.DateOfBirth != null && x.DateOfBirth.Value.Year > 0 ? x.DateOfBirth.Value.Year : null,
                 x.Team != null ? x.Team.TitleFull : null,
                 x.Team != null ? x.Team.Slug : null,
+                x.Team != null ? x.Team.TitleShort : null,
+                x.Team != null ? x.Team.LogoImageFilename : null,
                 0,
                 x.ProfileImageFilename))
             .FirstOrDefaultAsync(cancellationToken);

--- a/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
@@ -18,6 +18,8 @@ internal sealed class AthleteDetailsPageMockHandler(
         YearOfBirth: 1990,
         Club: "Test Club",
         ClubSlug: "test-club",
+        ClubShortTitle: "TCL",
+        ClubLogoImageFilename: null,
         RecordCount: 0,
         ProfileImageFilename: null);
 

--- a/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
@@ -19,7 +19,7 @@ internal sealed class AthleteDetailsPageMockHandler(
         Club: "Test Club",
         ClubSlug: "test-club",
         ClubShortTitle: "TCL",
-        ClubLogoImageFilename: null,
+        ClubLogoImageFilename: "default-club-logo.png",
         RecordCount: 0,
         ProfileImageFilename: null);
 
@@ -32,7 +32,10 @@ internal sealed class AthleteDetailsPageMockHandler(
         DefaultAthlete with { ClubLogoImageFilename = logoFilename };
 
     internal static AthleteDetails AthleteWithClubNoLogo() =>
-        DefaultAthlete with { ClubLogoImageFilename = null };
+        DefaultAthlete with { ClubLogoImageFilename = null, ClubShortTitle = "KSV" };
+
+    internal static AthleteDetails AthleteWithClubButNoSlug() =>
+        DefaultAthlete with { ClubSlug = null };
 
     internal static AthleteDetails AthleteWithNoClub() =>
         DefaultAthlete with

--- a/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/AthleteDetailsPageMockHandler.cs
@@ -28,6 +28,21 @@ internal sealed class AthleteDetailsPageMockHandler(
     internal static AthleteDetails AthleteWithPhoto(string filename) =>
         DefaultAthlete with { ProfileImageFilename = filename };
 
+    internal static AthleteDetails AthleteWithClubLogo(string logoFilename) =>
+        DefaultAthlete with { ClubLogoImageFilename = logoFilename };
+
+    internal static AthleteDetails AthleteWithClubNoLogo() =>
+        DefaultAthlete with { ClubLogoImageFilename = null };
+
+    internal static AthleteDetails AthleteWithNoClub() =>
+        DefaultAthlete with
+        {
+            Club = null,
+            ClubSlug = null,
+            ClubShortTitle = null,
+            ClubLogoImageFilename = null,
+        };
+
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         if (delay)

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
@@ -496,6 +496,75 @@ public sealed class AthleteDetailsPageTests : IDisposable
     }
 
     [Fact]
+    public void WhenAthleteHasClubWithLogo_RendersClubLogoImgWithPinnedVariantInsideNavLink()
+    {
+        // Arrange
+        AthleteDetails athlete = AthleteDetailsPageMockHandler.AthleteWithClubLogo("breidablik.png");
+        RegisterHttpClient(athlete: athlete);
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement anchor = cut.Find(".club-anchor");
+            anchor.GetAttribute("href").ShouldBe("/teams/test-club");
+            anchor.GetAttribute("title").ShouldBe("Test Club");
+
+            AngleSharp.Dom.IElement img = anchor.QuerySelector("img").ShouldNotBeNull();
+            string src = img.GetAttribute("src").ShouldNotBeNull();
+            src.ShouldStartWith($"{ImageBaseUrl}/breidablik.png");
+            src.ShouldContain("width=128");
+            src.ShouldContain("height=128");
+        });
+    }
+
+    [Fact]
+    public void WhenAthleteHasClubWithNoLogo_RendersMonogramInsideNavLink()
+    {
+        // Arrange
+        AthleteDetails athlete = AthleteDetailsPageMockHandler.AthleteWithClubNoLogo();
+        RegisterHttpClient(athlete: athlete);
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement anchor = cut.Find(".club-anchor");
+            anchor.GetAttribute("href").ShouldBe("/teams/test-club");
+
+            AngleSharp.Dom.IElement fallback = anchor.QuerySelector(".team-logo-fallback-text").ShouldNotBeNull();
+            fallback.TextContent.Trim().ShouldBe("TCL");
+
+            anchor.QuerySelector("img").ShouldBeNull();
+        });
+    }
+
+    [Fact]
+    public void WhenAthleteHasNoClub_ClubAnchorIsAbsent()
+    {
+        // Arrange
+        AthleteDetails athlete = AthleteDetailsPageMockHandler.AthleteWithNoClub();
+        RegisterHttpClient(athlete: athlete);
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".club-anchor").Count.ShouldBe(0);
+            cut.Find("h1").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
     public void WhenAthleteHasCurrentRecords_RendersPerEraRecordHeading()
     {
         // Arrange

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
@@ -472,7 +472,7 @@ public sealed class AthleteDetailsPageTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            AngleSharp.Dom.IElement img = cut.Find(".athlete-detail-header img");
+            AngleSharp.Dom.IElement img = cut.Find(".athlete-photo img");
             img.GetAttribute("src").ShouldStartWith($"{ImageBaseUrl}/jondoe.jpg");
         });
     }
@@ -490,8 +490,8 @@ public sealed class AthleteDetailsPageTests : IDisposable
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find(".athlete-detail-header svg").ShouldNotBeNull();
-            cut.FindAll(".athlete-detail-header img").Count.ShouldBe(0);
+            cut.Find(".athlete-photo svg").ShouldNotBeNull();
+            cut.FindAll(".athlete-photo img").Count.ShouldBe(0);
         });
     }
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Athletes/AthleteDetailsPageTests.cs
@@ -537,11 +537,31 @@ public sealed class AthleteDetailsPageTests : IDisposable
         {
             AngleSharp.Dom.IElement anchor = cut.Find(".club-anchor");
             anchor.GetAttribute("href").ShouldBe("/teams/test-club");
+            anchor.GetAttribute("aria-label").ShouldBe("Test Club");
 
             AngleSharp.Dom.IElement fallback = anchor.QuerySelector(".team-logo-fallback-text").ShouldNotBeNull();
-            fallback.TextContent.Trim().ShouldBe("TCL");
+            fallback.TextContent.Trim().ShouldBe("KSV");
 
             anchor.QuerySelector("img").ShouldBeNull();
+        });
+    }
+
+    [Fact]
+    public void WhenAthleteHasClubButNoClubSlug_ClubAnchorIsAbsent_AndMetaRowShowsClub()
+    {
+        // Arrange
+        AthleteDetails athlete = AthleteDetailsPageMockHandler.AthleteWithClubButNoSlug();
+        RegisterHttpClient(athlete: athlete);
+
+        // Act
+        IRenderedComponent<AthleteDetailsPage> cut = _context.Render<AthleteDetailsPage>(
+            parameters => parameters.Add(p => p.Slug, "test-athlete"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll(".club-anchor").Count.ShouldBe(0);
+            cut.Find(".athlete-meta").TextContent.ShouldContain("Test Club");
         });
     }
 
@@ -560,7 +580,6 @@ public sealed class AthleteDetailsPageTests : IDisposable
         cut.WaitForAssertion(() =>
         {
             cut.FindAll(".club-anchor").Count.ShouldBe(0);
-            cut.Find("h1").ShouldNotBeNull();
         });
     }
 

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
@@ -108,7 +108,7 @@ public sealed class GetAthleteDetailsTests(CollectionFixture fixture) : IAsyncLi
         const string LogoFilename = "team-logo.png";
 
         await fixture.ExecuteSqlAsync(
-            $"UPDATE Teams SET LogoImageFilename = '{LogoFilename}' WHERE TeamId = {TestSeedConstants.Team.Id}");
+            $"UPDATE Teams SET LogoImageFilename = {LogoFilename} WHERE TeamId = {TestSeedConstants.Team.Id}");
 
         try
         {

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
@@ -43,10 +43,6 @@ public sealed class GetAthleteDetailsTests(CollectionFixture fixture) : IAsyncLi
             }
         }
 
-        // Reset the logo that was seeded via SQL — no write endpoint exists for LogoImageFilename
-        await fixture.ExecuteSqlAsync(
-            $"UPDATE Teams SET LogoImageFilename = NULL WHERE TeamId = {TestSeedConstants.Team.Id}");
-
         _authorizedClient.Dispose();
         _unauthorizedHttpClient.Dispose();
     }
@@ -106,29 +102,42 @@ public sealed class GetAthleteDetailsTests(CollectionFixture fixture) : IAsyncLi
     [Fact]
     public async Task WhenTeamHasLogo_ProjectsClubShortTitleAndClubLogoImageFilename()
     {
-        // Arrange — seed a logo filename onto the seeded team via SQL (no write endpoint for LogoImageFilename)
+        // Arrange — seed a logo filename onto the seeded team via SQL (no write endpoint for LogoImageFilename).
+        // Uses TestSeedConstants.Athlete.Slug because that athlete is pre-assigned to TestSeedConstants.Team
+        // in the database seed, which is the team whose logo we mutate here.
         const string LogoFilename = "team-logo.png";
 
         await fixture.ExecuteSqlAsync(
-            $"UPDATE Teams SET LogoImageFilename = {LogoFilename} WHERE TeamId = {TestSeedConstants.Team.Id}");
+            $"UPDATE Teams SET LogoImageFilename = '{LogoFilename}' WHERE TeamId = {TestSeedConstants.Team.Id}");
 
-        string path = $"{BasePath}/{TestSeedConstants.Athlete.Slug}";
+        try
+        {
+            string path = $"{BasePath}/{TestSeedConstants.Athlete.Slug}";
 
-        // Act
-        AthleteDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<AthleteDetails>(path, CancellationToken.None);
+            // Act
+            AthleteDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<AthleteDetails>(path, CancellationToken.None);
 
-        // Assert
-        response.ShouldNotBeNull();
-        response.ShouldSatisfyAllConditions(
-            () => response.Club.ShouldBe(TestSeedConstants.Team.TitleFull),
-            () => response.ClubShortTitle.ShouldBe(TestSeedConstants.Team.TitleShort),
-            () => response.ClubLogoImageFilename.ShouldBe(LogoFilename));
+            // Assert
+            response.ShouldNotBeNull();
+            response.ShouldSatisfyAllConditions(
+                () => response.Club.ShouldBe(TestSeedConstants.Team.TitleFull),
+                () => response.ClubShortTitle.ShouldBe(TestSeedConstants.Team.TitleShort),
+                () => response.ClubLogoImageFilename.ShouldBe(LogoFilename),
+                () => response.ClubSlug.ShouldBe(TestSeedConstants.Team.Slug));
+        }
+        finally
+        {
+            // Restore to NULL so this test's mutation does not bleed into other tests.
+            await fixture.ExecuteSqlAsync(
+                $"UPDATE Teams SET LogoImageFilename = NULL WHERE TeamId = {TestSeedConstants.Team.Id}");
+        }
     }
 
     [Fact]
     public async Task WhenTeamHasNoLogo_ClubLogoImageFilenameIsNull()
     {
-        // Arrange — the seeded team has no logo by default (LogoImageFilename is NULL in seed)
+        // Arrange — the seeded team has no logo by default (LogoImageFilename is NULL in seed).
+        // Uses TestSeedConstants.Athlete.Slug because that athlete is pre-assigned to TestSeedConstants.Team.
         string path = $"{BasePath}/{TestSeedConstants.Athlete.Slug}";
 
         // Act

--- a/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
+++ b/tests/KRAFT.Results.WebApi.IntegrationTests/Features/Athletes/GetAthleteDetailsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 
 using KRAFT.Results.Contracts.Athletes;
+using KRAFT.Results.Tests.Shared;
 using KRAFT.Results.WebApi.IntegrationTests.Builders;
 using KRAFT.Results.WebApi.IntegrationTests.Collections;
 
@@ -41,6 +42,10 @@ public sealed class GetAthleteDetailsTests(CollectionFixture fixture) : IAsyncLi
                 // Best-effort cleanup; do not mask test failures.
             }
         }
+
+        // Reset the logo that was seeded via SQL — no write endpoint exists for LogoImageFilename
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Teams SET LogoImageFilename = NULL WHERE TeamId = {TestSeedConstants.Team.Id}");
 
         _authorizedClient.Dispose();
         _unauthorizedHttpClient.Dispose();
@@ -96,5 +101,43 @@ public sealed class GetAthleteDetailsTests(CollectionFixture fixture) : IAsyncLi
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task WhenTeamHasLogo_ProjectsClubShortTitleAndClubLogoImageFilename()
+    {
+        // Arrange — seed a logo filename onto the seeded team via SQL (no write endpoint for LogoImageFilename)
+        const string LogoFilename = "team-logo.png";
+
+        await fixture.ExecuteSqlAsync(
+            $"UPDATE Teams SET LogoImageFilename = {LogoFilename} WHERE TeamId = {TestSeedConstants.Team.Id}");
+
+        string path = $"{BasePath}/{TestSeedConstants.Athlete.Slug}";
+
+        // Act
+        AthleteDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<AthleteDetails>(path, CancellationToken.None);
+
+        // Assert
+        response.ShouldNotBeNull();
+        response.ShouldSatisfyAllConditions(
+            () => response.Club.ShouldBe(TestSeedConstants.Team.TitleFull),
+            () => response.ClubShortTitle.ShouldBe(TestSeedConstants.Team.TitleShort),
+            () => response.ClubLogoImageFilename.ShouldBe(LogoFilename));
+    }
+
+    [Fact]
+    public async Task WhenTeamHasNoLogo_ClubLogoImageFilenameIsNull()
+    {
+        // Arrange — the seeded team has no logo by default (LogoImageFilename is NULL in seed)
+        string path = $"{BasePath}/{TestSeedConstants.Athlete.Slug}";
+
+        // Act
+        AthleteDetails? response = await _unauthorizedHttpClient.GetFromJsonAsync<AthleteDetails>(path, CancellationToken.None);
+
+        // Assert
+        response.ShouldNotBeNull();
+        response.ShouldSatisfyAllConditions(
+            () => response.ClubShortTitle.ShouldBe(TestSeedConstants.Team.TitleShort),
+            () => response.ClubLogoImageFilename.ShouldBeNull());
     }
 }


### PR DESCRIPTION
## Summary
Gives the athlete's club real presence on the athlete details page: the club logo is pinned to the header's right edge at athlete-photo height (80 px; ~56 px on narrow screens) as a secondary identity anchor, per the athlete-centric display policy in `DOMAIN.md § Club logo`. The logo reuses the existing `TeamLogo` component (`?width=128&height=128` variant, `object-fit: contain`) inside a `NavLink` to the club; clubs without a logo fall back to a 3-char monogram block, and club-less athletes get no slot at all. The meta row is unchanged.

## Changes
- **Contract:** `AthleteDetails` gains `ClubShortTitle` and `ClubLogoImageFilename` (both nullable); `Club` stays the full title.
- **Projection:** `GetAthleteDetailsHandler` projects the two fields from `Team.TitleShort` / `Team.LogoImageFilename` with the existing `Team != null` guard.
- **UI:** `AthleteDetailsPage` renders the club anchor (logo / monogram / absent) with right-edge pinning, responsive shrink via `::deep`, `aria-label` for a reliable accessible name, and a `ShowClubLogo` guard that avoids a dead link when the slug is missing. `TeamLogo.razor.css` gains a Large-monogram rule.
- **Tests:** bUnit cases for logo+link, monogram fallback, and absent slot (club-less and slug-less); integration tests assert the projection with an SQL-seeded logo (no write endpoint for `LogoImageFilename`), scoped with try/finally so shared seed state is restored.

## Testing
- `dotnet build` clean (0 warnings, warnings-as-errors).
- Web.Client bUnit: 471 passing.
- Integration tests run in CI (Docker).

## Review
Ran the multi-reviewer gate (security, code quality, UX). All blocking findings fixed and re-verified — notably a Blazor CSS-isolation bug that silently disabled the responsive shrink (confirmed fixed in compiled scoped CSS) and accessible-name gaps in the logo link. One pre-existing meta-row `href="#"` edge case is deferred (the AC requires the meta row unchanged).

Closes #604
