### PR TITLE
feat(web-client): center club logo under Félag heading on participation cards at 48px

### DIFF
--- a/src/KRAFT.Results.Web.Client/Components/ClubLogo.razor
+++ b/src/KRAFT.Results.Web.Client/Components/ClubLogo.razor
@@ -61,7 +61,6 @@
     {
         _sizeClass = Size switch
         {
-            ClubLogoSize.XSmall => "team-logo--xs",
             ClubLogoSize.Small => "team-logo--sm",
             ClubLogoSize.Medium => "team-logo--md",
             ClubLogoSize.Large => "team-logo--lg",

--- a/src/KRAFT.Results.Web.Client/Components/ClubLogo.razor.css
+++ b/src/KRAFT.Results.Web.Client/Components/ClubLogo.razor.css
@@ -4,11 +4,6 @@
     overflow: hidden;
 }
 
-.team-logo--xs {
-    width: 24px;
-    height: 24px;
-}
-
 .team-logo--sm {
     width: 48px;
     height: 48px;
@@ -46,10 +41,14 @@
     height: 60%;
 }
 
-.team-logo--xs.team-logo--text {
+.team-logo--sm.team-logo--text {
     width: auto;
-    height: 24px;
+    height: 48px;
     overflow: visible;
+}
+
+.team-logo--sm.team-logo--text .team-logo-placeholder {
+    justify-content: center;
 }
 
 .team-logo-placeholder .team-logo-fallback-text {

--- a/src/KRAFT.Results.Web.Client/Components/ClubLogoSize.cs
+++ b/src/KRAFT.Results.Web.Client/Components/ClubLogoSize.cs
@@ -2,7 +2,6 @@
 
 public enum ClubLogoSize
 {
-    XSmall,
     Small,
     Medium,
     Large,

--- a/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/MeetDetailsPage.razor
@@ -150,7 +150,7 @@
                             <span>Nafn</span>
                             @if (ShowClubs)
                             {
-                                <span>Félag</span>
+                                <span class="col-header-center">Félag</span>
                             }
                             @foreach (Discipline disc in IncludedDisciplines.Keys.OrderBy(d => (byte)d))
                             {

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor
@@ -62,7 +62,7 @@
                     <ClubLogo Filename="@Participation.ClubLogoImageFilename"
                               Alt="@Participation.Club"
                               FallbackText="@Participation.Club"
-                              Size="ClubLogoSize.XSmall" />
+                              Size="ClubLogoSize.Small" />
                 </NavLink>
             }
             else

--- a/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
+++ b/src/KRAFT.Results.Web.Client/Features/Meets/ParticipationCard.razor.css
@@ -92,6 +92,8 @@
 
 .p-club {
     display: flex;
+    justify-content: center;
+    align-items: center;
     font-size: 12px;
     font-weight: 700;
     color: var(--color-primary);
@@ -99,7 +101,6 @@
     flex-shrink: 0;
     white-space: nowrap;
     transition: color var(--transition-fast) ease;
-    position: relative;
 }
 
 .p-club:hover {
@@ -253,14 +254,6 @@
         opacity: 1;
     }
 
-    /* Expand .p-club tap target to ~44px vertically on touch without affecting
-       the visual 24px logo or card row height. The pseudo-element does not
-       extend horizontally, so it cannot overlap the adjacent athlete-name link. */
-    .p-club::after {
-        content: "";
-        position: absolute;
-        inset: -10px 0;
-    }
 }
 
 /* ===== Medium: disciplines side-by-side ===== */
@@ -349,7 +342,6 @@
     .p-club {
         align-items: center;
         align-self: center;
-        min-height: 24px;
     }
 
     /* Always show club cell on desktop (fills grid column even when empty) */

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/ClubLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/ClubLogoTests.cs
@@ -21,7 +21,7 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Fact]
-    public void RendersSvgPlaceholder_WhenFilenameIsNull()
+    public void WhenFilenameIsNull_RendersSvgPlaceholder()
     {
         // Arrange
 
@@ -35,7 +35,7 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Fact]
-    public void RendersImg_WhenFilenameIsProvided()
+    public void WhenFilenameIsProvided_RendersImg()
     {
         // Arrange
 
@@ -52,7 +52,7 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Fact]
-    public void AltDefaultsToEmpty_ForDecorativeUse()
+    public void WhenAltNotProvided_DefaultsToEmpty()
     {
         // Arrange
 
@@ -68,7 +68,7 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Fact]
-    public void RendersAltText_WhenAltIsProvided()
+    public void WhenAltIsProvided_RendersAltText()
     {
         // Arrange
 
@@ -88,7 +88,7 @@ public sealed class ClubLogoTests : IDisposable
     [InlineData(ClubLogoSize.Small, "team-logo--sm")]
     [InlineData(ClubLogoSize.Medium, "team-logo--md")]
     [InlineData(ClubLogoSize.Large, "team-logo--lg")]
-    public void AppliesSizeClass_ForEachSize(ClubLogoSize size, string expectedClass)
+    public void WhenSizeIsSet_AppliesSizeClass(ClubLogoSize size, string expectedClass)
     {
         // Arrange
 
@@ -138,7 +138,7 @@ public sealed class ClubLogoTests : IDisposable
     [InlineData(ClubLogoSize.Small)]
     [InlineData(ClubLogoSize.Medium)]
     [InlineData(ClubLogoSize.Large)]
-    public void DoesNotEmitSrcset_ForAnySize(ClubLogoSize size)
+    public void WhenAnySize_DoesNotEmitSrcset(ClubLogoSize size)
     {
         // Arrange
 
@@ -311,7 +311,7 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Fact]
-    public void ShowsPlaceholder_WhenFilenameContainsComma()
+    public void WhenFilenameContainsComma_ShowsPlaceholder()
     {
         // Arrange
 
@@ -327,7 +327,7 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Fact]
-    public void ShowsPlaceholder_WhenFilenameContainsSpace()
+    public void WhenFilenameContainsSpace_ShowsPlaceholder()
     {
         // Arrange
 
@@ -352,7 +352,7 @@ public sealed class ClubLogoTests : IDisposable
     [InlineData("logo.png?width=999")]
     [InlineData("logo.png#section")]
     [InlineData("logo%2Fevil.png")]
-    public void ShowsPlaceholder_WhenFilenameIsInvalid(string invalidFilename)
+    public void WhenFilenameIsInvalid_ShowsPlaceholder(string invalidFilename)
     {
         // Arrange
 

--- a/tests/KRAFT.Results.Web.Client.Tests/Components/ClubLogoTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Components/ClubLogoTests.cs
@@ -85,7 +85,6 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Theory]
-    [InlineData(ClubLogoSize.XSmall, "team-logo--xs")]
     [InlineData(ClubLogoSize.Small, "team-logo--sm")]
     [InlineData(ClubLogoSize.Medium, "team-logo--md")]
     [InlineData(ClubLogoSize.Large, "team-logo--lg")]
@@ -102,10 +101,9 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Theory]
-    [InlineData(ClubLogoSize.XSmall)]
     [InlineData(ClubLogoSize.Small)]
     [InlineData(ClubLogoSize.Medium)]
-    public void WhenSizeIsXSmallSmallOrMedium_SrcQueryStringIsPinned64x64Crop(ClubLogoSize size)
+    public void WhenSizeIsSmallOrMedium_SrcQueryStringIsPinned64x64Crop(ClubLogoSize size)
     {
         // Arrange
 
@@ -137,7 +135,6 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Theory]
-    [InlineData(ClubLogoSize.XSmall)]
     [InlineData(ClubLogoSize.Small)]
     [InlineData(ClubLogoSize.Medium)]
     [InlineData(ClubLogoSize.Large)]
@@ -242,7 +239,7 @@ public sealed class ClubLogoTests : IDisposable
     }
 
     [Fact]
-    public void WhenSizeIsXSmallAndFallbackTextIsSet_AppliesTextModifierClass()
+    public void WhenSizeIsSmallAndFallbackTextIsSet_AppliesTextModifierClass()
     {
         // Arrange
 
@@ -250,10 +247,10 @@ public sealed class ClubLogoTests : IDisposable
         IRenderedComponent<ClubLogo> cut = _context.Render<ClubLogo>(
             p => p
                 .Add(c => c.FallbackText, "ÞOR")
-                .Add(c => c.Size, ClubLogoSize.XSmall));
+                .Add(c => c.Size, ClubLogoSize.Small));
 
         // Assert
-        cut.Find(".team-logo.team-logo--xs.team-logo--text").ShouldNotBeNull();
+        cut.Find(".team-logo.team-logo--sm.team-logo--text").ShouldNotBeNull();
     }
 
     [Fact]
@@ -278,7 +275,7 @@ public sealed class ClubLogoTests : IDisposable
 
         // Act
         IRenderedComponent<ClubLogo> cut = _context.Render<ClubLogo>(
-            p => p.Add(c => c.Size, ClubLogoSize.XSmall));
+            p => p.Add(c => c.Size, ClubLogoSize.Small));
 
         // Assert
         cut.FindAll(".team-logo--text").Count.ShouldBe(0);

--- a/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
+++ b/tests/KRAFT.Results.Web.Client.Tests/Features/Meets/ParticipationCardTests.cs
@@ -224,6 +224,7 @@ public sealed class ParticipationCardTests : IDisposable
         navLink.GetAttribute("title").ShouldBe("Þór");
         AngleSharp.Dom.IElement img = cut.Find(".p-club img");
         img.GetAttribute("alt").ShouldBe("Þór");
+        cut.Find(".p-club .team-logo--sm").ShouldNotBeNull();
     }
 
     [Fact]
@@ -250,6 +251,7 @@ public sealed class ParticipationCardTests : IDisposable
         navLink.GetAttribute("href").ShouldBe("/teams/thor");
         navLink.TextContent.Trim().ShouldContain("Þór");
         cut.FindAll(".p-club img").Count.ShouldBe(0);
+        cut.Find(".p-club .team-logo--sm.team-logo--text").ShouldNotBeNull();
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

Club logos on participation cards now render at **48px, horizontally centered** in the "Félag" column, with the short-name fallback and the column heading centered under them. 48px matches the combined height of the athlete-name + year-of-birth lines and natively satisfies the 44px touch target.

Closes #609.

## Changes
- **`ParticipationCard.razor`** — club logo `Size` changed `XSmall` → `Small` (48×48).
- **`ParticipationCard.razor.css`** — `.p-club` centers its child (`justify-content`/`align-items: center`) on both mobile header-row and desktop grid-cell; removed the stale `min-height: 24px`, the mobile `.p-club::after` tap-target hack + comment, and the now-vestigial `position: relative`.
- **`ClubLogo.razor` / `ClubLogoSize.cs` / `ClubLogo.razor.css`** — deleted the `XSmall` enum member, its switch arm, and its `.team-logo--xs` CSS rules (participation card was the sole consumer); added `.team-logo--sm.team-logo--text` (auto width, 48px height, visible overflow) + a centered placeholder rule so the fallback centers without clipping.
- **`MeetDetailsPage.razor`** — "Félag" heading gains `col-header-center` (reuses existing utility, no new CSS) so it centers over the logo.
- **Tests** — `ParticipationCardTests` asserts the rendered `team-logo--sm` class (logo + fallback); `ClubLogoTests` covers sm+text mode (replacing xs+text) and applies condition-first naming.

## Notes
- Image query strings unchanged — `Small` continues to serve `?width=64&height=64&crop=auto` (out of scope per issue / legacy-host contract).
- CSS visual centering is verified by emitted-class assertions at the unit level; bUnit does not evaluate layout, so pixel centering is a manual concern.
- Reviews: security ✅, UX ✅, code-review 1 Medium (test-naming drift) fixed. All 477 Web.Client tests green; build clean (`TreatWarningsAsErrors`).
